### PR TITLE
会話履歴の登録部分の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ LLM は、大量の文章を要約するタスクを得意としています。�
 
 ## デプロイ
 
+<div align="center">
+  <a href="https://www.youtube.com/watch?v=9sMA17OKP1k"><img src="https://img.youtube.com/vi/9sMA17OKP1k/0.jpg" alt="generative-ai-use-cases-jp デプロイガイド" target="_blank"></a>
+  <p><strong>YouTube にデプロイ手順をまとめた動画 (クリックして再生)</strong></p>
+</div>
+
 > **OpenAI を LLM として使用する場合は、あらかじめ [OpenAI の API キーを取得](https://platform.openai.com/account/api-keys)してください。**
 
 [AWS Cloud Development Kit](https://aws.amazon.com/jp/cdk/)（以降 CDK）を利用してデプロイします。最初に、npm パッケージをインストールしてください。なお、全てのコマンドはルートディレクトリで実行してください。

--- a/README.md
+++ b/README.md
@@ -82,11 +82,6 @@ LLM は、大量の文章を要約するタスクを得意としています。�
 
 ## デプロイ
 
-<div align="center">
-  <a href="https://www.youtube.com/watch?v=9sMA17OKP1k"><img src="https://img.youtube.com/vi/9sMA17OKP1k/0.jpg" alt="generative-ai-use-cases-jp デプロイガイド" target="_blank"></a>
-  <p><strong>YouTube にデプロイ手順をまとめた動画 (クリックして再生)</strong></p>
-</div>
-
 > **OpenAI を LLM として使用する場合は、あらかじめ [OpenAI の API キーを取得](https://platform.openai.com/account/api-keys)してください。**
 
 [AWS Cloud Development Kit](https://aws.amazon.com/jp/cdk/)（以降 CDK）を利用してデプロイします。最初に、npm パッケージをインストールしてください。なお、全てのコマンドはルートディレクトリで実行してください。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,6 +1344,440 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-wBwiX27kirnYEBmHSg2xQ9KirFtR0W+JF8q+QfRpUtXNpIjQ3qgcZVbx7Jhha0LNXK2erk29Q3YtQl7xlnpZwg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.395.0",
+        "@aws-sdk/credential-provider-node": "3.395.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.391.0",
+        "@aws-sdk/middleware-host-header": "3.391.0",
+        "@aws-sdk/middleware-logger": "3.391.0",
+        "@aws-sdk/middleware-recursion-detection": "3.391.0",
+        "@aws-sdk/middleware-signing": "3.391.0",
+        "@aws-sdk/middleware-user-agent": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@aws-sdk/util-endpoints": "3.391.0",
+        "@aws-sdk/util-user-agent-browser": "3.391.0",
+        "@aws-sdk/util-user-agent-node": "3.391.0",
+        "@smithy/config-resolver": "^2.0.3",
+        "@smithy/fetch-http-handler": "^2.0.3",
+        "@smithy/hash-node": "^2.0.3",
+        "@smithy/invalid-dependency": "^2.0.3",
+        "@smithy/middleware-content-length": "^2.0.3",
+        "@smithy/middleware-endpoint": "^2.0.3",
+        "@smithy/middleware-retry": "^2.0.3",
+        "@smithy/middleware-serde": "^2.0.3",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.3",
+        "@smithy/node-http-handler": "^2.0.3",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/smithy-client": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "@smithy/url-parser": "^2.0.3",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.3",
+        "@smithy/util-defaults-mode-node": "^2.0.3",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.3",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.395.0.tgz",
+      "integrity": "sha512-IEmqpZnflzFk6NTlkRpEXIcU2uBrTYl+pA5z4ZerbKclYWuxJ7MoLtLDNWgIn3mkNxvdroWgaPY1B2dkQlTe4g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.391.0",
+        "@aws-sdk/middleware-logger": "3.391.0",
+        "@aws-sdk/middleware-recursion-detection": "3.391.0",
+        "@aws-sdk/middleware-user-agent": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@aws-sdk/util-endpoints": "3.391.0",
+        "@aws-sdk/util-user-agent-browser": "3.391.0",
+        "@aws-sdk/util-user-agent-node": "3.391.0",
+        "@smithy/config-resolver": "^2.0.3",
+        "@smithy/fetch-http-handler": "^2.0.3",
+        "@smithy/hash-node": "^2.0.3",
+        "@smithy/invalid-dependency": "^2.0.3",
+        "@smithy/middleware-content-length": "^2.0.3",
+        "@smithy/middleware-endpoint": "^2.0.3",
+        "@smithy/middleware-retry": "^2.0.3",
+        "@smithy/middleware-serde": "^2.0.3",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.3",
+        "@smithy/node-http-handler": "^2.0.3",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/smithy-client": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "@smithy/url-parser": "^2.0.3",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.3",
+        "@smithy/util-defaults-mode-node": "^2.0.3",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.395.0.tgz",
+      "integrity": "sha512-zWxZ+pjeP88uRN4k0Zzid6t/8Yhzg1Cv2LnrYX6kZzbS6AOTDho7fVGZgUl+cme33QZhtE8pXUvwGeJAptbhqg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.395.0",
+        "@aws-sdk/middleware-host-header": "3.391.0",
+        "@aws-sdk/middleware-logger": "3.391.0",
+        "@aws-sdk/middleware-recursion-detection": "3.391.0",
+        "@aws-sdk/middleware-sdk-sts": "3.391.0",
+        "@aws-sdk/middleware-signing": "3.391.0",
+        "@aws-sdk/middleware-user-agent": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@aws-sdk/util-endpoints": "3.391.0",
+        "@aws-sdk/util-user-agent-browser": "3.391.0",
+        "@aws-sdk/util-user-agent-node": "3.391.0",
+        "@smithy/config-resolver": "^2.0.3",
+        "@smithy/fetch-http-handler": "^2.0.3",
+        "@smithy/hash-node": "^2.0.3",
+        "@smithy/invalid-dependency": "^2.0.3",
+        "@smithy/middleware-content-length": "^2.0.3",
+        "@smithy/middleware-endpoint": "^2.0.3",
+        "@smithy/middleware-retry": "^2.0.3",
+        "@smithy/middleware-serde": "^2.0.3",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.3",
+        "@smithy/node-http-handler": "^2.0.3",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/smithy-client": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "@smithy/url-parser": "^2.0.3",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.3",
+        "@smithy/util-defaults-mode-node": "^2.0.3",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.391.0.tgz",
+      "integrity": "sha512-mAzICedcg4bfL0mM5O6QTd9mQ331NLse1DMr6XL21ZZiLB48ej19L7AGV2xq5QwVbqKU3IVv1myRyhvpDM9jMg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.395.0.tgz",
+      "integrity": "sha512-t7cWs+syJsSkj9NGdKyZ1t/+nYQyOec2nPjTtPWwKs8D7rvH3IMIgJwkvAGNzYaiIoIpXXx0wgCqys84TSEIYQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.391.0",
+        "@aws-sdk/credential-provider-process": "3.391.0",
+        "@aws-sdk/credential-provider-sso": "3.395.0",
+        "@aws-sdk/credential-provider-web-identity": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.395.0.tgz",
+      "integrity": "sha512-qJawWTYf5L7Z1Is0sSJEYc4e96Qd0HWGqluO2h9qoUNrRREZ9RSxsDq+LGxVVAYLupYFcIFtiCnA/MoBBIWhzg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.391.0",
+        "@aws-sdk/credential-provider-ini": "3.395.0",
+        "@aws-sdk/credential-provider-process": "3.391.0",
+        "@aws-sdk/credential-provider-sso": "3.395.0",
+        "@aws-sdk/credential-provider-web-identity": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.391.0.tgz",
+      "integrity": "sha512-KMlzPlBI+hBmXDo+EoFZdLgCVRkRa9B9iEE6x0+hQQ6g9bW6HI7cDRVdceR1ZoPasSaNAZ9QOXMTIBxTpn0sPQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.395.0.tgz",
+      "integrity": "sha512-wAoHG9XqO0L8TvJv4cjwN/2XkYskp0cbnupKKTJm+D29MYcctKEtL0aYOHxaNN2ECAYxIFIQDdlo62GKb3nJ5Q==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.395.0",
+        "@aws-sdk/token-providers": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.391.0.tgz",
+      "integrity": "sha512-n0vYg82B8bc4rxKltVbVqclev7hx+elyS9pEnZs3YbnbWJq0qqsznXmDfLqd1TcWpa09PGXcah0nsRDolVThsA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.391.0.tgz",
+      "integrity": "sha512-+nyNr0rb2ixY7mU48nibr7L7gsw37y4oELhqgnNKhcjZDJ34imBwKIMFa64n21FdftmhcjR8IdSpzXE9xrkJ8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.391.0.tgz",
+      "integrity": "sha512-KOwl5zo16b17JDhqILHBStccBQ2w35em7+/6vdkJdUII6OU8aVIFTlIQT9wOUvd4do6biIRBMZG3IK0Rg7mRDQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.391.0.tgz",
+      "integrity": "sha512-hVR3z59G7pX4pjDQs9Ag1tMgbLeGXOzeAAaNP9fEtHSd3KBMAGQgN3K3b9WPjzE2W0EoloHRJMK4qxZErdde2g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.391.0.tgz",
+      "integrity": "sha512-6ZXI3Z4QU+TnT5PwKWloGmRHG81tWeI18/zxf9wWzrO2NhYFvITzEJH0vWLLiXdWtn/BYfLULXtDvkTaepbI5A==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.391.0.tgz",
+      "integrity": "sha512-2pAJJlZqaHc0d+cz2FTVrQmWi8ygKfqfczHUo/loCtOaMNtWXBHb/JsLEecs6cXdizy6gi3YsLz6VZYwY4Ssxw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.2.0",
+        "@smithy/util-middleware": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.391.0.tgz",
+      "integrity": "sha512-LdK9uMNA14zqRw3B79Mhy7GX36qld/GYo93xuu+lr+AQ98leZEdc6GUbrtNDI3fP1Z8TMQcyHUKBml4/B+wXpQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@aws-sdk/util-endpoints": "3.391.0",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.391.0.tgz",
+      "integrity": "sha512-kgfArsKLDJE71qQjfXiHiM5cZqgDHlMsqEx35+A65GmTWJaS1PGDqu3ZvVVU8E5mxnCCLw7vho21fsjvH6TBpg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.391.0",
+        "@aws-sdk/middleware-logger": "3.391.0",
+        "@aws-sdk/middleware-recursion-detection": "3.391.0",
+        "@aws-sdk/middleware-user-agent": "3.391.0",
+        "@aws-sdk/types": "3.391.0",
+        "@aws-sdk/util-endpoints": "3.391.0",
+        "@aws-sdk/util-user-agent-browser": "3.391.0",
+        "@aws-sdk/util-user-agent-node": "3.391.0",
+        "@smithy/config-resolver": "^2.0.3",
+        "@smithy/fetch-http-handler": "^2.0.3",
+        "@smithy/hash-node": "^2.0.3",
+        "@smithy/invalid-dependency": "^2.0.3",
+        "@smithy/middleware-content-length": "^2.0.3",
+        "@smithy/middleware-endpoint": "^2.0.3",
+        "@smithy/middleware-retry": "^2.0.3",
+        "@smithy/middleware-serde": "^2.0.3",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.3",
+        "@smithy/node-http-handler": "^2.0.3",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/shared-ini-file-loader": "^2.0.0",
+        "@smithy/smithy-client": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "@smithy/url-parser": "^2.0.3",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.3",
+        "@smithy/util-defaults-mode-node": "^2.0.3",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.391.0.tgz",
+      "integrity": "sha512-QpYVFKMOnzHz/JMj/b8wb18qxiT92U/5r5MmtRz2R3LOH6ooTO96k4ozXCrYr0qNed1PAnOj73rPrrH2wnCJKQ==",
+      "dependencies": {
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.391.0.tgz",
+      "integrity": "sha512-zv4sYDTQhNxyLoekcE02/nk3xvoo6yCHDy1kDJk0MFxOKaqUB+CvZdQBR4YBLSDlD4o4DUBmdYgKT58FfbM8sQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.391.0.tgz",
+      "integrity": "sha512-6ipHOB1WdCBNeAMJauN7l2qNE0WLVaTNhkD290/ElXm1FHGTL8yw6lIDIjhIFO1bmbZxDiKApwDiG7ROhaJoxQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/types": "^2.2.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.391.0.tgz",
+      "integrity": "sha512-PVvAK/Lf4BdB1eJIZtyFpGSslGQwKpYt9/hKs5NlR+qxBMXU9T0DnTqH4GiXZaazvXr7OUVWitIF2b7iKBMTow==",
+      "dependencies": {
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/node-config-provider": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/@aws-sdk/client-firehose": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-firehose/-/client-firehose-3.6.1.tgz",
@@ -6515,6 +6949,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.310.0.tgz",
+      "integrity": "sha512-y3wipforet41EDTI0vnzxILqwAGll1KfI5qcdX9pXF/WF1f+3frcOtPiWtQEZQpy4czRogKm3BHo70QBYAZxlQ==",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/@aws-sdk/eventstream-codec": {
       "version": "3.186.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.186.0.tgz",
@@ -6834,6 +7285,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-HNOx+XmG3RXVOj2Z9oH0fDmE6bYmQND5WgVHfYOx7xqRWHEOyt8cNlZVktzPiK9XDNNQbG2qm98ux8We2e44eA==",
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": "3.395.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/@aws-sdk/md5-js": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.6.1.tgz",
@@ -6890,6 +7361,38 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.391.0.tgz",
+      "integrity": "sha512-HoqCuhRyBqDikVBuXwYRRxuTrMpYpg6LBGR3F9Zhdu+18AUui9eUIEd2VazHSq5uojeVhPrdlbB8sxT5TJWNlQ==",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.310.0",
+        "@aws-sdk/types": "3.391.0",
+        "@smithy/protocol-http": "^2.0.3",
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+      "version": "3.391.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.391.0.tgz",
+      "integrity": "sha512-QpYVFKMOnzHz/JMj/b8wb18qxiT92U/5r5MmtRz2R3LOH6ooTO96k4ozXCrYr0qNed1PAnOj73rPrrH2wnCJKQ==",
+      "dependencies": {
+        "@smithy/types": "^2.2.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
       "version": "3.186.0",
@@ -7687,6 +8190,22 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.395.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.395.0.tgz",
+      "integrity": "sha512-hc97G4f75+xoOn2stERwORvsuugZ6mYPJIdCuaapxWFckqHc8H0jBnEFA1z8XbPVIZdvtS23ixcXOOM4TBWXuA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.387.0",
@@ -12484,11 +13003,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
-      "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
+      "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12496,16 +13015,16 @@
       }
     },
     "node_modules/@smithy/abort-controller/node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.2.tgz",
-      "integrity": "sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.5.tgz",
+      "integrity": "sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
@@ -12520,14 +13039,14 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz",
-      "integrity": "sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz",
+      "integrity": "sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.2",
-        "@smithy/property-provider": "^2.0.2",
-        "@smithy/types": "^2.1.0",
-        "@smithy/url-parser": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.5",
+        "@smithy/property-provider": "^2.0.5",
+        "@smithy/types": "^2.2.2",
+        "@smithy/url-parser": "^2.0.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12556,13 +13075,13 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz",
-      "integrity": "sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz",
+      "integrity": "sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.2",
-        "@smithy/querystring-builder": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/protocol-http": "^2.0.5",
+        "@smithy/querystring-builder": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
@@ -12573,11 +13092,11 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
-      "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.5.tgz",
+      "integrity": "sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -12592,11 +13111,11 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz",
-      "integrity": "sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz",
+      "integrity": "sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       }
     },
@@ -12622,12 +13141,12 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz",
-      "integrity": "sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz",
+      "integrity": "sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/protocol-http": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12640,13 +13159,13 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz",
-      "integrity": "sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz",
+      "integrity": "sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.2",
-        "@smithy/types": "^2.1.0",
-        "@smithy/url-parser": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.5",
+        "@smithy/types": "^2.2.2",
+        "@smithy/url-parser": "^2.0.5",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -12660,13 +13179,13 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz",
-      "integrity": "sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz",
+      "integrity": "sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.5",
         "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
@@ -12682,11 +13201,11 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz",
-      "integrity": "sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
+      "integrity": "sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12715,13 +13234,13 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz",
-      "integrity": "sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz",
+      "integrity": "sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.2",
-        "@smithy/shared-ini-file-loader": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/property-provider": "^2.0.5",
+        "@smithy/shared-ini-file-loader": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12734,14 +13253,14 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz",
-      "integrity": "sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
+      "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.2",
-        "@smithy/protocol-http": "^2.0.2",
-        "@smithy/querystring-builder": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/abort-controller": "^2.0.5",
+        "@smithy/protocol-http": "^2.0.5",
+        "@smithy/querystring-builder": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12754,11 +13273,11 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.2.tgz",
-      "integrity": "sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.5.tgz",
+      "integrity": "sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12771,11 +13290,11 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
-      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
+      "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12788,11 +13307,11 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz",
-      "integrity": "sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
+      "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -12801,16 +13320,16 @@
       }
     },
     "node_modules/@smithy/querystring-builder/node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
-      "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz",
+      "integrity": "sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12818,9 +13337,9 @@
       }
     },
     "node_modules/@smithy/querystring-parser/node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "2.0.0",
