### PR TITLE
Fixed bug in disable self-signup feature

### DIFF
--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -8,9 +8,9 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     process.env.overrideWarningsEnabled = 'false';
 
-    const ragEnabled: boolean = this.node.tryGetContext('ragEnabled') || false;
+    const ragEnabled: boolean = this.node.tryGetContext('ragEnabled') ?? false;
     const selfSignUpEnabled: boolean =
-      this.node.tryGetContext('selfSignUpEnabled') || false;
+      this.node.tryGetContext('selfSignUpEnabled') ?? true;
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -10,7 +10,7 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     const ragEnabled: boolean = this.node.tryGetContext('ragEnabled') || false;
     const selfSignUpEnabled: boolean =
-      this.node.tryGetContext('selfSignUpEnabled') || true;
+      this.node.tryGetContext('selfSignUpEnabled') || false;
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -9,7 +9,8 @@ export class GenerativeAiUseCasesStack extends Stack {
     process.env.overrideWarningsEnabled = 'false';
 
     const ragEnabled: boolean = this.node.tryGetContext('ragEnabled')!;
-    const selfSignUpEnabled: boolean = this.node.tryGetContext('selfSignUpEnabled')!;
+    const selfSignUpEnabled: boolean =
+      this.node.tryGetContext('selfSignUpEnabled')!;
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -8,9 +8,8 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     process.env.overrideWarningsEnabled = 'false';
 
-    const ragEnabled: boolean = this.node.tryGetContext('ragEnabled') ?? false;
-    const selfSignUpEnabled: boolean =
-      this.node.tryGetContext('selfSignUpEnabled') ?? true;
+    const ragEnabled: boolean = this.node.tryGetContext('ragEnabled')!;
+    const selfSignUpEnabled: boolean = this.node.tryGetContext('selfSignUpEnabled')!;
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,


### PR DESCRIPTION
Changed
```
    const ragEnabled: boolean = this.node.tryGetContext('ragEnabled') || false;
    const selfSignUpEnabled: boolean =
      this.node.tryGetContext('selfSignUpEnabled') || true;
```
to 
```
    const ragEnabled: boolean = this.node.tryGetContext('ragEnabled')!;
    const selfSignUpEnabled: boolean =
      this.node.tryGetContext('selfSignUpEnabled')!;
```