### PR TITLE
write 系のバックエンドの実装し直し

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14181,6 +14181,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
       "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g=="
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -25249,6 +25254,7 @@
         "@aws-amplify/ui-react": "^5.0.6",
         "@headlessui/react": "^1.7.15",
         "@react-icons/all-files": "^4.1.0",
+        "@types/uuid": "^9.0.2",
         "aws-amplify": "^5.3.5",
         "axios": "^1.4.0",
         "copy-to-clipboard": "^3.3.3",
@@ -25263,6 +25269,7 @@
         "remark-gfm": "^3.0.1",
         "swr": "^2.2.0",
         "tailwind-scrollbar": "^3.0.4",
+        "uuid": "^9.0.0",
         "zustand": "^4.3.9"
       },
       "devDependencies": {
@@ -25285,6 +25292,14 @@
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
         "vite-plugin-svgr": "^3.2.0"
+      }
+    },
+    "packages/web/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     }
   }

--- a/packages/cdk/lambda/createMessages.ts
+++ b/packages/cdk/lambda/createMessages.ts
@@ -1,13 +1,16 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { createChat } from './repository';
+import { CreateMessagesRequest } from 'generative-ai-use-cases-jp';
+import { batchCreateMessages } from './repository';
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
+    const req: CreateMessagesRequest = JSON.parse(event.body!);
     const userId: string =
       event.requestContext.authorizer!.claims['cognito:username'];
-    const chat = await createChat(userId);
+    const chatId = event.pathParameters!.chatId!;
+    const messages = await batchCreateMessages(req.messages, userId, chatId);
 
     return {
       statusCode: 200,
@@ -16,7 +19,7 @@ export const handler = async (
         'Access-Control-Allow-Origin': '*',
       },
       body: JSON.stringify({
-        chat,
+        messages,
       }),
     };
   } catch (error) {

--- a/packages/cdk/lambda/predict.ts
+++ b/packages/cdk/lambda/predict.ts
@@ -1,6 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Configuration, OpenAIApi } from 'openai';
-import { PredictRequest, ShownMessage } from 'generative-ai-use-cases-jp';
+import { PredictRequest } from 'generative-ai-use-cases-jp';
 import { fetchOpenApiKey } from './secret';
 
 export const handler = async (

--- a/packages/cdk/lambda/predict.ts
+++ b/packages/cdk/lambda/predict.ts
@@ -2,34 +2,12 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { Configuration, OpenAIApi } from 'openai';
 import { PredictRequest, ShownMessage } from 'generative-ai-use-cases-jp';
 import { fetchOpenApiKey } from './secret';
-import { recordMessage } from './repository';
-
-const omitUnusedProperties = (messages: ShownMessage[]) => {
-  return messages.map((m) => {
-    return {
-      role: m.role,
-      content: m.content,
-    };
-  });
-};
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
     const req: PredictRequest = JSON.parse(event.body!);
-    const userId: string =
-      event.requestContext.authorizer!.claims['cognito:username'];
-
-    let predictedMessages: ShownMessage[] = [];
-
-    if (req.skipRecording) {
-      predictedMessages = req.unrecordedMessages;
-    } else {
-      for (const m of req.unrecordedMessages) {
-        predictedMessages.push(await recordMessage(m, userId, req.chatId!));
-      }
-    }
 
     // Secret 情報の取得
     const apiKey = await fetchOpenApiKey();
@@ -41,33 +19,16 @@ export const handler = async (
     // OpenAI API を使用してチャットの応答を取得
     const chatCompletion = await openai.createChatCompletion({
       model: 'gpt-3.5-turbo',
-      messages: omitUnusedProperties(
-        (req.recordedMessages as ShownMessage[]).concat(predictedMessages)
-      ),
+      messages: req.messages,
     });
-
-    let assistantMessage: ShownMessage = {
-      role: 'assistant',
-      content: chatCompletion.data.choices[0].message?.content!,
-    };
-
-    if (!req.skipRecording) {
-      assistantMessage = await recordMessage(
-        assistantMessage,
-        userId,
-        req.chatId!
-      );
-    }
-
-    predictedMessages.push(assistantMessage);
 
     return {
       statusCode: 200,
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'text/plain',
         'Access-Control-Allow-Origin': '*',
       },
-      body: JSON.stringify({ messages: predictedMessages }),
+      body: chatCompletion.data.choices[0].message?.content!,
     };
   } catch (error) {
     console.log(error);

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -56,6 +56,16 @@ export class Api extends Construct {
     });
     props.table.grantWriteData(createChatFunction);
 