@@ -12831,11 +13350,11 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz",
-      "integrity": "sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz",
+      "integrity": "sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==",
       "dependencies": {
-        "@smithy/types": "^2.1.0",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12871,13 +13390,13 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.2.tgz",
-      "integrity": "sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.5.tgz",
+      "integrity": "sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==",
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.1.0",
-        "@smithy/util-stream": "^2.0.2",
+        "@smithy/types": "^2.2.2",
+        "@smithy/util-stream": "^2.0.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -12890,9 +13409,9 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
+      "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -12906,12 +13425,12 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
-      "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.5.tgz",
+      "integrity": "sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/querystring-parser": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       }
     },
@@ -13000,12 +13519,12 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz",
-      "integrity": "sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz",
+      "integrity": "sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/property-provider": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -13019,15 +13538,15 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz",
-      "integrity": "sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz",
+      "integrity": "sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.2",
-        "@smithy/credential-provider-imds": "^2.0.2",
-        "@smithy/node-config-provider": "^2.0.2",
-        "@smithy/property-provider": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/config-resolver": "^2.0.5",
+        "@smithy/credential-provider-imds": "^2.0.5",
+        "@smithy/node-config-provider": "^2.0.5",
+        "@smithy/property-provider": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -13089,13 +13608,13 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.2.tgz",
-      "integrity": "sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.5.tgz",
+      "integrity": "sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.0.2",
-        "@smithy/node-http-handler": "^2.0.2",
-        "@smithy/types": "^2.1.0",
+        "@smithy/fetch-http-handler": "^2.0.5",
+        "@smithy/node-http-handler": "^2.0.5",
+        "@smithy/types": "^2.2.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -13107,9 +13626,9 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-uri-escape": {
       "version": "2.0.0",
@@ -13143,6 +13662,24 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.5.tgz",
+      "integrity": "sha512-1lkkUmI/bhaDX+LIT3RiUNAn+NzPmsWjE7beMq0oQ3H1/CffaILIN67riDA0aE1YBj6xll7uWMIy4tJqc+peXw==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.0.5",
+        "@smithy/types": "^2.2.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "7.0.0",
@@ -13519,6 +14056,10 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
       "dev": true
+    },
+    "node_modules/@types/generative-ai-use-cases-jp": {
+      "resolved": "packages/types",
+      "link": true
     },
     "node_modules/@types/hast": {
       "version": "2.3.5",
@@ -20315,6 +20856,14 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -20675,6 +21224,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -24668,7 +25222,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@aws-cdk/aws-lambda-python-alpha": "^2.88.0-alpha.0",
+        "@aws-sdk/client-dynamodb": "^3.395.0",
         "@aws-sdk/client-secrets-manager": "^3.386.0",
+        "@aws-sdk/lib-dynamodb": "^3.395.0",
         "@aws-solutions-constructs/aws-cloudfront-s3": "^2.41.0",
         "aws-cdk-lib": "2.88.0",
         "constructs": "^10.0.0",
@@ -24683,6 +25239,9 @@
         "ts-node": "^10.9.1",
         "typescript": "~5.1.6"
       }
