### PR TITLE
会話件名の更新

### DIFF
--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -158,7 +158,7 @@ export const setChatTitle = async (
   createdDate: string,
   title: string
 ) => {
-  await dynamoDbDocument.send(
+  const res = await dynamoDbDocument.send(
     new UpdateCommand({
       TableName: TABLE_NAME,
       Key: {
@@ -169,8 +169,10 @@ export const setChatTitle = async (
       ExpressionAttributeValues: {
         ':title': title,
       },
+      ReturnValues: 'ALL_NEW',
     })
   );
+  return res.Attributes as Chat;
 };
 
 export const updateFeedback = async (

--- a/packages/cdk/lambda/updateTitle.ts
+++ b/packages/cdk/lambda/updateTitle.ts
@@ -1,0 +1,52 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { UpdateTitleRequest } from 'generative-ai-use-cases-jp';
+import { findChatById, setChatTitle } from './repository';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
+    const chatId = event.pathParameters!.chatId!;
+    const req: UpdateTitleRequest = JSON.parse(event.body!);
+
+    const chatItem = await findChatById(userId, chatId);
+
+    if (!chatItem) {
+      return {
+        statusCode: 404,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: '',
+      };
+    }
+
+    const updatedChat = await setChatTitle(
+      chatItem?.id,
+      chatItem?.createdDate,
+      req.title
+    );
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ chat: updatedChat }),
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    };
+  }
+};

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -103,6 +103,20 @@ export class Api extends Construct {
     });
     table.grantWriteData(createMessagesFunction);
 