+    const createMessagesFunction = new NodejsFunction(this, 'CreateMessages', {
+      runtime: Runtime.NODEJS_18_X,
+      entry: './lambda/createMessages.ts',
+      timeout: Duration.minutes(15),
+      environment: {
+        TABLE_NAME: props.table.tableName,
+      },
+    });
+    props.table.grantWriteData(createMessagesFunction);
+
     const listChatsFunction = new NodejsFunction(this, 'ListChats', {
       runtime: Runtime.NODEJS_18_X,
       entry: './lambda/listChats.ts',
@@ -129,6 +139,13 @@ export class Api extends Construct {
     messagesResource.addMethod(
       'GET',
       new LambdaIntegration(listMessagesFunction),
+      commonAuthorizerProps
+    );
+
+    // POST: /chats/{chatId}/messages
+    messagesResource.addMethod(
+      'POST',
+      new LambdaIntegration(createMessagesFunction),
       commonAuthorizerProps
     );
 

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -44,7 +44,6 @@ export class Api extends Construct {
       },
     });
     secret.grantRead(predictFunction);
-    props.table.grantReadWriteData(predictFunction);
 
     const createChatFunction = new NodejsFunction(this, 'CreateChat', {
       runtime: Runtime.NODEJS_18_X,

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -19,6 +19,10 @@ export type RecordedMessage = PrimaryKey &
   MessageAttributes &
   UnrecordedMessage;
 
+export type ToBeRecordedMessage = UnrecordedMessage & {
+  messageId: string;
+};
+
 export type ShownMessage = Partial<PrimaryKey> &
   Partial<MessageAttributes> &
   UnrecordedMessage;

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -1,13 +1,16 @@
-import { RecordedMessage, UnrecordedMessage, ShownMessage } from './message';
+import { RecordedMessage, ShownMessage, ToBeRecordedMessage } from './message';
 import { Chat } from './chat';
-
-export type CreateChatRequest = {
-  systemContext?: UnrecordedMessage;
-};
 
 export type CreateChatResponse = {
   chat: Chat;
-  systemContext?: RecordedMessage;
+};
+
+export type CreateMessagesRequest = {
+  messages: ToBeRecordedMessage[];
+};
+
+export type CreateMessagesResponse = {
+  messages: RecordedMessage[];
 };
 
 export type ListChatsResponse = {
@@ -19,12 +22,7 @@ export type ListMessagesResponse = {
 };
 
 export type PredictRequest = {
-  chatId?: string;
-  recordedMessages: RecordedMessage[];
-  unrecordedMessages: UnrecordedMessage[];
-  skipRecording?: boolean;
-};
-
-export type PredictResponse = {
   messages: ShownMessage[];
 };
+
+export type PredictResponse = string;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
     "@aws-amplify/ui-react": "^5.0.6",
     "@headlessui/react": "^1.7.15",
     "@react-icons/all-files": "^4.1.0",
+    "@types/uuid": "^9.0.2",
     "aws-amplify": "^5.3.5",
     "axios": "^1.4.0",
     "copy-to-clipboard": "^3.3.3",
@@ -27,6 +28,7 @@
     "remark-gfm": "^3.0.1",
     "swr": "^2.2.0",
     "tailwind-scrollbar": "^3.0.4",
+    "uuid": "^9.0.0",
     "zustand": "^4.3.9"
   },
   "devDependencies": {

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -46,7 +46,6 @@ const ChatMessage: React.FC<Props> = (props) => {
           )}
 
           <div className="ml-5 grow ">
-            {JSON.stringify(props.chatContent)}
             {chatContent?.role === 'user' && (
               <div className="break-all">
                 {chatContent.content.split('\n').map((c, idx) => (

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -46,6 +46,7 @@ const ChatMessage: React.FC<Props> = (props) => {
           )}
 
           <div className="ml-5 grow ">
+            {JSON.stringify(props.chatContent)}
             {chatContent?.role === 'user' && (
               <div className="break-all">
                 {chatContent.content.split('\n').map((c, idx) => (

--- a/packages/web/src/hooks/useHttp.ts
+++ b/packages/web/src/hooks/useHttp.ts
@@ -1,6 +1,6 @@
 // import { Auth } from "aws-amplify";
 import { Auth } from 'aws-amplify';
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
 import useSWR, { SWRConfiguration } from 'swr';
 // import useAlertSnackbar from "./useAlertSnackbar";
 
@@ -64,12 +64,13 @@ const useHttp = () => {
     post: <RES = any, DATA = any>(
       url: string,
       data: DATA,
+      reqConfig?: AxiosRequestConfig,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       errorProcess?: (err: any) => void
     ) => {
       return new Promise<AxiosResponse<RES>>((resolve, reject) => {
         api
-          .post<RES, AxiosResponse<RES>, DATA>(url, data)
+          .post<RES, AxiosResponse<RES>, DATA>(url, data, reqConfig)
           .then((data) => {
             resolve(data);
           })

--- a/packages/web/src/hooks/usePredictor.ts
+++ b/packages/web/src/hooks/usePredictor.ts
@@ -1,8 +1,9 @@
 import {
   PredictRequest,
   PredictResponse,
-  CreateChatRequest,
   CreateChatResponse,
+  CreateMessagesRequest,
+  CreateMessagesResponse,
 } from 'generative-ai-use-cases-jp';
 import useHttp from '../hooks/useHttp';
 
@@ -10,8 +11,16 @@ const usePredictor = () => {
   const http = useHttp();
 
   return {
-    createChat: async (req: CreateChatRequest): Promise<CreateChatResponse> => {
-      const res = await http.post('chats', req);
+    createChat: async (): Promise<CreateChatResponse> => {
+      const res = await http.post('chats', {});
+      return res.data;
+    },
+    createMessages: async (
+      _chatId: string,
+      req: CreateMessagesRequest
+    ): Promise<CreateMessagesResponse> => {
+      const chatId = _chatId.split('#')[1];
+      const res = await http.post(`chats/${chatId}/messages`, req);
       return res.data;
     },
     listChats: () => {
@@ -21,8 +30,8 @@ const usePredictor = () => {
       return http.get(`chats/${chatId}/messages`);
     },
     predict: async (req: PredictRequest): Promise<PredictResponse> => {
-      const res = await http.post('predict', req);
-      return res.data;
+      const res = await http.post('predict', req, { responseType: 'blob' });
+      return await res.data.text();
     },
   };
 };

--- a/packages/web/src/hooks/useTextToJson.ts
+++ b/packages/web/src/hooks/useTextToJson.ts
@@ -26,8 +26,7 @@ const useTextToJson = () => {
       format: T
     ): Promise<T | null> => {
       const req: PredictRequest = {
-        recordedMessages: [],
-        unrecordedMessages: [
+        messages: [
           {
             role: 'system',
             content: textToJsonPrompt.systemPrompt(context, format),
@@ -37,7 +36,6 @@ const useTextToJson = () => {
             content: text,
           },
         ],
-        skipRecording: true,
       };
 
       setLoading(true);
@@ -55,7 +53,7 @@ const useTextToJson = () => {
 
           // 推論結果がJSON形式であるかどうかの確認
           try {
-            resJson = JSON.parse(res.messages.slice(-1)[0].content);
+            resJson = JSON.parse(res);
           } catch {
             throw new FormatError(
               textToJsonPrompt.parseErrorRetryPrompt(format)
@@ -96,8 +94,11 @@ const useTextToJson = () => {
           // JSONの出力形式エラーの場合は、エラー情報をセットして再度推論を実行
           if (e instanceof FormatError && res) {
             // 推論結果 (Assistant のメッセージ) と訂正文 (User のメッセージ) を追加して再実行
-            req.unrecordedMessages.push(res.messages.slice(-1)[0]);
-            req.unrecordedMessages.push({
+            req.messages.push({
+              role: 'assistant',
+              content: res,
+            });
+            req.messages.push({
               role: 'user',
               content: e.message,
             });


### PR DESCRIPTION
ポイントは以下です
- messageId をフロントエンドで付与することで、ddb に登録後に message の replace が安全にできるようになった (messageId を照合する)
- predict は llm の答えを text/plain で返すだけで、chat の作成と messages の記録は別 API とした
  - streaming response を見据えた対応