+    },
+    "packages/types": {
+      "name": "@types/generative-ai-use-cases-jp"
     },
     "packages/web": {
       "version": "0.0.1",

--- a/packages/cdk/lambda/createChat.ts
+++ b/packages/cdk/lambda/createChat.ts
@@ -1,0 +1,41 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { CreateChatRequest, RecordedMessage } from 'generative-ai-use-cases-jp';
+import { createChat, recordMessage } from './repository';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const req: CreateChatRequest = JSON.parse(event.body!);
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
+    const chat = await createChat(userId);
+    const messages: RecordedMessage[] = [];
+
+    for (const m of req.unrecordedMessages) {
+      messages.push(await recordMessage(m, userId, chat.chatId));
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        chat,
+        messages,
+      }),
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    };
+  }
+};

--- a/packages/cdk/lambda/createChat.ts
+++ b/packages/cdk/lambda/createChat.ts
@@ -6,14 +6,15 @@ export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
-    const req: CreateChatRequest = JSON.parse(event.body!);
+    const req: CreateChatRequest = JSON.parse(event.body || '{}');
     const userId: string =
       event.requestContext.authorizer!.claims['cognito:username'];
     const chat = await createChat(userId);
-    const messages: RecordedMessage[] = [];
 
-    for (const m of req.unrecordedMessages) {
-      messages.push(await recordMessage(m, userId, chat.chatId));
+    let systemContext = null;
+
+    if (req.systemContext) {
+      systemContext = await recordMessage(req.systemContext, userId, chat.chatId);
     }
 
     return {
@@ -24,7 +25,7 @@ export const handler = async (
       },
       body: JSON.stringify({
         chat,
-        messages,
+        systemContext,
       }),
     };
   } catch (error) {

--- a/packages/cdk/lambda/predict.ts
+++ b/packages/cdk/lambda/predict.ts
@@ -1,37 +1,65 @@
-import {
-  SecretsManagerClient,
-  GetSecretValueCommand,
-} from '@aws-sdk/client-secrets-manager';
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Configuration, OpenAIApi } from 'openai';
+import { PredictRequest, ShownMessage } from 'generative-ai-use-cases-jp';
+import { fetchOpenApiKey } from './secret';
+import { recordMessage } from './repository';
 
