### PR TITLE
Feedback 送信 (チャットのみ)

### DIFF
--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -171,3 +171,27 @@ export const setChatTitle = async (
     })
   );
 };
+
+export const updateFeedback = async (
+  _chatId: string,
+  createdDate: string,
+  feedback: string
+): Promise<RecordedMessage> => {
+  const chatId = `chat#${_chatId}`;
+  const res = await dynamoDbDocument.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: {
+        id: chatId,
+        createdDate,
+      },
+      UpdateExpression: 'set feedback = :feedback',
+      ExpressionAttributeValues: {
+        ':feedback': feedback,
+      },
+      ReturnValues: 'ALL_NEW',
+    })
+  );
+
+  return res.Attributes as RecordedMessage;
+};

--- a/packages/cdk/lambda/updateFeedback.ts
+++ b/packages/cdk/lambda/updateFeedback.ts
@@ -1,0 +1,33 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { UpdateFeedbackRequest } from 'generative-ai-use-cases-jp';
+import { updateFeedback } from './repository';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const chatId = event.pathParameters!.chatId!;
+    const req: UpdateFeedbackRequest = JSON.parse(event.body!);
+
+    const message = await updateFeedback(chatId, req.createdDate, req.feedback);
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ message }),
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    };
+  }
+};

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -123,6 +123,16 @@ export class Api extends Construct {
     });
     table.grantReadData(listMessagesFunction);
 