+    const updateChatTitleFunction = new NodejsFunction(
+      this,
+      'UpdateChatTitle',
+      {
+        runtime: Runtime.NODEJS_18_X,
+        entry: './lambda/updateTitle.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          TABLE_NAME: table.tableName,
+        },
+      }
+    );
+    table.grantReadWriteData(updateChatTitleFunction);
+
     const listChatsFunction = new NodejsFunction(this, 'ListChats', {
       runtime: Runtime.NODEJS_18_X,
       entry: './lambda/listChats.ts',
@@ -224,6 +238,15 @@ export class Api extends Construct {
     chatResource.addMethod(
       'DELETE',
       new LambdaIntegration(deleteChatFunction),
+      commonAuthorizerProps
+    );
+
+    const titleResource = chatResource.addResource('title');
+
+    // PUT: /chats/{chatId}/title
+    titleResource.addMethod(
+      'PUT',
+      new LambdaIntegration(updateChatTitleFunction),
       commonAuthorizerProps
     );
 

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -39,6 +39,14 @@ export type UpdateFeedbackResponse = {
   message: RecordedMessage;
 };
 
+export type UpdateTitleRequest = {
+  title: string;
+};
+
+export type UpdateTitleResponse = {
+  chat: Chat;
+};
+
 export type PredictRequest = {
   messages: UnrecordedMessage[];
 };

--- a/packages/web/src/components/ChatList.tsx
+++ b/packages/web/src/components/ChatList.tsx
@@ -1,34 +1,37 @@
 import React, { useCallback } from 'react';
 import { BaseProps } from '../@types/common';
 import useConversation from '../hooks/useConversation';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import ChatListItem from './ChatListItem';
 import { decomposeChatId } from '../utils/ChatUtils';
-import useChat from '../hooks/useChat';
 
 type Props = BaseProps;
 
 const ChatList: React.FC<Props> = (props) => {
-  const { conversations, loading, deleteConversation } = useConversation();
+  const {
+    conversations,
+    loading,
+    deleteConversation,
+    updateConversationTitle,
+  } = useConversation();
   const { chatId } = useParams();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
-  const { updateChatTitle } = useChat(pathname);
 
   const onDelete = useCallback(
     (_chatId: string) => {
-      return deleteConversation(_chatId).then(() => {
-        navigate('/chat');
+      navigate('/chat');
+      return deleteConversation(_chatId).catch(() => {
+        navigate(`/chat/${_chatId}`);
       });
     },
     [deleteConversation, navigate]
   );
 
   const onUpdateTitle = useCallback(
-    (title: string) => {
-      return updateChatTitle(title);
+    (_chatId: string, title: string) => {
+      return updateConversationTitle(_chatId, title);
     },
-    [updateChatTitle]
+    [updateConversationTitle]
   );
 
   return (

--- a/packages/web/src/components/ChatList.tsx
+++ b/packages/web/src/components/ChatList.tsx
@@ -1,41 +1,38 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { BaseProps } from '../@types/common';
 import useConversation from '../hooks/useConversation';
-import { PiChat, PiTrash } from 'react-icons/pi';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import ButtonIcon from './ButtonIcon';
-import DialogConfirmDeleteChat from './DialogConfirmDeleteChat';
-import { Chat } from 'generative-ai-use-cases-jp';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import ChatListItem from './ChatListItem';
+import { decomposeChatId } from '../utils/ChatUtils';
+import useChat from '../hooks/useChat';
 
 type Props = BaseProps;
 
 const ChatList: React.FC<Props> = (props) => {
   const { conversations, loading, deleteConversation } = useConversation();
   const { chatId } = useParams();
-  const [openDialog, setOpenDialog] = useState(false);
-  const [targetDelete, setTargetDelete] = useState<Chat>();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { updateChatTitle } = useChat(pathname);
 
   const onDelete = useCallback(
     (_chatId: string) => {
-      deleteConversation(_chatId).then(() => {
-        setOpenDialog(false);
+      return deleteConversation(_chatId).then(() => {
         navigate('/chat');
       });
     },
     [deleteConversation, navigate]
   );
 
+  const onUpdateTitle = useCallback(
+    (title: string) => {
+      return updateChatTitle(title);
+    },
+    [updateChatTitle]
+  );
+
   return (
     <>
-      <DialogConfirmDeleteChat
-        isOpen={openDialog}
-        target={targetDelete}
-        onDelete={onDelete}
-        onClose={() => {
-          setOpenDialog(false);
-        }}
-      />
       <div
         className={`${
           props.className ?? ''
@@ -49,40 +46,16 @@ const ChatList: React.FC<Props> = (props) => {
                 className="bg-aws-sky/20 h-8 w-full animate-pulse rounded"></div>
             ))}
         {conversations.map((chat) => {
-          const _chatId = chat.chatId.split('#')[1];
+          const _chatId = decomposeChatId(chat.chatId);
           return (
-            <div
+            <ChatListItem
               key={_chatId}
-              className={`hover:bg-aws-sky group flex w-full items-center rounded  ${
-                chatId === _chatId && 'bg-aws-sky'
-              }
-          ${props.className}`}>
-              <Link
-                className={`flex h-8 w-full items-center justify-start p-2`}
-                to={`/chat/${_chatId}`}>
-                <div className="mr-2 ">
-                  <PiChat />
-                </div>
-                <div className="relative max-h-5 flex-1 overflow-hidden text-ellipsis break-all">
-                  {chat.title}
-                  <div
-                    className={`group-hover:from-aws-sky group-hover:to-aws-sky/40 absolute inset-y-0 right-0 w-8 bg-gradient-to-l
-              ${chatId === _chatId ? 'from-aws-sky' : 'from-aws-squid-ink'}
-              `}></div>
-                </div>
-              </Link>
-              {chatId === _chatId && (
-                <div className="-ml-2 flex pr-2">
-                  <ButtonIcon
-                    onClick={() => {
-                      setOpenDialog(true);
-                      setTargetDelete(chat);
-                    }}>
-                    <PiTrash />
-                  </ButtonIcon>
-                </div>
-              )}
-            </div>
+              className={`${props.className && ''}`}
+              active={chatId === _chatId}
+              chat={chat}
+              onDelete={onDelete}
+              onUpdateTitle={onUpdateTitle}
+            />
           );
         })}
       </div>

--- a/packages/web/src/components/ChatListItem.tsx
+++ b/packages/web/src/components/ChatListItem.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -37,6 +38,13 @@ const ChatListItem: React.FC<Props> = (props) => {
       setTempTitle(props.chat.title);
     }
   }, [editing, props.chat.title]);
+
+  const updateTitle = useCallback(() => {
+    setEditing(false);
+    props.onUpdateTitle(chatId, tempTitle).catch(() => {
+      setEditing(true);
+    });
+  }, [chatId, props, tempTitle]);
 
   useLayoutEffect(() => {
     if (editing) {
@@ -133,7 +141,7 @@ const ChatListItem: React.FC<Props> = (props) => {
             )}
             {editing && (
               <>
-                <ButtonIcon className="text-base" onClick={() => {}}>
+                <ButtonIcon className="text-base" onClick={updateTitle}>
                   <PiCheck />
                 </ButtonIcon>
 

--- a/packages/web/src/components/ChatListItem.tsx
+++ b/packages/web/src/components/ChatListItem.tsx
@@ -16,8 +16,10 @@ import DialogConfirmDeleteChat from './DialogConfirmDeleteChat';
 type Props = BaseProps & {
   active: boolean;
   chat: Chat;
-  onDelete: (chatId: string) => Promise<void>;
-  onUpdateTitle: (title: string) => Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onDelete: (chatId: string) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onUpdateTitle: (chatId: string, title: string) => Promise<any>;
 };
 
 const ChatListItem: React.FC<Props> = (props) => {
@@ -45,7 +47,7 @@ const ChatListItem: React.FC<Props> = (props) => {
           // dispatch 処理の中で Title の更新を行う（同期を取るため）
           setTempTitle((newTitle) => {
             setEditing(false);
-            props.onUpdateTitle(newTitle).catch(() => {
+            props.onUpdateTitle(chatId, newTitle).catch(() => {
               setEditing(true);
             });
             return newTitle;
@@ -71,9 +73,8 @@ const ChatListItem: React.FC<Props> = (props) => {
           isOpen={openDialog}
           target={props.chat}
           onDelete={() => {
-            props.onDelete(chatId).finally(() => {
-              setOpenDialog(false);
-            });
+            setOpenDialog(false);
+            props.onDelete(chatId);
           }}
           onClose={() => {
             setOpenDialog(false);

--- a/packages/web/src/components/ChatListItem.tsx
+++ b/packages/web/src/components/ChatListItem.tsx
@@ -1,0 +1,155 @@
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { BaseProps } from '../@types/common';
+import { Link } from 'react-router-dom';
+import { PiChat, PiCheck, PiPencilLine, PiTrash, PiX } from 'react-icons/pi';
+import ButtonIcon from './ButtonIcon';
+import { Chat } from 'generative-ai-use-cases-jp';
+import { decomposeChatId } from '../utils/ChatUtils';
+import DialogConfirmDeleteChat from './DialogConfirmDeleteChat';
+
+type Props = BaseProps & {
+  active: boolean;
+  chat: Chat;
+  onDelete: (chatId: string) => Promise<void>;
+  onUpdateTitle: (title: string) => Promise<void>;
+};
+
+const ChatListItem: React.FC<Props> = (props) => {
+  const [openDialog, setOpenDialog] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const chatId = useMemo(() => {
+    return decomposeChatId(props.chat.chatId) ?? '';
+  }, [props.chat.chatId]);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [tempTitle, setTempTitle] = useState('');
+
+  useEffect(() => {
+    if (editing) {
+      setTempTitle(props.chat.title);
+    }
+  }, [editing, props.chat.title]);
+
+  useLayoutEffect(() => {
+    if (editing) {
+      const listener = (e: DocumentEventMap['keypress']) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+
+          // dispatch 処理の中で Title の更新を行う（同期を取るため）
+          setTempTitle((newTitle) => {
+            setEditing(false);
+            props.onUpdateTitle(newTitle).catch(() => {
+              setEditing(true);
+            });
+            return newTitle;
+          });
+        }
+      };
+      inputRef.current?.addEventListener('keypress', listener);
+
+      inputRef.current?.focus();
+
+      return () => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        inputRef.current?.removeEventListener('keypress', listener);
+      };
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editing]);
+
+  return (
+    <>
+      {openDialog && (
+        <DialogConfirmDeleteChat
+          isOpen={openDialog}
+          target={props.chat}
+          onDelete={() => {
+            props.onDelete(chatId).finally(() => {
+              setOpenDialog(false);
+            });
+          }}
+          onClose={() => {
+            setOpenDialog(false);
+          }}
+        />
+      )}
+      <Link
+        className={`hover:bg-aws-sky group flex  h-8 w-full items-center justify-start rounded p-2  ${
+          props.active && 'bg-aws-sky'
+        }
+          ${props.className}`}
+        to={`/chat/${chatId}`}>
+        <div
+          className={`flex h-8 max-h-5 w-full justify-start overflow-hidden`}>
+          <div className="mr-2 ">
+            <PiChat />
+          </div>
+          <div className="relative flex-1 text-ellipsis break-all">
+            {editing ? (
+              <input
+                ref={inputRef}
+                type="text"
+                className="max-h-5 w-full bg-transparent p-0 text-sm ring-0"
+                value={tempTitle}
+                onChange={(e) => {
+                  setTempTitle(e.target.value);
+                }}
+              />
+            ) : (
+              <>{props.chat.title}</>
+            )}
+            {!editing && (
+              <div
+                className={`group-hover:from-aws-sky group-hover:to-aws-sky/40 absolute inset-y-0 right-0 w-8 bg-gradient-to-l
+            ${props.active ? 'from-aws-sky' : 'from-aws-squid-ink'}
+            `}
+              />
+            )}
+          </div>
+          <div className="flex">
+            {props.active && !editing && (
+              <>
+                <ButtonIcon
+                  onClick={() => {
+                    setEditing(true);
+                  }}>
+                  <PiPencilLine />
+                </ButtonIcon>
+                <ButtonIcon
+                  onClick={() => {
+                    setOpenDialog(true);
+                  }}>
+                  <PiTrash />
+                </ButtonIcon>
+              </>
+            )}
+            {editing && (
+              <>
+                <ButtonIcon className="text-base" onClick={() => {}}>
+                  <PiCheck />
+                </ButtonIcon>
+
+                <ButtonIcon
+                  className="text-base"
+                  onClick={() => {
+                    setEditing(false);
+                  }}>
+                  <PiX />
+                </ButtonIcon>
+              </>
+            )}
+          </div>
+        </div>
+      </Link>
+    </>
+  );
+};
+
+export default ChatListItem;

--- a/packages/web/src/components/DialogConfirmDeleteChat.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteChat.tsx
@@ -3,6 +3,7 @@ import { BaseProps } from '../@types/common';
 import Button from './Button';
 import ModalDialog from './ModalDialog';
 import { Chat } from 'generative-ai-use-cases-jp';
+import { decomposeChatId } from '../utils/ChatUtils';
 
 type Props = BaseProps & {
   isOpen: boolean;
@@ -26,7 +27,7 @@ const DialogConfirmDeleteChat: React.FC<Props> = (props) => {
         </Button>
         <Button
           onClick={() => {
-            props.onDelete(props.target?.chatId.split('#')[1] ?? '');
+            props.onDelete(decomposeChatId(props.target?.chatId ?? '') ?? '');
           }}
           className="bg-red-500 p-2 text-white">
           削除

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -36,11 +36,6 @@ const useChatState = create<{
     content: string,
     mutateListChat: KeyedMutator<ListChatsResponse>
   ) => void;
-  updateChatTitle: (
-    id: string,
-    title: string,
-    mutateListChat: KeyedMutator<ListChatsResponse>
-  ) => Promise<void>;
   sendFeedback: (
     id: string,
     createdDate: string,
@@ -51,7 +46,6 @@ const useChatState = create<{
     createChat,
     createMessages,
     updateFeedback,
-    updateTitle,
     predictStream,
     predictTitle,
   } = useChatApi();
@@ -261,27 +255,7 @@ const useChatState = create<{
 
       replaceMessages(id, messages);
     },
-    updateChatTitle: async (
-      id: string,
-      title: string,
-      mutateListChat: KeyedMutator<ListChatsResponse>
-    ) => {
-      const chat = get().chats[id].chat;
-      if (chat) {
-        const beforeTitle = chat.title;
 
-        console.log(title);
-        // 画面に即時反映して、エラーが発生したら画面表示をロールバックする
-        setTitle(id, title);
-        await updateTitle(chat.chatId, title)
-          .catch(() => {
-            setTitle(id, beforeTitle);
-          })
-          .finally(() => {
-            mutateListChat();
-          });
-      }
-    },
     sendFeedback: async (id: string, createdDate: string, feedback: string) => {
       const chat = get().chats[id].chat;
 
@@ -304,16 +278,8 @@ const useChatState = create<{
  * @returns
  */
 const useChat = (id: string, systemContext?: string, chatId?: string) => {
-  const {
-    chats,
-    loading,
-    init,
-    initFromMessages,
-    clear,
-    post,
-    sendFeedback,
-    updateChatTitle,
-  } = useChatState();
+  const { chats, loading, init, initFromMessages, clear, post, sendFeedback } =
+    useChatState();
   const { data: messagesData, isLoading: isLoadingMessage } =
     useChatApi().listMessages(chatId);
   const { data: chatData, isLoading: isLoadingChat } =
@@ -346,9 +312,6 @@ const useChat = (id: string, systemContext?: string, chatId?: string) => {
     clearChats: (systemContext: string) => clear(id, systemContext),
     messages: filteredMessages,
     isEmpty: filteredMessages.length === 0,
-    updateChatTitle: (title: string) => {
-      return updateChatTitle(id, title, mutateConversations);
-    },
     postChat: (content: string) => {
       post(id, content, mutateConversations);
     },

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -54,8 +54,7 @@ const useChatApi = () => {
         chatId ? `chats/${chatId}/messages` : null
       );
     },
-    updateTitle: async (_chatId: string, title: string) => {
-      const chatId = decomposeChatId(_chatId);
+    updateTitle: async (chatId: string, title: string) => {
       const req: UpdateTitleRequest = {
         title,
       };

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -11,6 +11,8 @@ import {
   FindChatByIdResponse,
   UpdateFeedbackRequest,
   UpdateFeedbackResponse,
+  UpdateTitleRequest,
+  UpdateTitleResponse,
 } from 'generative-ai-use-cases-jp';
 import {
   LambdaClient,
@@ -20,6 +22,7 @@ import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-id
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { Auth } from 'aws-amplify';
 import useHttp from '../hooks/useHttp';
+import { decomposeChatId } from '../utils/ChatUtils';
 
 const useChatApi = () => {
   const http = useHttp();
@@ -33,7 +36,7 @@ const useChatApi = () => {
       _chatId: string,
       req: CreateMessagesRequest
     ): Promise<CreateMessagesResponse> => {
-      const chatId = _chatId.split('#')[1];
+      const chatId = decomposeChatId(_chatId);
       const res = await http.post(`chats/${chatId}/messages`, req);
       return res.data;
     },
@@ -51,11 +54,22 @@ const useChatApi = () => {
         chatId ? `chats/${chatId}/messages` : null
       );
     },
+    updateTitle: async (_chatId: string, title: string) => {
+      const chatId = decomposeChatId(_chatId);
+      const req: UpdateTitleRequest = {
+        title,
+      };
+      const res = await http.put<UpdateTitleResponse>(
+        `chats/${chatId}/title`,
+        req
+      );
+      return res.data;
+    },
     updateFeedback: async (
       _chatId: string,
       req: UpdateFeedbackRequest
     ): Promise<UpdateFeedbackResponse> => {
-      const chatId = _chatId.split('#')[1];
+      const chatId = decomposeChatId(_chatId);
       const res = await http.post(`chats/${chatId}/feedbacks`, req);
       return res.data;
     },

--- a/packages/web/src/hooks/useConversation.ts
+++ b/packages/web/src/hooks/useConversation.ts
@@ -1,15 +1,47 @@
+import { produce } from 'immer';
 import useChatApi from './useChatApi';
 
 const useConversation = () => {
   const { listChats, deleteChat, updateTitle } = useChatApi();
   const { data, isLoading, mutate } = listChats();
   const deleteConversation = (chatId: string) => {
-    return deleteChat(chatId).then(() => {
+    mutate(
+      produce(data, (draft) => {
+        if (data && draft) {
+          const idx = data.chats.findIndex(
+            (c) => c.chatId === `chat#${chatId}`
+          );
+          if (idx > -1) {
+            draft.chats.splice(idx, 1);
+          }
+        }
+      }),
+      {
+        revalidate: false,
+      }
+    );
+
+    return deleteChat(chatId).finally(() => {
       mutate();
     });
   };
   const updateConversationTitle = (chatId: string, title: string) => {
-    return updateTitle(chatId, title).then(() => {
+    mutate(
+      produce(data, (draft) => {
+        if (data && draft) {
+          const idx = data.chats.findIndex(
+            (c) => c.chatId === `chat#${chatId}`
+          );
+          if (idx > -1) {
+            draft.chats[idx].title = title;
+          }
+        }
+      }),
+      {
+        revalidate: false,
+      }
+    );
+    return updateTitle(chatId, title).finally(() => {
       mutate();
     });
   };

--- a/packages/web/src/hooks/useConversation.ts
+++ b/packages/web/src/hooks/useConversation.ts
@@ -1,10 +1,15 @@
 import useChatApi from './useChatApi';
 
 const useConversation = () => {
-  const { listChats, deleteChat } = useChatApi();
+  const { listChats, deleteChat, updateTitle } = useChatApi();
   const { data, isLoading, mutate } = listChats();
   const deleteConversation = (chatId: string) => {
     return deleteChat(chatId).then(() => {
+      mutate();
+    });
+  };
+  const updateConversationTitle = (chatId: string, title: string) => {
+    return updateTitle(chatId, title).then(() => {
       mutate();
     });
   };
@@ -13,6 +18,7 @@ const useConversation = () => {
     loading: isLoading,
     conversations: data ? data.chats : [],
     mutate,
+    updateConversationTitle,
     deleteConversation,
   };
 };

--- a/packages/web/src/utils/ChatUtils.ts
+++ b/packages/web/src/utils/ChatUtils.ts
@@ -1,0 +1,11 @@
+/**
+ * chat#xxxx 形式の ChatId から xxxx の部分を取り出す
+ * @param _chatId chat#xxxx 形式の ChatId
+ * @returns chat#xxxx ではない場合は null を返す
+ */
+export const decomposeChatId = (_chatId: string): string | null => {
+  if (!_chatId.includes('#')) {
+    return null;
+  }
+  return _chatId.split('#')[1];
+};


### PR DESCRIPTION
*Issue #, if available:*
#70 #40 

*Description of changes:*

楽観的更新（APIのレスポンスを待たずに画面を更新。エラー時は画面表示をロールバック）の手法で実装しました。
削除も同様の実装にしたため、ローディング表示対応は不要になると思います。


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