-const SECRET_ARN: string = process.env.SECRET_ARN!;
-const client = new SecretsManagerClient({});
-let secret: string;
+const omitUnusedProperties = (messages: ShownMessage[]) => {
+  return messages.map((m) => {
+    return {
+      role: m.role,
+      content: m.content,
+    };
+  });
+};
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
-    const messages = JSON.parse(event.body!).messages;
+    const req: PredictRequest = JSON.parse(event.body!);
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
+
+    let predictedMessages: ShownMessage[] = [];
+
+    if (req.skipRecording) {
+      predictedMessages = req.unrecordedMessages;
+    } else {
+      for (const m of req.unrecordedMessages) {
+        predictedMessages.push(await recordMessage(m, userId, req.chatId!));
+      }
+    }
 
     // Secret 情報の取得
-    const secretData = await client.send(
-      new GetSecretValueCommand({ SecretId: SECRET_ARN })
-    );
-    secret = secretData.SecretString!;
+    const apiKey = await fetchOpenApiKey();
 
     // OpenAI API の初期化
-    const configuration = new Configuration({
-      apiKey: secret,
-    });
+    const configuration = new Configuration({ apiKey });
     const openai = new OpenAIApi(configuration);
 
     // OpenAI API を使用してチャットの応答を取得
     const chatCompletion = await openai.createChatCompletion({
       model: 'gpt-3.5-turbo',
-      messages: messages,
+      messages: omitUnusedProperties(
+        (req.recordedMessages as ShownMessage[]).concat(predictedMessages)
+      ),
     });