+    const updateFeedbackFunction = new NodejsFunction(this, 'UpdateFeedback', {
+      runtime: Runtime.NODEJS_18_X,
+      entry: './lambda/updateFeedback.ts',
+      timeout: Duration.minutes(15),
+      environment: {
+        TABLE_NAME: table.tableName,
+      },
+    });
+    table.grantWriteData(updateFeedbackFunction);
+
     // API Gateway
     const authorizer = new CognitoUserPoolsAuthorizer(this, 'Authorizer', {
       cognitoUserPools: [userPool],
@@ -213,6 +223,15 @@ export class Api extends Construct {
     messagesResource.addMethod(
       'POST',
       new LambdaIntegration(createMessagesFunction),
+      commonAuthorizerProps
+    );
+
+    const feedbacksResource = chatResource.addResource('feedbacks');
+
+    // POST: /chats/{chatId}/feedbacks
+    feedbacksResource.addMethod(
+      'POST',
+      new LambdaIntegration(updateFeedbackFunction),
       commonAuthorizerProps
     );
 

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -30,6 +30,15 @@ export type ListMessagesResponse = {
   messages: RecordedMessage[];
 };
 
+export type UpdateFeedbackRequest = {
+  createdDate: string;
+  feedback: string;
+};
+
+export type UpdateFeedbackResponse = {
+  message: RecordedMessage;
+};
+
 export type PredictRequest = {
   messages: UnrecordedMessage[];
 };

--- a/packages/web/src/components/ButtonFeedback.tsx
+++ b/packages/web/src/components/ButtonFeedback.tsx
@@ -1,20 +1,56 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { BaseProps } from '../@types/common';
 import ButtonIcon from './ButtonIcon';
-import { PiThumbsUp, PiThumbsDown } from 'react-icons/pi';
+import {
+  PiThumbsUp,
+  PiThumbsDown,
+  PiThumbsUpFill,
+  PiThumbsDownFill,
+} from 'react-icons/pi';
+import { ShownMessage } from 'generative-ai-use-cases-jp';
 
 type Props = BaseProps & {
-  good: boolean;
+  message: ShownMessage;
+  feedback: string;
+  onClick: () => void;
+  disabled: boolean;
 };
 
 const ButtonFeedback: React.FC<Props> = (props) => {
+  const color = useMemo(() => {
+    if (props.disabled) {
+      return 'text-gray-500';
+    }
+
+    if (props.feedback === 'good') {
+      return 'text-green-500';
+    } else {
+      return 'text-red-500';
+    }
+  }, [props]);
+
+  const icon = useMemo(() => {
+    if (props.feedback === 'good') {
+      if (props.message.feedback === 'good') {
+        return <PiThumbsUpFill />;
+      } else {
+        return <PiThumbsUp />;
+      }
+    } else {
+      if (props.message.feedback === 'bad') {
+        return <PiThumbsDownFill />;
+      } else {
+        return <PiThumbsDown />;
+      }
+    }
+  }, [props]);
+
   return (
     <ButtonIcon
-      className={`${props.className ?? ''} ${
-        props.good ? 'text-green-500' : 'text-red-500'
-      }`}
-      onClick={() => {}}>
-      {props.good ? <PiThumbsUp /> : <PiThumbsDown />}
+      className={`${props.className} ${color}`}
+      disabled={props.disabled}
+      onClick={props.onClick}>
+      {icon}
     </ButtonIcon>
   );
 };

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -30,7 +30,11 @@ const ChatMessage: React.FC<Props> = (props) => {
   const onSendFeedback = async (feedback: string) => {
     if (!disabled) {
       setIsSendingFeedback(true);
-      await sendFeedback(props.chatContent!.createdDate!, feedback);
+      if (feedback !== chatContent.feedback) {
+        await sendFeedback(props.chatContent!.createdDate!, feedback);
+      } else {
+        await sendFeedback(props.chatContent!.createdDate!, 'none');
+      }
       setIsSendingFeedback(false);
     }
   };

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -1,12 +1,13 @@
-import React, { useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import Markdown from './Markdown';
 import ButtonCopy from './ButtonCopy';
 import ButtonFeedback from './ButtonFeedback';
-import Tooltip from './Tooltip';
 import { PiUserFill } from 'react-icons/pi';
 import { BaseProps } from '../@types/common';
 import { ShownMessage } from 'generative-ai-use-cases-jp';
 import { ReactComponent as MLLogo } from '../assets/model.svg';
+import useChat from '../hooks/useChat';
 
 type Props = BaseProps & {
   chatContent?: ShownMessage;
@@ -17,6 +18,22 @@ const ChatMessage: React.FC<Props> = (props) => {
   const chatContent = useMemo(() => {
     return props.chatContent;
   }, [props]);
+
+  const { pathname } = useLocation();
+  const { sendFeedback } = useChat(pathname);
+  const [isSendingFeedback, setIsSendingFeedback] = useState(false);
+
+  const disabled = useMemo(() => {
+    return isSendingFeedback || !props.chatContent.id;
+  }, [isSendingFeedback, props]);
+
+  const onSendFeedback = async (feedback: string) => {
+    if (!disabled) {
+      setIsSendingFeedback(true);
+      await sendFeedback(props.chatContent.createdDate, feedback);
+      setIsSendingFeedback(false);
+    }
+  };
 
   return (
     <div
@@ -71,12 +88,26 @@ const ChatMessage: React.FC<Props> = (props) => {
                 className="mr-0.5 text-gray-400"
                 text={chatContent.content}
               />
-              <Tooltip message="未実装です">
-                <ButtonFeedback className="mx-0.5" good={true} />
-              </Tooltip>
-              <Tooltip message="未実装です">
-                <ButtonFeedback className="ml-0.5" good={false} />
-              </Tooltip>
+              {chatContent && (
+                <>
+                  <ButtonFeedback
+                    className="mx-0.5"
+                    feedback="good"
+                    message={chatContent}
+                    disabled={disabled}
+                    onClick={() => {
+                      onSendFeedback('good');
+                    }}
+                  />
+                  <ButtonFeedback
+                    className="ml-0.5"
+                    feedback="bad"
+                    message={chatContent}
+                    disabled={disabled}
+                    onClick={() => onSendFeedback('bad')}
+                  />
+                </>
+              )}
             </>
           )}
         </div>

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -24,13 +24,13 @@ const ChatMessage: React.FC<Props> = (props) => {
   const [isSendingFeedback, setIsSendingFeedback] = useState(false);
 
   const disabled = useMemo(() => {
-    return isSendingFeedback || !props.chatContent.id;
+    return isSendingFeedback || !props.chatContent?.id;
   }, [isSendingFeedback, props]);
 
   const onSendFeedback = async (feedback: string) => {
     if (!disabled) {
       setIsSendingFeedback(true);
-      await sendFeedback(props.chatContent.createdDate, feedback);
+      await sendFeedback(props.chatContent!.createdDate!, feedback);
       setIsSendingFeedback(false);
     }
   };

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -9,6 +9,8 @@ import {
   PredictTitleRequest,
   PredictTitleResponse,
   FindChatByIdResponse,
+  UpdateFeedbackRequest,
+  UpdateFeedbackResponse,
 } from 'generative-ai-use-cases-jp';
 import {
   LambdaClient,
@@ -45,6 +47,14 @@ const useChatApi = () => {
       return http.get<ListMessagesResponse>(
         chatId ? `chats/${chatId}/messages` : null
       );
+    },
+    updateFeedback: async (
+      _chatId: string,
+      req: UpdateFeedbackRequest
+    ): Promise<UpdateFeedbackResponse> => {
+      const chatId = _chatId.split('#')[1];
+      const res = await http.post(`chats/${chatId}/feedbacks`, req);
+      return res.data;
     },
     // Buffered Response (useTextToJson で利用)
     predict: async (req: PredictRequest): Promise<PredictResponse> => {

--- a/packages/web/src/pages/PromptTamplatePageBase.tsx
+++ b/packages/web/src/pages/PromptTamplatePageBase.tsx
@@ -123,10 +123,22 @@ const PromptTamplatePageBase: React.FC<Props> = (props) => {
                         text={message.content}
                       />
                       <Tooltip message="未実装です">
-                        <ButtonFeedback className="mx-0.5" good={true} />
+                        <ButtonFeedback
+                          className="mx-0.5"
+                          message={message}
+                          feedback="good"
+                          onClick={() => {}}
+                          disabled={false}
+                        />
                       </Tooltip>
                       <Tooltip message="未実装です">
-                        <ButtonFeedback className="ml-0.5" good={false} />
+                        <ButtonFeedback
+                          className="ml-0.5"
+                          message={message}
+                          feedback="bad"
+                          onClick={() => {}}
+                          disabled={false}
+                        />
                       </Tooltip>
                     </div>
                   </>


### PR DESCRIPTION
Feedback 送信機能を、とりあえずチャット画面 (履歴も含め) のみ対応しました。その他のユースケース別の実装の方にも追加可能ですが、多少リファクタリングを入れたいと思っているので (可能であれば ChatPage.tsx と統合したい) 別 Issue に上げさせてもらいます。Internal Knowledge Sharing ではチャットのみで十分だと思うので、取り急ぎ。