+
+    let assistantMessage: ShownMessage = {
+      role: 'assistant',
+      content: chatCompletion.data.choices[0].message?.content!,
+    };
+
+    if (!req.skipRecording) {
+      assistantMessage = await recordMessage(
+        assistantMessage,
+        userId,
+        req.chatId!
+      );
+    }
+
+    predictedMessages.push(assistantMessage);
 
     return {
       statusCode: 200,
@@ -39,9 +67,7 @@ export const handler = async (
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*',
       },
-      body: JSON.stringify({
-        response: chatCompletion.data.choices[0].message?.content,
-      }),
+      body: JSON.stringify({ messages: predictedMessages }),
     };
   } catch (error) {
     console.log(error);

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -38,7 +38,7 @@ export const recordMessage = async (
   userId: string,
   chatId: string
 ): Promise<RecordedMessage> => {
-  const messageId = `message#{crypto.randomUUID()}`;
+  const messageId = `message#${crypto.randomUUID()}`;
   const item = {
     id: chatId,
     createdDate: `${Date.now()}#0`,

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -1,0 +1,61 @@
+import {
+  Chat,
+  RecordedMessage,
+  UnrecordedMessage,
+} from 'generative-ai-use-cases-jp';
+import * as crypto from 'crypto';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+
+const TABLE_NAME: string = process.env.TABLE_NAME!;
+const dynamoDb = new DynamoDBClient({});
+const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);
+
+export const createChat = async (_userId: string): Promise<Chat> => {
+  const userId = `user#${_userId}`;
+  const chatId = `chat#${crypto.randomUUID()}`;
+  const item = {
+    id: userId,
+    createdDate: `${Date.now()}`,
+    chatId,
+    usecase: '',
+    title: '仮のタイトルです',
+    updatedDate: '',
+  };
+
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: TABLE_NAME,
+      Item: item,
+    })
+  );
+
+  return item;
+};
+
+export const recordMessage = async (
+  unrecordedMessage: UnrecordedMessage,
+  userId: string,
+  chatId: string
+): Promise<RecordedMessage> => {
+  const messageId = `message#{crypto.randomUUID()}`;
+  const item = {
+    id: chatId,
+    createdDate: `${Date.now()}#0`,
+    messageId,
+    userId,
+    feedback: 'none',
+    usecase: '',
+    llmType: 'OpenAI',
+    ...unrecordedMessage,
+  };
+
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: TABLE_NAME,
+      Item: item,
+    })
+  );
+
+  return item;
+};

--- a/packages/cdk/lambda/secret.ts
+++ b/packages/cdk/lambda/secret.ts
@@ -1,0 +1,15 @@
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
+
+const SECRET_ARN: string = process.env.SECRET_ARN!;
+const secretsManager = new SecretsManagerClient({});
+
+export const fetchOpenApiKey = async () => {
+  const secretData = await secretsManager.send(
+    new GetSecretValueCommand({ SecretId: SECRET_ARN })
+  );
+
+  return secretData.SecretString!;
+};

--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -1,0 +1,34 @@
+import { Construct } from 'constructs';
+import * as ddb from 'aws-cdk-lib/aws-dynamodb';
+
+export class Database extends Construct {
+  public readonly table: ddb.Table;
+  public readonly feedbackIndexName: string;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const feedbackIndexName = 'FeedbackIndex';
+    const table = new ddb.Table(this, 'Table', {
+      partitionKey: {
+        name: 'id',
+        type: ddb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'createdDate',
+        type: ddb.AttributeType.STRING,
+      },
+    });
+
+    table.addGlobalSecondaryIndex({
+      indexName: feedbackIndexName,
+      partitionKey: {
+        name: 'feedback',
+        type: ddb.AttributeType.STRING,
+      },
+    });
+
+    this.table = table;
+    this.feedbackIndexName = feedbackIndexName;
+  }
+}

--- a/packages/cdk/lib/construct/index.ts
+++ b/packages/cdk/lib/construct/index.ts
@@ -1,3 +1,4 @@
 export * from './api';
 export * from './auth';
 export * from './web';
+export * from './database';

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -1,6 +1,6 @@
 import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Auth, Api, Web } from './construct';
+import { Auth, Api, Web, Database } from './construct';
 
 export class GenerativeAiUseCasesStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -9,8 +9,10 @@ export class GenerativeAiUseCasesStack extends Stack {
     process.env.overrideWarningsEnabled = 'false';
 
     const auth = new Auth(this, 'Auth');
+    const database = new Database(this, 'Database');
     const api = new Api(this, 'API', {
       userPool: auth.userPool,
+      table: database.table,
     });
 
     const web = new Web(this, 'Api', {

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -15,8 +15,10 @@
     "typescript": "~5.1.6"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.386.0",
     "@aws-cdk/aws-lambda-python-alpha": "^2.88.0-alpha.0",
+    "@aws-sdk/client-dynamodb": "^3.395.0",
+    "@aws-sdk/client-secrets-manager": "^3.386.0",
+    "@aws-sdk/lib-dynamodb": "^3.395.0",
     "@aws-solutions-constructs/aws-cloudfront-s3": "^2.41.0",
     "aws-cdk-lib": "2.88.0",
     "constructs": "^10.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@types/generative-ai-use-cases-jp",
+  "types": "src/index.d.ts",
+  "private": true
+}

--- a/packages/types/src/base.d.ts
+++ b/packages/types/src/base.d.ts
@@ -1,0 +1,4 @@
+export type PrimaryKey = {
+  id: string;
+  createdDate: string;
+};

--- a/packages/types/src/chat.d.ts
+++ b/packages/types/src/chat.d.ts
@@ -1,0 +1,8 @@
+import { PrimaryKey } from './base';
+
+export type Chat = PrimaryKey & {
+  chatId: string;
+  usecase: string;
+  title: string;
+  updatedDate: string;
+};

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -1,0 +1,4 @@
+export * from './base';
+export * from './message';
+export * from './chat';
+export * from './protocol';

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -1,0 +1,24 @@
+import { PrimaryKey } from './base';
+
+export type Role = 'system' | 'user' | 'assistant';
+
+export type MessageAttributes = {
+  messageId: string;
+  usecase: string;
+  userId: string;
+  feedback: string;
+  llmType: string;
+};
+
+export type UnrecordedMessage = {
+  role: Role;
+  content: string;
+};
+
+export type RecordedMessage = PrimaryKey &
+  MessageAttributes &
+  UnrecordedMessage;
+
+export type ShownMessage = Partial<PrimaryKey> &
+  Partial<MessageAttributes> &
+  UnrecordedMessage;

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -2,12 +2,12 @@ import { RecordedMessage, UnrecordedMessage, ShownMessage } from './message';
 import { Chat } from './chat';
 
 export type CreateChatRequest = {
-  unrecordedMessages: UnrecordedMessage[];
+  systemContext?: UnrecordedMessage;
 };
 
 export type CreateChatResponse = {
   chat: Chat;
-  messages: RecordedMessage[];
+  systemContext?: RecordedMessage;
 };
 
 export type PredictRequest = {

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -1,0 +1,22 @@
+import { RecordedMessage, UnrecordedMessage, ShownMessage } from './message';
+import { Chat } from './chat';
+
+export type CreateChatRequest = {
+  unrecordedMessages: UnrecordedMessage[];
+};
+
+export type CreateChatResponse = {
+  chat: Chat;
+  messages: RecordedMessage[];
+};
+
+export type PredictRequest = {
+  chatId?: string;
+  recordedMessages: RecordedMessage[];
+  unrecordedMessages: UnrecordedMessage[];
+  skipRecording?: boolean;
+};
+
+export type PredictResponse = {
+  messages: ShownMessage[];
+};

--- a/packages/web/src/@types/predict.d.ts
+++ b/packages/web/src/@types/predict.d.ts
@@ -1,5 +1,0 @@
-export type Role = 'system' | 'user' | 'assistant';
-export type PredictContent = {
-  role: Role;
-  content: string;
-};

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -5,11 +5,11 @@ import ButtonFeedback from './ButtonFeedback';
 import Tooltip from './Tooltip';
 import { PiChatCircleDotsFill, PiUserFill } from 'react-icons/pi';
 import { BaseProps } from '../@types/common';
-import { PredictContent } from '../@types/predict';
+import { ShownMessage } from 'generative-ai-use-cases-jp';
 import { ReactComponent as MLLogo } from '../assets/model.svg';
 
 type Props = BaseProps & {
-  chatContent?: PredictContent;
+  chatContent?: ShownMessage;
   loading?: boolean;
 };
 

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -38,16 +38,16 @@ const useChatState = create<{
     });
   };
 
-  const replaceAndPushMessages = (
+  const mergeRecordedMessages = (
     id: string,
     recordedMessages: RecordedMessage[]
   ) => {
     set((state) => {
       return {
         chats: produce(state.chats, (draft) => {
-          // 記録されていない User のメッセージを削除
-          draft[id].messages.pop();
-          // 記録されたもので置き換えつつ、アシスタントのメッセージを追加
+          // messageId が付与されていない unrecorded なメッセージを削除
+          draft[id].messages = draft[id].messages.filter((m) => m.messageId);
+          // recorded なメッセージを末尾に追加
           draft[id].messages = draft[id].messages.concat(recordedMessages);
         }),
       };
@@ -135,7 +135,7 @@ const useChatState = create<{
               });
             })
             .then((res: PredictResponse) => {
-              replaceAndPushMessages(id, res.messages as RecordedMessage[]);
+              mergeRecordedMessages(id, res.messages as RecordedMessage[]);
             })
             .finally(() => {
               setLoading(id, false);
@@ -148,7 +148,7 @@ const useChatState = create<{
             unrecordedMessages: [unrecordedUserMessage],
           })
             .then((res: PredictResponse) => {
-              replaceAndPushMessages(id, res.messages as RecordedMessage[]);
+              mergeRecordedMessages(id, res.messages as RecordedMessage[]);
             })
             .finally(() => {
               setLoading(id, false);

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -122,7 +122,6 @@ const useChatState = create<{
           // systemContext の message で Chat を初期化する
           createChat({ unrecordedMessages: [state.chats[id].messages[0]] })
             .then((res: CreateChatResponse) => {
-              console.log('chat created', res);
               initChat(
                 id,
                 res.chat,
@@ -136,7 +135,6 @@ const useChatState = create<{
               });
             })
             .then((res: PredictResponse) => {
-              console.log('predicted', res);
               replaceAndPushMessages(id, res.messages as RecordedMessage[]);
             })
             .finally(() => {
@@ -150,7 +148,6 @@ const useChatState = create<{
             unrecordedMessages: [unrecordedUserMessage],
           })
             .then((res: PredictResponse) => {
-              console.log('predicted', res);
               replaceAndPushMessages(id, res.messages as RecordedMessage[]);
             })
             .finally(() => {

--- a/packages/web/src/hooks/usePredictor.ts
+++ b/packages/web/src/hooks/usePredictor.ts
@@ -1,19 +1,22 @@
-import { PredictContent } from '../@types/predict';
+import {
+  PredictRequest,
+  PredictResponse,
+  CreateChatRequest,
+  CreateChatResponse,
+} from 'generative-ai-use-cases-jp';
 import useHttp from '../hooks/useHttp';
 
 const usePredictor = () => {
   const http = useHttp();
 
   return {
-    predict: async (contents: PredictContent[]): Promise<PredictContent> => {
-      const res = await http.post(`predict`, {
-        messages: contents,
-      });
-
-      return {
-        role: 'assistant',
-        content: res.data['response'],
-      };
+    createChat: async (req: CreateChatRequest): Promise<CreateChatResponse> => {
+      const res = await http.post('chat', req);
+      return res.data;
+    },
+    predict: async (req: PredictRequest): Promise<PredictResponse> => {
+      const res = await http.post('predict', req);
+      return res.data;
     },
   };
 };

--- a/packages/web/src/hooks/useTextToJson.ts
+++ b/packages/web/src/hooks/useTextToJson.ts
@@ -57,7 +57,6 @@ const useTextToJson = () => {
           try {
             resJson = JSON.parse(res.messages.slice(-1)[0].content);
           } catch {
-            console.log(res.messages);
             throw new FormatError(
               textToJsonPrompt.parseErrorRetryPrompt(format)
             );
@@ -69,7 +68,6 @@ const useTextToJson = () => {
 
           // キーの数が異なる場合はエラー
           if (formatKeys.length !== resKeys.length) {
-            console.log(resJson);
             throw new FormatError(
               textToJsonPrompt.keysInvalidErrorRetryPrompt(format)
             );
@@ -77,7 +75,6 @@ const useTextToJson = () => {
           // フォーマットに指定していない項目が含まれていればエラー
           resKeys.forEach((key) => {
             if (!formatKeys.includes(key)) {
-              console.log(resJson);
               throw new FormatError(
                 textToJsonPrompt.keysInvalidErrorRetryPrompt(format)
               );

--- a/packages/web/src/pages/NotFound.tsx
+++ b/packages/web/src/pages/NotFound.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 const NotFound: React.FC = () => {
   return (
-    <div className="h-full flex flex-col justify-center items-center">
-      <h1 className="text-5xl mb-2">404</h1>
-      <h2 className="text-lg text-aws-smile">NotFound</h2>
+    <div className="flex h-full flex-col items-center justify-center">
+      <h1 className="mb-2 text-5xl">404</h1>
+      <h2 className="text-aws-smile text-lg">NotFound</h2>
     </div>
-  )
+  );
 };
 
 export default NotFound;


### PR DESCRIPTION
- ddb に登録するようにした
- 検索系や feedback 系はこの PR では対応していない
  - マネコンで必要な query ができることは確認
- chat の init 時に chatId を作成してしまうと、画面を開くたびに空の chat ができてしまうため、最初のメッセージを送ったときに作成するようにした
  - chat を作成しつつ、systemContext を最初のメッセージとして record する
- predict 関数は unrecorded (ddb に記録されていない) と recorded (ddb に記録されている) のメッセージを渡して、unrecorded のものを ddb に登録しつつ、推論結果を recorded にして返すという挙動にした
  - skipRecording: true を渡せば ddb に記録されない (情報抽出のユースケースで利用)
- transaction だと時間 (createdDate) のずれがなく会話の復元に失敗する可能性があると思い、putItem はメッセージごとに行なっている
- web <=> lambda 間で protocol が必要だったため、workspace に共通で使う type definition を定義した types を追加した