### PR TITLE
[DNM] i18n updates first pass to add English support.

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,151 @@
+>**This repository is optimized for Japanese with English language translations provided by Amazon Translate. It still needs more work editing the English translations for minor improvements and broken links and images.**
+
+# Generative AI Use Cases
+
+Generative AI (Generative AI) brings revolutionary possibilities to business transformation. This repository demonstrates business use cases utilizing Generative AI.
+
+<FIX THESE IMAGES LATER>
+! [sc_lp.png] (/imgs/sc_lp.png)
+
+> **As generative AI evolves, disruptive changes are often made. If an error occurs, first check if there are any updates to the main branch. **
+
+## Features List
+
+> :white_check_mark:... Implemented, :construction:... Not implemented yet
+
+- :white_check_mark: Use Amazon Bedrock as LLM
+- :white_check_mark: data collection for Amazon Bedrock Fine-Tuning
+-: Construction: Labeling Data for Amazon Bedrock Fine-Tuning
+-: Construction: Execute Amazon Bedrock Fine-Tuning
+
+## Use Case List
+
+> Use cases will be added over time. If you have a request, please file a vote on [Issue] (https://github.com/aws-samples/generative-ai-use-cases-jp/issues).
+
+<details>
+ <summary>chat</summary>
+
+ You can interact with LLM in a chat format. Thanks to the existence of a platform that directly interacts with LLM, it is possible to respond quickly to detailed use cases and new use cases. It is also effective as a verification environment for prompt engineering.
+
+ <img src="/imgs/usecase_chat.gif"/></details>
+
+<details>
+ <summary>RAG chat</summary>
+
+ RAG is a method of conveying the latest information and domain knowledge from outside that LLM is not good at, so that it is possible to answer content that could not be answered originally. At the same time, since only evidence-based answers are allowed, it also has the effect of not having them answer “such incorrect information,” which is common in LLM. For example, if internal documents are passed to LLM, internal inquiry handling can be automated. This repository retrieves information from Amazon Kendra.
+
+ <img src="/imgs/usecase_rag.gif"/></details>
+
+<details>
+ <summary>Text generation</summary>
+
+ Generating sentences in every context is one of the tasks LLM excels at. It supports all kinds of contexts, such as articles, reports, emails, etc.
+
+ <img src="/imgs/usecase_generate_text.gif"/></details>
+
+<details>
+ <summary>summary</summary>
+
+ LLM excels at the task of summarizing large amounts of sentences. In addition to simply summarizing, it is also possible to pull out necessary information in an interactive format after giving sentences as context. For example, let me read the contract and ask “What are the conditions of XXX?” “How much is YYY?” It is possible to obtain such information.
+
+ <img src="/imgs/usecase_summarize.gif"/></details>
+
+<details>
+ <summary>proofreading</summary>
+
+ In addition to checking for typos and omissions, LLM can also suggest improvements from a more objective point of view that takes into account the flow and content of sentences. You can expect the effect of improving quality by having LLM objectively check points you weren't aware of before showing them to others.
+
+ <img src="/imgs/usecase_editorial.gif"/></details>
+
+<details>
+ <summary>translation</summary>
+
+ LLM learned in multiple languages can also be translated. Also, in addition to simply translating, it is possible to reflect various specified context information such as casuality and target groups in the translation.
+
+ <img src="/imgs/usecase_translate.gif"/></details>
+
+
+<details>
+ <summary>image generation</summary>
+
+ Image generation AI can generate new images based on text and images. Ideas can be immediately visualized, and efficiency in design work etc. can be expected to improve. With this feature, you can get LLM to help you create prompts.
+
+ <img src="/imgs/usecase_generate_image.gif"/></details>
+
+
+## Architecture
+
+In this sample, the front end is implemented using React, and the static files are delivered by Amazon CloudFront+ Amazon S3. We use Amazon API Gateway+ AWS Lambda for the backend and Amazon Congito for authentication. Also, LLM uses Amazon Bedrock. The RAG data source is Amazon Kendra.
+
+! [arch.png] (/imgs/arch.png)
+
+## Deploy
+
+**This repository is set to use the Northern Virginia (us-east-1) region's Anthropic Claude models by default. To make sure they're enabled, go to the [Model Access screen](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess) in Bedrock and click "Manage Model Access," check the desired Anthropic Claude models, and click “Save changes.” This will enable Anthropic models to be used in the Northern Virginia region. Please read [if you want to use a different model of Amazon Bedrock](/docs/Bedrock.md) for more information about how to change settings, such as when using Claude Instant. **
+
+Applications are deployed using the [AWS Cloud Development Kit](https://aws.amazon.com/en/cdk/)（hereafter "CDK"). You can check more detailed instructions in [this document](https://catalog.workshops.aws/generative-ai-use-cases-jp), which explains how to prepare a CDK environment, explain deployment procedures, and add security features. You can also check out the deployment instructions in [this video](https://www.youtube.com/watch?v=9sMA17OKP1k).
+
+The deployment procedure is described below.
+
+```bash
+npm ci
+```
+
+If you haven't used CDK, you only need to do [Bootstrap](https://docs.aws.amazon.com/ja_jp/cdk/v2/guide/bootstrapping.html) for the first time. The following command is unnecessary in an environment that is already Bootstrapped.
+
+```bash
+npx -w packages/cdk cdk bootstrap
+```
+
+Next, deploy the AWS resources with the following command. Please wait until the deployment is complete (this may take up to 20 minutes).
+
+```bash
+npm run cdk:deploy
+```
+
+- [Reference (if you want to use a different model or region)] (/docs/bedrock.md)
+
+### RAG enabled
+
+If you're trying out the RAG use case, you'll need to enable RAG and manually sync Kendra's data source.
+
+First, enable RAG and redeploy.
+Open `packages/cdk/cdk.json` and change `rageenabled` in `context` to `true`.
+Then redeploy with the following command.
+
+```bash
+npm run cdk:deploy
+```
+
+Next, follow the steps below to sync Kendra's Data Source.
+
+1. Open [Amazon Kendra console screen] (https://console.aws.amazon.com/kendra/home)
+1. Click generative-ai-use-cases-index
+1. Click on Data Sources
+1. Click WebCrawler
+1. Click Sync Now
+
+If Completed is displayed in the Status/ Summary of the sync run history, then you're done. Pages related to Amazon Bedrock on AWS are crawled, and documentation is automatically added.
+
+### Enabling image generation
+
+When using image generation use cases, it is necessary to enable Stability AI's Stable Diffusion XL model. [Model access screen] (https://us-east-1.console.aws.amazon.com/bedrock/home? Open region=us-east-1#/modelaccess) and operate “Edit” → “Check Stable Diffusion XL” → “Save changes” so that Amazon Bedrock (base model: Stable Diffusion XL) can be used in the Northern Virginia region. Note that image generation is displayed on the screen as a use case even when Stable Diffusion XL is not enabled, so be aware. If you run the model without being enabled, an error will occur.
+
+## Other documentation
+- Deployment options
+ - [If you want to use a different model region of Amazon Bedrock] (/docs/Bedrock.md)
+ - [If you want to use Amazon SageMaker] (/docs/SageMaker.md)
+ - [security-related] (/docs/security.md)
+- development
+ - [Procedure for building a local development environment] (/docs/development.md)
+ - [How to add use cases (blog: Develop an Interpreter with Amazon Bedrock!)] (https://aws.amazon.com/jp/builders-flash/202311/bedrock-interpreter/#04)
+ - [How to delete resources] (/docs/destroy.md)
+
+## Security
+
+See [CONTRIBUTING.MD #security -issue-notifications) for more information.
+
+## License
+
+This library is licensed under the MIT-0 license. See the LICENSE file.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13923,9 +13923,9 @@
       }
     },
     "node_modules/@tailwindcss/forms": {
-      "version": "0.5.6",
-      "dev": true,
-      "license": "MIT",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
+      "integrity": "sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==",
       "dependencies": {
         "mini-svg-data-uri": "^1.2.3"
       },
@@ -20677,7 +20677,6 @@
     },
     "node_modules/mini-svg-data-uri": {
       "version": "1.4.4",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mini-svg-data-uri": "cli.js"
@@ -24682,6 +24681,7 @@
         "@aws-sdk/credential-provider-cognito-identity": "^3.398.0",
         "@headlessui/react": "^1.7.15",
         "@react-icons/all-files": "^4.1.0",
+        "@tailwindcss/forms": "^0.5.7",
         "@types/uuid": "^9.0.2",
         "aws-amplify": "^5.3.5",
         "axios": "^1.6.0",

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -17,7 +17,7 @@
     ]
   },
   "context": {
-    "ragEnabled": false,
+    "ragEnabled": true,
     "selfSignUpEnabled": true,
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
@@ -17,6 +17,7 @@
     "@aws-sdk/credential-provider-cognito-identity": "^3.398.0",
     "@headlessui/react": "^1.7.15",
     "@react-icons/all-files": "^4.1.0",
+    "@tailwindcss/forms": "^0.5.7",
     "@types/uuid": "^9.0.2",
     "aws-amplify": "^5.3.5",
     "axios": "^1.6.0",

--- a/packages/web/src/@types/i18n.d.ts
+++ b/packages/web/src/@types/i18n.d.ts
@@ -1,0 +1,4 @@
+export type i18nStrings = {
+    [key: string]: {[key: string]: string; }
+};
+

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -20,11 +20,14 @@ import { Outlet } from 'react-router-dom';
 import Drawer, { ItemProps } from './components/Drawer';
 import { Authenticator, translations } from '@aws-amplify/ui-react';
 import { Amplify, I18n } from 'aws-amplify';
+import { langStrings } from "./utils/i18n";
 import '@aws-amplify/ui-react/styles.css';
 import MenuDropdown from './components/MenuDropdown';
 import MenuItem from './components/MenuItem';
 import useDrawer from './hooks/useDrawer';
 import useConversation from './hooks/useConversation';
+
+I18n.putVocabularies(langStrings);
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const selfSignUpEnabled: boolean =
@@ -32,70 +35,70 @@ const selfSignUpEnabled: boolean =
 
 const items: ItemProps[] = [
   {
-    label: 'ホーム',
+    label: I18n.get('home'),
     to: '/',
     icon: <PiHouse />,
     display: 'usecase' as const,
   },
   {
-    label: '設定情報',
+    label: I18n.get('settings'),
     to: '/setting',
     icon: <PiGear />,
     display: 'none' as const,
   },
   {
-    label: 'チャット',
+    label: I18n.get("chat"),
     to: '/chat',
     icon: <PiChatsCircle />,
     display: 'usecase' as const,
   },
   ragEnabled
     ? {
-        label: 'RAG チャット',
+        label: I18n.get('rag_chat'),
         to: '/rag',
         icon: <PiChatCircleText />,
         display: 'usecase' as const,
       }
     : null,
   {
-    label: '文章生成',
+    label: I18n.get("text_gen"),
     to: '/generate',
     icon: <PiPencil />,
     display: 'usecase' as const,
   },
   {
-    label: '要約',
+    label: I18n.get("summarize"),
     to: '/summarize',
     icon: <PiNote />,
     display: 'usecase' as const,
   },
   {
-    label: '校正',
+    label: I18n.get('editor'),
     to: '/editorial',
     icon: <PiPenNib />,
     display: 'usecase' as const,
   },
   {
-    label: '翻訳',
+    label: I18n.get("translation"),
     to: '/translate',
     icon: <PiTranslate />,
     display: 'usecase' as const,
   },
   {
-    label: '画像生成',
+    label: I18n.get("image_gen"),
     to: '/image',
     icon: <PiImages />,
     display: 'usecase' as const,
   },
   {
-    label: '音声認識',
+    label: I18n.get('audio_transcription'),
     to: '/transcribe',
     icon: <PiSpeakerHighBold />,
     display: 'tool' as const,
   },
   ragEnabled
     ? {
-        label: 'Kendra 検索',
+        label: I18n.get("kendra_search"),
         to: '/kendra',
         icon: <PiMagnifyingGlass />,
         display: 'tool' as const,
@@ -105,6 +108,9 @@ const items: ItemProps[] = [
 
 // /chat/:chatId の形式から :chatId を返す
 // path が別の形式の場合は null を返す
+///chat/: returns :chatId from the format /chat/ :chatId
+//if path is in another format, it returns null
+
 const extractChatId = (path: string): string | null => {
   const pattern = /\/chat\/(.+)/;
   const match = path.match(pattern);
@@ -121,9 +127,10 @@ const App: React.FC = () => {
       authenticationFlowType: 'USER_SRP_AUTH',
     },
   });
-
-  I18n.putVocabularies(translations);
-  I18n.setLanguage('ja');
+  // Amplify should figure out the language for us.
+  //I18n.setLanguage('en');
+  // I18n.putVocabularies(translations);
+  // I18n.setLanguage('ja');
 
   const { switchOpen: switchDrawer } = useDrawer();
   const navigate = useNavigate();
@@ -146,7 +153,7 @@ const App: React.FC = () => {
       components={{
         Header: () => (
           <div className="text-aws-font-color mb-5 mt-10 flex justify-center text-3xl">
-            Generative AI on AWS
+            {I18n.get("gen_ai_on_aws")}
           </div>
         ),
       }}>
@@ -176,14 +183,14 @@ const App: React.FC = () => {
                       onClick={() => {
                         navigate('/setting');
                       }}>
-                      設定情報
+                      {I18n.get('settings')}
                     </MenuItem>
                     <MenuItem
                       icon={<PiSignOut />}
                       onClick={() => {
                         signOut ? signOut() : null;
                       }}>
-                      サインアウト
+                        {I18n.get("sign_out")}
                     </MenuItem>
                   </>
                 </MenuDropdown>

--- a/packages/web/src/components/Alert.tsx
+++ b/packages/web/src/components/Alert.tsx
@@ -3,6 +3,7 @@ import { BaseProps } from '../@types/common';
 import { PiInfo, PiXCircle } from 'react-icons/pi';
 
 // MEMO: 現在は Error しか実装していない
+// MEMO: Currently only Error is implemented
 type Props = BaseProps & {
   title?: string;
   severity: 'info' | 'error';

--- a/packages/web/src/components/DialogConfirmDeleteChat.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteChat.tsx
@@ -4,6 +4,7 @@ import Button from './Button';
 import ModalDialog from './ModalDialog';
 import { Chat } from 'generative-ai-use-cases-jp';
 import { decomposeChatId } from '../utils/ChatUtils';
+import { I18n } from 'aws-amplify';
 
 type Props = BaseProps & {
   isOpen: boolean;
@@ -14,23 +15,23 @@ type Props = BaseProps & {
 
 const DialogConfirmDeleteChat: React.FC<Props> = (props) => {
   return (
-    <ModalDialog {...props} title="削除確認">
+    <ModalDialog {...props} title={I18n.get('cut_confirmation')}> {/*"削除確認">*/}
       <div>
-        チャット
+        {I18n.get("chats")}
         <span className="font-bold">「{props.target?.title}」</span>
-        を削除しますか？
+        {I18n.get("delete_confirmation")}
       </div>
 
       <div className="mt-4 flex justify-end gap-2">
         <Button outlined onClick={props.onClose} className="p-2">
-          Cancel
+          {I18n.get("cancel")}
         </Button>
         <Button
           onClick={() => {
             props.onDelete(decomposeChatId(props.target?.chatId ?? '') ?? '');
           }}
           className="bg-red-500 p-2 text-white">
-          削除
+          {I18n.get("delete")}
         </Button>
       </div>
     </ModalDialog>

--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -6,6 +6,7 @@ import ButtonIcon from './ButtonIcon';
 import { PiSignOut, PiX, PiGithubLogo, PiGear } from 'react-icons/pi';
 import { ReactComponent as BedrockIcon } from '../assets/bedrock.svg';
 import ChatList from './ChatList';
+import { I18n } from 'aws-amplify';
 
 export type ItemProps = BaseProps & {
   label: string;
@@ -19,6 +20,7 @@ const Item: React.FC<ItemProps> = (props) => {
   const { switchOpen } = useDrawer();
 
   // 狭い画面の場合は、クリックしたらDrawerを閉じる
+  // If the screen is narrow, click to close Drawer
   const onClick = useCallback(() => {
     if (
       document
@@ -52,6 +54,7 @@ const RefLink: React.FC<RefLinkProps> = (props) => {
   const { switchOpen } = useDrawer();
 
   // 狭い画面の場合は、クリックしたらDrawerを閉じる
+  // If the screen is narrow, click to close the Drawer
   const onClick = useCallback(() => {
     if (
       document
@@ -101,7 +104,7 @@ const Drawer: React.FC<Props> = (props) => {
           opened ? 'visible w-64' : 'invisible w-0'
         } transition-width bg-aws-squid-ink fixed z-50 flex h-screen flex-col justify-between text-sm text-white print:hidden lg:static lg:z-0`}>
         <div className="text-aws-smile mx-3 my-2 text-xs">
-          ユースケース <span className="text-gray-400">(生成系AI)</span>
+          {I18n.get('use_case')} <span className="text-gray-400">{I18n.get("gen_ai")}</span>
         </div>
         <div className="scrollbar-thin scrollbar-thumb-white ml-2 mr-1 h-full overflow-y-auto">
           {usecases.map((item, idx) => (
@@ -118,7 +121,7 @@ const Drawer: React.FC<Props> = (props) => {
         {tools.length > 0 && (
           <>
             <div className="text-aws-smile mx-3 my-2 text-xs">
-              ツール <span className="text-gray-400">(AIサービス)</span>
+              {I18n.get("tool")} <span className="text-gray-400">({I18n.get("AI Service")})</span>
             </div>
             <div className="mb-1 ml-2 mr-1">
               {tools.map((item, idx) => (
@@ -134,7 +137,7 @@ const Drawer: React.FC<Props> = (props) => {
             <div className="border-b" />
           </>
         )}
-        <div className="text-aws-smile mx-3 my-2  text-xs">会話履歴</div>
+        <div className="text-aws-smile mx-3 my-2  text-xs">{I18n.get("meeting_resume")}</div>
         <div className="scrollbar-thin scrollbar-thumb-white ml-2 mr-1 h-full overflow-y-auto">
           <ChatList className="mr-1" />
         </div>
@@ -159,11 +162,11 @@ const Drawer: React.FC<Props> = (props) => {
               navigate('/setting');
             }}>
             <PiGear className="mr-1 text-base" />
-            <span className="ml-1 text-sm">設定情報</span>
+            <span className="ml-1 text-sm">{I18n.get("Settings")}</span>
           </ButtonIcon>
           <ButtonIcon onClick={props.signOut}>
             <PiSignOut className="mr-1 text-base" />
-            <span className="ml-1 text-sm">サインアウト</span>
+            <span className="ml-1 text-sm">{I18n.get("sign_out")}</span>
           </ButtonIcon>
         </div>
       </nav>

--- a/packages/web/src/components/GenerateImageAssistant.tsx
+++ b/packages/web/src/components/GenerateImageAssistant.tsx
@@ -6,6 +6,8 @@ import useChat from '../hooks/useChat';
 import { PiLightbulbFilamentBold, PiWarningFill } from 'react-icons/pi';
 import { BaseProps } from '../@types/common';
 import Button from './Button';
+import { I18n } from "aws-amplify";
+
 
 type Props = BaseProps & {
   content: string;
@@ -83,6 +85,7 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
 
   useEffect(() => {
     // メッセージ追加時の画像の自動生成
+    // Automatically generate an image when adding a message
     const _length = contents.length;
     if (contents.length === 0) {
       return;
@@ -119,8 +122,8 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
   return (
     <div className="relative h-full w-full">
       <Card
-        label="チャット形式で画像生成"
-        help="チャット形式でプロンプトの生成と設定、画像生成を自動で行います。"
+        label={I18n.get("image_gen_chat")}
+        help={I18n.get("prompts_gen")}
         className={`${props.className ?? ''} h-full pb-32`}>
         <div className="h-full overflow-y-auto overflow-x-hidden">
           {contents.length === 0 && (
@@ -130,24 +133,22 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
                 ヒント
               </div>
               <div className="m-1 rounded border p-2 text-sm">
-                具体的かつ詳細な指示を出すようにしましょう。
-                形容詞や副詞を使って、正確に表現することが重要です。
+                {I18n.get("be_specific")}
               </div>
               <div className="m-1 rounded border p-2 text-sm">
-                「犬が遊んでいる」ではなく、「柴犬が草原で楽しそうに走り回っている」のように具体的に指示をしましょう。
+                {I18n.get("dogs_playing_example")}
               </div>
               <div className="m-1 rounded border p-2 text-sm">
-                文章で書くことが難しい場合は、文章で書く必要はありません。「元気、ボール遊び、ジャンプしている」のように、特徴を羅列して指示をしましょう。
+                {I18n.get("no_sentences_needed_example")}
               </div>
               <div className="m-1 rounded border p-2 text-sm">
-                除外して欲しい要素も指示することができます。「人間は出力しない」など。
+                {I18n.get("exclusion_example")}
               </div>
               <div className="m-1 rounded border p-2 text-sm">
-                LLM
-                が会話の流れを考慮してくれるので、「やっぱり犬じゃなくて猫にして」などの会話形式の指示もできます。
+                {I18n.get("conversational_style_example")}
               </div>
               <div className="m-1 rounded border p-2 text-sm">
-                プロンプトで意図した画像が生成できない場合は、初期画像の設定やパラメータの変更を試してみましょう。
+                {I18n.get("image_gen_prompt_advice")}
               </div>
             </div>
           )}
@@ -169,14 +170,14 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
                 <div>
                   <div className="flex items-center gap-2 font-bold text-red-500">
                     <PiWarningFill />
-                    エラー
+                    {I18n.get("errors")}
                   </div>
                   <div className="text-gray-600">
-                    プロンプト生成中にエラーが発生しました。
+                    {I18n.get("prompts_gen_error")}
                   </div>
                   <div className="mt-3 flex w-full justify-center">
                     <Button outlined onClick={onRetrySend}>
-                      再実行
+                      {I18n.get("rerun")}
                     </Button>
                   </div>
                 </div>
@@ -186,7 +187,7 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
                 !c.content.error && (
                   <div className="flex items-center gap-2 text-gray-600">
                     <div className="border-aws-sky h-5 w-5 animate-spin rounded-full border-4 border-t-transparent"></div>
-                    プロンプト生成中
+                    {I18n.get("generating_prompts")}
                   </div>
                 )}
               {c.role === 'assistant' && c.content.prompt !== null && (
@@ -197,11 +198,11 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
                     <>
                       <div className="flex items-center gap-2 text-gray-600">
                         <div className="h-5 w-5 rounded-full border-4 border-gray-600"></div>
-                        プロンプト生成完了
+                        {I18n.get("prompt_gen_complete")}
                       </div>
                       <div className="flex items-center gap-2 text-gray-600">
                         <div className="border-aws-sky h-5 w-5 animate-spin rounded-full border-4 border-t-transparent"></div>
-                        画像生成中
+                        {I18n.get("generating_images")}
                       </div>
                     </>
                   ) : (
@@ -236,7 +237,7 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
                                 ''
                               );
                             }}>
-                            未設定
+                            {I18n.get("not_set")}
                           </Button>
                         </div>
                       </div>

--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -5,7 +5,7 @@ import useChat from '../hooks/useChat';
 import { useLocation } from 'react-router-dom';
 import Button from './Button';
 import { PiArrowsCounterClockwise } from 'react-icons/pi';
-
+import {I18n} from "aws-amplify";
 type Props = {
   content: string;
   disabled?: boolean;
@@ -86,7 +86,7 @@ const InputChatContent: React.FC<Props> = (props) => {
             disabled={loading}
             onClick={props.onReset}>
             <PiArrowsCounterClockwise className="mr-2" />
-            最初からやり直す
+            {I18n.get("start_over")}
           </Button>
         )}
       </div>

--- a/packages/web/src/components/SketchPad.tsx
+++ b/packages/web/src/components/SketchPad.tsx
@@ -19,6 +19,7 @@ import SignatureCanvas from 'react-signature-canvas';
 import Button from './Button';
 import { BaseProps } from '../@types/common';
 import ModalDialog from './ModalDialog';
+import { I18n } from 'aws-amplify';
 
 type SketchButtonProps = BaseProps & {
   isActive?: boolean;
@@ -142,6 +143,7 @@ const SketchPad: React.FC<Props> = (props) => {
 
         img.onload = () => {
           // 画像をリサイズ
+          // resize image
           const canvas = document.createElement('canvas');
           const ctx = canvas.getContext('2d');
           canvas.width = IMAGE_SIZE;
@@ -165,7 +167,7 @@ const SketchPad: React.FC<Props> = (props) => {
 
   return (
     <>
-      <ModalDialog isOpen={isOpenUpload} title="画像をアップロード">
+      <ModalDialog isOpen={isOpenUpload} title={I18n.get("upload_image")}>
         <div>
           <div className="mb-3 flex w-full">
             <input type="file" onChange={handleImageUpload} accept="image/*" />
@@ -180,9 +182,9 @@ const SketchPad: React.FC<Props> = (props) => {
               onClick={() => {
                 setIsOpenUpload(false);
               }}>
-              キャンセル
+                {I18n.get("cancelled")}
             </Button>
-            <Button onClick={onClickUploadComplet}>完了</Button>
+            <Button onClick={onClickUploadComplet}>{I18n.get("completions")}</Button>
           </div>
         </div>
       </ModalDialog>
@@ -240,7 +242,7 @@ const SketchPad: React.FC<Props> = (props) => {
 
           <Button outlined onClick={onClickClear}>
             <PiTrash className="mr-2" />
-            Clear
+            {I18n.get("clear")}
           </Button>
         </div>
 
@@ -265,13 +267,13 @@ const SketchPad: React.FC<Props> = (props) => {
               setIsOpenUpload(true);
             }}>
             <PiUploadSimple />
-            画像をアップロード
+            {I18n.get("upload_image")}
           </Button>
           <div className="flex gap-3">
             <Button outlined onClick={props.onCancel}>
-              キャンセル
+              {I18n.get("cancelled")}
             </Button>
-            <Button onClick={onClickComplete}>完了</Button>
+            <Button onClick={onClickComplete}>{I18n.get("completions")}</Button>
           </div>
         </div>
       </div>

--- a/packages/web/src/components/TextEditor.tsx
+++ b/packages/web/src/components/TextEditor.tsx
@@ -7,6 +7,7 @@ import ButtonIcon from './ButtonIcon';
 import { ErrorBoundary } from './ErrorBoundary';
 import { PiTrash } from 'react-icons/pi';
 import HighlightWithinTextarea from 'react-highlight-within-textarea';
+import { I18n } from "aws-amplify";
 import 'draft-js/dist/Draft.css';
 
 type Props = RowItemProps & {
@@ -33,6 +34,7 @@ const Texteditor: React.FC<Props> = (props) => {
         <ErrorBoundary>
           {/* 
           draft.js の不具合でクラッシュすることがあるためエラーが発生した際に再レンダリングを行う。
+          Since a crash may occur due to a bug in draft.js, re-rendering is performed when an error occurs.
           https://github.com/facebookarchive/draft-js/issues/1320#issuecomment-472776784
            */}
           <HighlightWithinTextarea
@@ -71,7 +73,7 @@ const Texteditor: React.FC<Props> = (props) => {
               )
           )}
         {!props.loading && props.comments && props.comments.length === 0 && (
-          <div className="mb-2 ml-2 w-80">指摘事項はありません</div>
+          <div className="mb-2 ml-2 w-80">{I18n.get("no_indications")}</div>
         )}
         {props.loading && (
           <div className="mb-2 ml-2 flex w-80 justify-center">

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -136,6 +136,7 @@ const useChatState = create<{
           if (!m.messageId) {
             m.messageId = uuid();
             // 参照が切れるとエラーになるため clone する
+            // clone because an error will occur if the reference is broken
             toBeRecordedMessages.push(
               Object.assign({}, m as ToBeRecordedMessage)
             );
@@ -260,6 +261,7 @@ const useChatState = create<{
       };
 
       // User/Assistant の発言を反映
+      // reflect what User/Assistant said
       set((state) => {
         const newChats = produce(state.chats, (draft) => {
           draft[id].messages.push(unrecordedUserMessage);
@@ -275,6 +277,8 @@ const useChatState = create<{
       const stream = predictStream({
         // 最後のメッセージはアシスタントのメッセージなので、排除
         // ignoreHistory が設定されている場合は最後の会話だけ反映（コスト削減）
+        // the last message is an assistant message, so remove it
+        // If ignoreHistory is set, only the last conversation is reflected (cost reduction)
         messages: omitUnusedMessageProperties(
           ignoreHistory
             ? [chatMessages[0], ...chatMessages.slice(-2, -1)]
@@ -283,6 +287,7 @@ const useChatState = create<{
       });
 
       // Assistant の発言を更新
+      //Update Assistant's statement
       for await (const chunk of stream) {
         set((state) => {
           const newChats = produce(state.chats, (draft) => {
@@ -309,6 +314,7 @@ const useChatState = create<{
       const chatId = await createChatIfNotExist(id, get().chats[id].chat);
 
       // タイトルが空文字列だった場合、タイトルを予測して設定
+      // If the title is an empty string, the title is predicted and set
       if (get().chats[id].chat?.title === '') {
         setPredictedTitle(id).then(() => {
           mutateListChat();
@@ -344,6 +350,13 @@ const useChatState = create<{
  * @param chatId
  * @returns
  */
+/**
+ * Hooks for manipulating chat
+ * @param ID screen URI (used to identify state)
+ * @param SystemContext
+ * @param ChatID
+ * @returns
+ */
 const useChat = (id: string, chatId?: string) => {
   const {
     chats,
@@ -366,6 +379,7 @@ const useChat = (id: string, chatId?: string) => {
 
   useEffect(() => {
     // 新規チャットの場合
+    // If it's a new chat
     if (!chatId) {
       init(id);
     }
@@ -373,6 +387,7 @@ const useChat = (id: string, chatId?: string) => {
 
   useEffect(() => {
     // 登録済みのチャットの場合
+    // If it's a registered chat
     if (!isLoadingMessage && messagesData && !isLoadingChat && chatData) {
       restore(id, messagesData.messages, chatData.chat);
     }

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -74,6 +74,7 @@ const useChatApi = () => {
       return res.data;
     },
     // Buffered Response (useTextToJson で利用)
+    // Buffered Response (used with useTextToJson)
     predict: async (req: PredictRequest): Promise<string> => {
       const res = await http.post<PredictResponse>('predict', req);
       return res.data;

--- a/packages/web/src/hooks/useHttp.ts
+++ b/packages/web/src/hooks/useHttp.ts
@@ -30,6 +30,7 @@ const fetcher = (url: string) => {
 // };
 
 // FIXME:バックエンドができた時点で最適化する
+// FIXME: optimize once the backend is ready
 
 /**
  * Hooks for Http Request

--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -2,6 +2,7 @@ import useChat from './useChat';
 import useChatApi from './useChatApi';
 import useRagApi from './useRagApi';
 import { ragPrompt } from '../prompts';
+import { I18n } from "aws-amplify";
 
 const useRag = (id: string) => {
   const {
@@ -26,9 +27,10 @@ const useRag = (id: string) => {
     messages,
     postMessage: async (content: string) => {
       // Kendra から Retrieve する際に、ローディング表示する
+      // Show loading when retrieving from Kendra
       setLoading(true);
       pushMessage('user', content);
-      pushMessage('assistant', '[Kendra から参照ドキュメントを取得中...]');
+      pushMessage('assistant', `[${I18n.get("kendra_fetch")}...]`);
 
       const query = await predict({
         messages: [
@@ -43,6 +45,7 @@ const useRag = (id: string) => {
       });
 
       // Kendra から 参考ドキュメントを Retrieve してシステムコンテキストとして設定する
+      // Retrieve reference documentation from Kendra and set it as system context
       const items = await retrieve(query);
       updateSystemContext(
         ragPrompt({
@@ -52,6 +55,7 @@ const useRag = (id: string) => {
       );
 
       // ローディング表示を消してから通常のチャットの POST 処理を実行する
+      //Turn off the loading display and then execute the normal chat POST process
       popMessage();
       popMessage();
       postChat(content);

--- a/packages/web/src/hooks/useTranscribe.ts
+++ b/packages/web/src/hooks/useTranscribe.ts
@@ -43,16 +43,19 @@ const useTranscribeState = create<{
     const mediaFormat = get().file?.name.split('.').pop() as MediaFormat;
 
     // 署名付き URL の取得
+    // get signed URL
     const signedUrlRes = await api.getSignedUrl({
       mediaFormat: mediaFormat,
     });
     const signedUrl = signedUrlRes.data;
-    const audioUrl = signedUrl.split(/[?#]/)[0]; // 署名付き url からクエリパラメータを除外
+    const audioUrl = signedUrl.split(/[?#]/)[0]; // 署名付き url からクエリパラメータを除外 Exclude query parameters from signed urls
 
     // 音声のアップロード
+    // Audio upload
     await api.uploadAudio(signedUrl, { file: get().file! });
 
     // 音声認識
+    // speech recognition
     const startTranscripitonRes = await api.startTranscripiton({
       audioUrl: audioUrl,
     });

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -7,6 +7,8 @@ import ChatMessage from '../components/ChatMessage';
 import useScroll from '../hooks/useScroll';
 import { create } from 'zustand';
 import { ReactComponent as BedrockIcon } from '../assets/bedrock.svg';
+import { I18n } from "aws-amplify";
+
 
 type StateType = {
   content: string;
@@ -36,9 +38,9 @@ const ChatPage: React.FC = () => {
 
   const title = useMemo(() => {
     if (chatId) {
-      return getConversationTitle(chatId) || 'チャット';
+      return getConversationTitle(chatId) || I18n.get("chats");
     } else {
-      return 'チャット';
+      return I18n.get("chats");
     }
   }, [chatId, getConversationTitle]);
 

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -16,6 +16,7 @@ import { useLocation } from 'react-router-dom';
 import useChat from '../hooks/useChat';
 import Base64Image from '../components/Base64Image';
 import { AxiosError } from 'axios';
+import { I18n } from 'aws-amplify';
 
 const MAX_SAMPLE = 7;
 
@@ -159,6 +160,7 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
 
 // StableDiffusion の StylePreset
 // 一覧は、以下の style_preset を参照
+// See style_preset below for a list
 // https://platform.stability.ai/docs/api-reference#tag/v1generation/operation/textToImage
 const stylePresetOptions = [
   '3d-model',
@@ -221,6 +223,7 @@ const GenerateImagePage: React.FC = () => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
   // LandingPage のデモデータ設定
+  // LandingPage demo data setup
   useEffect(() => {
     if (state !== null) {
       setChatContent(state.content);
@@ -323,9 +326,9 @@ const GenerateImagePage: React.FC = () => {
     <>
       <ModalDialog
         isOpen={isOpenSketch}
-        title="初期画像の設定"
+        title={I18n.get("initial_image_settings")}
         className="w-[530px]"
-        help="画像生成の初期状態として使われます。指定した画像に近い画像が生成されます。"
+        help={I18n.get("initial_image_settings_help")}
         onClose={() => {
           setIsOpenSketch(false);
         }}>
@@ -361,8 +364,8 @@ const GenerateImagePage: React.FC = () => {
             <Card className="mt-8 flex">
               <div className="w-full">
                 <Textarea
-                  label="プロンプト"
-                  help="生成したい画像の説明を記載してください。文章ではなく、単語の羅列で記載します。"
+                  label={I18n.get("prompts")}
+                  help={I18n.get("image_gen_prompt")}
                   value={prompt}
                   onChange={setPrompt}
                   maxHeight={84}
@@ -370,8 +373,8 @@ const GenerateImagePage: React.FC = () => {
                 />
 
                 <Textarea
-                  label="ネガティブプロンプト"
-                  help="生成したくない要素、排除したい要素を記載してください。文章ではなく、単語の羅列で記載します。"
+                  label={I18n.get("negative_prompt")}
+                  help={I18n.get("negative_prompt_help")}
                   value={negativePrompt}
                   onChange={setNegativePrompt}
                   maxHeight={84}
@@ -419,11 +422,11 @@ const GenerateImagePage: React.FC = () => {
                 <div className="mb-8 flex flex-col xl:flex-row">
                   <div className="flex w-full flex-col items-center justify-center xl:w-1/2">
                     <div className="mb-1 flex items-center text-sm font-bold">
-                      初期画像
+                        {I18n.get("initial_image")}
                       <Help
                         className="ml-1"
                         direction="left"
-                        message="画像生成の初期状態となる画像を設定できます。初期画像を設定することで、初期画像に近い画像を生成するように誘導できます。"
+                        message={I18n.get("initial_image_help")}
                       />
                     </div>
                     <Base64Image
@@ -436,7 +439,7 @@ const GenerateImagePage: React.FC = () => {
                         setIsOpenSketch(true);
                       }}>
                       <PiFileArrowUp className="mr-2" />
-                      設定
+                      {I18n.get("settings")}
                     </Button>
                   </div>
 
@@ -457,12 +460,12 @@ const GenerateImagePage: React.FC = () => {
                       onChange={(n) => {
                         setSeed(n, selectedImageIndex);
                       }}
-                      help="乱数のシード値です。同じシード値を指定すると同じ画像が生成されます。"
+                      help={I18n.get("seed_help")}
                     />
 
                     <div className="-mt-3 mb-3 flex w-full justify-end text-xs">
                       <Button onClick={onClickRandomSeed}>
-                        Seed をランダム設定
+                        {I18n.get("seed_button_text")}
                       </Button>
                     </div>
                   </div>
@@ -471,45 +474,45 @@ const GenerateImagePage: React.FC = () => {
                 <div className="flex flex-col xl:flex-row xl:gap-x-4">
                   <RangeSlider
                     className="w-full xl:w-1/2"
-                    label="画像生成数"
+                    label={I18n.get("image_gen_num_images")}
                     min={1}
                     max={7}
                     value={imageSample}
                     onChange={setImageSample}
-                    help="Seed をランダム設定しながら画像を指定の数だけ同時に生成します。"
+                    help={I18n.get("image_gen_num_images_help")}
                   />
 
                   <RangeSlider
                     className="w-full xl:w-1/2"
-                    label="CFG Scale"
+                    label={I18n.get("cfg_scale")}
                     min={0}
                     max={30}
                     value={cfgScale}
                     onChange={setCfgScale}
-                    help="この値が高いほどプロンプトに対して忠実な画像を生成します。"
+                    help={I18n.get("cfg_scale_help")}
                   />
                 </div>
 
                 <div className="flex flex-col xl:flex-row xl:gap-x-4">
                   <RangeSlider
                     className="w-full xl:w-1/2"
-                    label="Step"
+                    label={I18n.get("step")}
                     min={10}
                     max={150}
                     value={step}
                     onChange={setStep}
-                    help="画像生成の反復回数です。Step 数が多いほど画像が洗練されますが、生成に時間がかかります。"
+                    help={I18n.get("image_gen_iterations_help")}
                   />
 
                   <RangeSlider
                     className="w-full xl:w-1/2"
-                    label="ImageStrength"
+                    label={I18n.get("image_gen_strength")}
                     min={0}
                     max={1}
                     step={0.01}
                     value={imageStrength}
                     onChange={setImageStrength}
-                    help="1に近いほど「初期画像」に近い画像が生成され、0に近いほど「初期画像」とは異なる画像が生成されます。"
+                    help={I18n.get("image_gen_strength_help")}
                   />
                 </div>
               </div>

--- a/packages/web/src/pages/GenerateTextPage.tsx
+++ b/packages/web/src/pages/GenerateTextPage.tsx
@@ -8,6 +8,8 @@ import ButtonCopy from '../components/ButtonCopy';
 import useChat from '../hooks/useChat';
 import { create } from 'zustand';
 import { generateTextPrompt } from '../prompts';
+import { I18n } from "aws-amplify";
+
 
 type StateType = {
   information: string;
@@ -84,6 +86,7 @@ const GenerateTextPage: React.FC = () => {
   };
 
   // リアルタイムにレスポンスを表示
+  // display responses in real time
   useEffect(() => {
     if (messages.length === 0) return;
     const _lastMessage = messages[messages.length - 1];
@@ -94,6 +97,7 @@ const GenerateTextPage: React.FC = () => {
   }, [messages]);
 
   // 要約を実行
+  // execute summary
   const onClickExec = useCallback(() => {
     if (loading) return;
     getGeneratedText(information, context);
@@ -101,6 +105,7 @@ const GenerateTextPage: React.FC = () => {
   }, [information, context, loading]);
 
   // リセット
+  // resetting
   const onClickClear = useCallback(() => {
     clear();
     clearChat();
@@ -110,30 +115,30 @@ const GenerateTextPage: React.FC = () => {
   return (
     <div className="grid grid-cols-12">
       <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-        文章生成
+        {I18n.get("text_gen")}
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">
-        <Card label="文章の元になる情報">
+        <Card label={I18n.get("text_gen_source")}>
           <Textarea
-            placeholder="入力してください"
+            placeholder={I18n.get("please_enter")}
             value={information}
             onChange={setInformation}
             maxHeight={-1}
           />
 
           <Textarea
-            placeholder="文章の形式を指示してください。(マークダウン、ブログ、ビジネスメールなど)"
+            placeholder={I18n.get("text_gen_format")}
             value={context}
             onChange={setContext}
           />
 
           <div className="flex justify-end gap-3">
             <Button outlined onClick={onClickClear} disabled={disabledExec}>
-              クリア
+              {I18n.get("clear")}
             </Button>
 
             <Button disabled={disabledExec} onClick={onClickExec}>
-              実行
+              {I18n.get("executions")}
             </Button>
           </div>
 
@@ -141,7 +146,7 @@ const GenerateTextPage: React.FC = () => {
             <Markdown>{text}</Markdown>
             {!loading && text === '' && (
               <div className="text-gray-500">
-                生成された文章がここに表示されます
+                {I18n.get("text_gen_display_label")}
               </div>
             )}
             {loading && (

--- a/packages/web/src/pages/KendraSearchPage.tsx
+++ b/packages/web/src/pages/KendraSearchPage.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 import useRag from '../hooks/useSearch';
 import HighlightText from '../components/HighlightText';
 import ButtonIcon from '../components/ButtonIcon';
+import { I18n } from 'aws-amplify';
+
 
 const KendraSearchPage: React.FC = () => {
   const { loading, resultItems, query, setQuery, search } = useRag();
@@ -32,18 +34,17 @@ const KendraSearchPage: React.FC = () => {
   return (
     <div className="flex flex-col items-center">
       <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-        Kendra 検索
+        {I18n.get("kendra_search")}
       </div>
       <div className="text-sm text-gray-600">
         <div>
-          この機能は、Amazon Kendra の標準機能である Query API
-          で検索を行います。
+          {I18n.get("kendra_search_desc")}
           <span className="font-bold">
-            生成系 AI は利用していません。RAG は
+            {I18n.get("kendra_rag_no_llm")}
             <Link className="text-aws-smile" to="/rag">
-              こちら
+              {I18n.get("here")}
             </Link>
-            で実行できます。
+            {I18n.get("it_can_be_executed_by")}
           </span>
         </div>
       </div>
@@ -52,7 +53,7 @@ const KendraSearchPage: React.FC = () => {
         <input
           ref={queryRef}
           className="absolute w-full rounded-full border-gray-400 pl-9"
-          placeholder="検索ワードを入力してください"
+          placeholder={I18n.get("please_enter_search")}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />

--- a/packages/web/src/pages/LandingPage.tsx
+++ b/packages/web/src/pages/LandingPage.tsx
@@ -12,6 +12,8 @@ import {
   PiImages,
 } from 'react-icons/pi';
 import { ReactComponent as AwsIcon } from '../assets/aws.svg';
+import { I18n } from 'aws-amplify';
+
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 
@@ -21,8 +23,7 @@ const LandingPage: React.FC = () => {
   const demoChat = () => {
     navigate('/chat', {
       state: {
-        content: `フィボナッチ数を返す Python の関数を書いてください。
-引数が項で、処理は再帰で書くようにしてください。`,
+        content: I18n.get("fibonacci_example"),
       },
     });
   };
@@ -30,8 +31,7 @@ const LandingPage: React.FC = () => {
   const demoRag = () => {
     navigate('/rag', {
       state: {
-        content: `Bedrock のセキュリティについて、教えてください。
-なぜ Bedrock が安全に利用できるのかわかるように説明してください。`,
+        content: I18n.get("bedrock_security_example_q"),
       },
     });
   };
@@ -39,9 +39,9 @@ const LandingPage: React.FC = () => {
   const demoGenerate = () => {
     navigate('/generate', {
       state: {
-        information: `Amazon Bedrock は、AI21 Labs、Anthropic、Cohere、Meta、Stability AI、Amazon などの大手 AI 企業が提供する高性能な基盤モデル (FM) を単一の API で選択できるフルマネージド型サービスです。また、生成系 AI アプリケーションの構築に必要な幅広い機能も備えているため、プライバシーとセキュリティを維持しながら開発を簡素化できます。Amazon Bedrock の包括的な機能を使用すると、さまざまなトップ FM を簡単に試したり、微調整や検索拡張生成 (RAG) などの手法を使用してデータを使用してプライベートにカスタマイズしたり、旅行の予約や保険金請求の処理から広告キャンペーンの作成や在庫管理まで、複雑なビジネスタスクを実行するマネージドエージェントを作成したりできます。これらはすべて、コードを記述することなく行えます。Amazon Bedrock はサーバーレスであるため、インフラストラクチャを管理する必要がありません。また、使い慣れた AWS サービスを使用して、生成系 AI 機能をアプリケーションに安全に統合してデプロイできます。`,
+        information: I18n.get("bedrock_security_example_a"),
         context:
-          'プレゼンテーションのために、マークダウン形式で章立てして、それぞれ端的に説明を',
+          I18n.get("bedrock_security_example_c"),
       },
     });
   };
@@ -50,7 +50,7 @@ const LandingPage: React.FC = () => {
     navigate('/summarize', {
       state: {
         sentence:
-          'Amazon Bedrock は、Amazon や主要な AI スタートアップ企業が提供する基盤モデル (FM) を API を通じて利用できるようにする完全マネージド型サービスです。そのため、さまざまな FM から選択して、ユースケースに最も適したモデルを見つけることができます。Amazon Bedrock のサーバーレスエクスペリエンスにより、すぐに FM を開始したり、FM を簡単に試したり、独自のデータを使用して FM をプライベートにカスタマイズしたり、AWS のツールや機能を使用して FM をアプリケーションにシームレスに統合してデプロイしたりできます。Amazon Bedrock のエージェントは、開発者が独自の知識源に基づいて最新の回答を提供し、幅広いユースケースのタスクを完了できるジェネレーティブ AI アプリケーションを開発者が簡単に作成できるようにする完全マネージド機能です。Bedrock のサーバーレスエクスペリエンスにより、インフラストラクチャを管理することなく、すぐに使用を開始し、独自のデータを使用して FM をプライベートにカスタマイズし、使い慣れた AWS ツールや機能を使用してそれらをアプリケーションに簡単に統合してデプロイできます (さまざまなモデルをテストするための実験や FM を大規模に管理するためのパイプラインなどの Amazon SageMaker の ML 機能との統合を含みます)。',
+          I18n.get("bedrock_summary_example_q"),
         additionalContext: '',
       },
     });
@@ -60,7 +60,7 @@ const LandingPage: React.FC = () => {
     navigate('/editorial', {
       state: {
         sentence:
-          'こんちは。私は校正を支援する完璧な AI アシスタントです。お好きな文章を入力してくさい。',
+         I18n.get("editor_initial_greeting"),
       },
     });
   };
@@ -69,7 +69,7 @@ const LandingPage: React.FC = () => {
     navigate('/translate', {
       state: {
         sentence:
-          'こんにちは。私は翻訳を支援する AI アシスタントです。お好きな文章を入力してください。',
+          I18n.get("translation_initial_greeting")
       },
     });
   };
@@ -77,8 +77,7 @@ const LandingPage: React.FC = () => {
   const demoGenerateImage = () => {
     navigate('/image', {
       state: {
-        content: `スマホ広告のデザイン案を出力してください。
-可愛い、おしゃれ、使いやすい、POPカルチャー、親しみやすい、若者向け、音楽、写真、流行のスマホ、背景が街`,
+        content: I18n.get("image_gen_initial_greeting")
       },
     });
   };
@@ -87,64 +86,64 @@ const LandingPage: React.FC = () => {
     <div className="pb-24">
       <div className="bg-aws-squid-ink flex flex-col items-center justify-center px-3 py-5 text-xl font-semibold text-white lg:flex-row">
         <AwsIcon className="mr-5 h-20 w-20" />
-        生成系 AI を体験してみましょう。
+        {I18n.get("lets_experience_gen_ai")}
       </div>
 
       <h1 className="mt-6 flex justify-center text-2xl font-bold">
-        ユースケース一覧
+        {I18n.get("use_case_list")}
       </h1>
 
       <div className="mx-3 mb-6 mt-5 flex flex-col items-center justify-center text-xs lg:flex-row">
         <Button className="mb-2 mr-0 lg:mb-0 lg:mr-2" onClick={() => {}}>
-          デモ
+          {I18n.get("demos")}
         </Button>
-        をクリックすることで、各ユースケースを体験できます。
+        {I18n.get("click_each_use_case")}
       </div>
 
       <div className="mx-20 grid gap-x-20 gap-y-5 md:grid-cols-1 xl:grid-cols-2">
         <CardDemo
-          label="チャット"
+          label={I18n.get('chats')}
           onClickDemo={demoChat}
           icon={<PiChatsCircle />}
-          description="LLM とチャット形式で対話することができます。細かいユースケースや新しいユースケースに迅速に対応することができます。プロンプトエンジニアリングの検証用環境としても有効です。"
+          description= {I18n.get("chats_overview")}
         />
         {ragEnabled && (
           <CardDemo
-            label="RAG チャット"
+            label={I18n.get("rag_chat")}
             onClickDemo={demoRag}
             icon={<PiChatCircleText />}
-            description="RAG (Retrieval Augmented Generation) は、情報の検索と LLM の文章生成を組み合わせる手法のことで、効果的な情報アクセスを実現できます。Amazon Kendra から取得した参考ドキュメントをベースに LLM が回答を生成してくれるため、「社内情報に対応した LLM チャット」を簡単に実現することが可能です。"
+            description={I18n.get("rag_desc")}
           />
         )}
         <CardDemo
-          label="文章生成"
+          label={I18n.get('text_gen')}
           onClickDemo={demoGenerate}
           icon={<PiPencil />}
-          description="あらゆるコンテキストで文章を生成することは LLM が最も得意とするタスクの 1 つです。記事・レポート・メールなど、あらゆるコンテキストに対応します。"
+          description={I18n.get("text_gen_desc")}
         />
         <CardDemo
-          label="要約"
+          label={I18n.get("summarize")}
           onClickDemo={demoSummarize}
           icon={<PiNote />}
-          description="LLM は、大量の文章を要約するタスクを得意としています。要約する際に「1行で」や「子供でもわかる言葉で」などコンテキストを与えることができます。"
+          description={I18n.get("summarize_desc")}
         />
         <CardDemo
-          label="校正"
+          label={I18n.get("editor")}
           onClickDemo={demoEditorial}
           icon={<PiPenNib />}
-          description="LLM は、誤字脱字のチェックだけでなく、文章の流れや内容を考慮したより客観的な視点から改善点を提案できます。人に見せる前に LLM に自分では気づかなかった点を客観的にチェックしてもらいクオリティを上げる効果が期待できます。"
+          description={I18n.get("editor_desc")}
         />
         <CardDemo
-          label="翻訳"
+          label={I18n.get("translation")}
           onClickDemo={demoTranslate}
           icon={<PiTranslate />}
-          description="多言語で学習した LLM は、翻訳を行うことも可能です。また、ただ翻訳するだけではなく、カジュアルさ・対象層など様々な指定されたコンテキスト情報を翻訳に反映させることが可能です。"
+          description={I18n.get("translation_desc")}
         />
         <CardDemo
-          label="画像生成"
+          label={I18n.get("image_gen")}
           onClickDemo={demoGenerateImage}
           icon={<PiImages />}
-          description="画像生成 AI は、テキストや画像を元に新しい画像を生成できます。アイデアを即座に可視化することができ、デザイン作業などの効率化を期待できます。こちらの機能では、プロンプトの作成を LLM に支援してもらうことができます。"
+          description={I18n.get("image_gen_desc")}
         />
       </div>
     </div>

--- a/packages/web/src/pages/RagPage.tsx
+++ b/packages/web/src/pages/RagPage.tsx
@@ -9,6 +9,7 @@ import useScroll from '../hooks/useScroll';
 import { ReactComponent as BedrockIcon } from '../assets/bedrock.svg';
 import { ReactComponent as KendraIcon } from '../assets/kendra.svg';
 import { PiPlus } from 'react-icons/pi';
+import { I18n } from 'aws-amplify';
 
 type StateType = {
   content: string;
@@ -62,7 +63,7 @@ const RagPage: React.FC = () => {
     <>
       <div className={`${!isEmpty ? 'screen:pb-36' : ''}`}>
         <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-          RAG チャット
+          {I18n.get("rag_chat")}
         </div>
 
         {isEmpty && (
@@ -79,20 +80,16 @@ const RagPage: React.FC = () => {
           <div className="absolute inset-x-0 top-20 m-auto flex justify-center">
             <Alert severity="info">
               <div>
-                RAG (Retrieval Augmented Generation)
-                手法のチャットを行うことができます。
+                {I18n.get("rag_alert")}
               </div>
               <div>
-                メッセージが入力されると Amazon Kendra
-                でドキュメントを検索し、検索したドキュメントをもとに LLM
-                が回答を生成します。
+                {I18n.get("kendra_alert")}
               </div>
               <div className="font-bold">
-                Amazon Kendra の検索のみを実行する場合は
+                {I18n.get("kendra_if_you_only_want")}
                 <Link className="text-aws-smile" to="/kendra">
-                  こちら
+                {I18n.get("click_here")}.
                 </Link>
-                のページに遷移してください。
               </div>
             </Alert>
           </div>

--- a/packages/web/src/pages/Setting.tsx
+++ b/packages/web/src/pages/Setting.tsx
@@ -1,3 +1,4 @@
+import { I18n } from 'aws-amplify';
 import useChatApi from '../hooks/useChatApi';
 import { Link } from 'react-router-dom';
 
@@ -21,73 +22,72 @@ const Setting = () => {
   return (
     <div>
       <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-        設定情報
+        {I18n.get("settings")}
       </div>
 
       <div className="mx-3 mb-6 mt-5 flex flex-row items-center justify-center">
         <div className="w-2/3 text-xs lg:w-1/2">
-          設定の変更はこの画面ではなく
+          {I18n.get("changing_settings_not_here")}
           <Link
             className="text-aws-smile"
             to="https://docs.aws.amazon.com/ja_jp/cdk/v2/guide/home.html"
             target="_blank">
             AWS CDK
           </Link>
-          で行います。方法については
+          {I18n.get("please_refer_to_jp_pt1")}
           <Link
             className="text-aws-smile"
             to="https://github.com/aws-samples/generative-ai-use-cases-jp"
             target="_blank">
             generative-ai-use-cases-jp
           </Link>
-          をご参照ください。
+          {I18n.get("please_refer_to_jp_pt2")}
         </div>
       </div>
 
       {isLoading && (
-        <div className="flex justify-center text-sm">読み込み中...</div>
+        <div className="flex justify-center text-sm">{I18n.get("loading")}...</div>
       )}
 
       {!isLoading && error && (
         <div className="flex justify-center text-sm">
-          エラーで取得できませんでした
+          {I18n.get("could_not_be_retrieved_error")}
         </div>
       )}
 
       {!isLoading && !error && setting && (
         <>
           <div className="flex w-full flex-col items-center text-sm">
-            <SettingItem name="LLM モデルタイプ" value={setting.modelType} />
-            <SettingItem name="LLM モデル名" value={setting.modelName} />
+            <SettingItem name={I18n.get("llm_model_type")} value={setting.modelType} />
+            <SettingItem name={I18n.get("llm_model_name")} value={setting.modelName} />
             <SettingItem
-              name="LLM プロンプトテンプレート"
+              name={I18n.get("llm_prompt_template")}
               value={setting.promptTemplateFile}
             />
             <SettingItem
-              name="画像生成 モデル名"
+              name={I18n.get("image_gen_model_name")}
               value={setting.imageGenModelName}
             />
             <SettingItem
-              name="LLM & 画像生成 モデルリージョン"
+              name={I18n.get("llm_model_regions")}
               value={setting.modelRegion}
             />
-            <SettingItem name="RAG 有効" value={ragEnabled.toString()} />
+            <SettingItem name={I18n.get("rag_enabled")} value={ragEnabled.toString()} />
             {setting.modelType === 'bedrock' && (
               <div className="mt-5 w-2/3 text-xs lg:w-1/2">
-                ユースケース実行時にエラーになる場合は、必ず
-                <span className="font-bold">{setting.modelRegion}</span> にて
+                 {I18n.get("use_case_if_error_pt1")}
+                <span className="font-bold">{setting.modelRegion}</span> {I18n.get("use_case_if_error_pt2")}
                 <span className="font-bold">{setting.modelName}</span>
-                (LLM) と
+                {I18n.get("use_case_if_error_pt3")}
                 <span className="font-bold">{setting.imageGenModelName}</span>
-                (画像生成)
-                を有効化しているか確認してください。有効化する方法については
+                {I18n.get("use_case_if_error_pt4")}
                 <Link
                   className="text-aws-smile"
                   to="https://github.com/aws-samples/generative-ai-use-cases-jp"
                   target="_blank">
                   generative-ai-use-cases-jp
                 </Link>
-                をご参照ください。
+                {I18n.get("use_case_if_error_pt5")}
               </div>
             )}
           </div>

--- a/packages/web/src/pages/SummarizePage.tsx
+++ b/packages/web/src/pages/SummarizePage.tsx
@@ -9,6 +9,7 @@ import ButtonCopy from '../components/ButtonCopy';
 import useChat from '../hooks/useChat';
 import { create } from 'zustand';
 import { summarizePrompt } from '../prompts';
+import { I18n } from 'aws-amplify';
 
 type StateType = {
   sentence: string;
@@ -85,6 +86,7 @@ const SummarizePage: React.FC = () => {
   };
 
   // リアルタイムにレスポンスを表示
+  // show response in real time
   useEffect(() => {
     if (messages.length === 0) return;
     const _lastMessage = messages[messages.length - 1];
@@ -97,6 +99,7 @@ const SummarizePage: React.FC = () => {
   }, [messages]);
 
   // 要約を実行
+  // execute summary
   const onClickExec = useCallback(() => {
     if (loading) return;
     getSummary(sentence, additionalContext);
@@ -104,6 +107,7 @@ const SummarizePage: React.FC = () => {
   }, [sentence, additionalContext, loading]);
 
   // リセット
+  // resetting
   const onClickClear = useCallback(() => {
     clear();
     clearChat();
@@ -113,20 +117,20 @@ const SummarizePage: React.FC = () => {
   return (
     <div className="grid grid-cols-12">
       <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-        要約
+        {I18n.get("appointment")}
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">
-        <Card label="要約したい文章">
+        <Card label={I18n.get("summarize_sentences")}>
           <Textarea
-            placeholder="入力してください"
+            placeholder={I18n.get("please_enter")}
             value={sentence}
             onChange={setSentence}
             maxHeight={-1}
           />
 
-          <ExpandedField label="追加コンテキスト" optional>
+          <ExpandedField label={I18n.get("additional_context")}optional>
             <Textarea
-              placeholder="追加で考慮してほしい点を入力することができます（カジュアルさ等）"
+              placeholder={I18n.get("additional_context_placeholder")}
               value={additionalContext}
               onChange={setAdditionalContext}
             />
@@ -134,11 +138,11 @@ const SummarizePage: React.FC = () => {
 
           <div className="flex justify-end gap-3">
             <Button outlined onClick={onClickClear} disabled={disabledExec}>
-              クリア
+              {I18n.get("clear")}
             </Button>
 
             <Button disabled={disabledExec} onClick={onClickExec}>
-              実行
+              {I18n.get("execute")}
             </Button>
           </div>
 
@@ -146,7 +150,7 @@ const SummarizePage: React.FC = () => {
             <Markdown>{summarizedSentence}</Markdown>
             {!loading && summarizedSentence === '' && (
               <div className="text-gray-500">
-                要約された文章がここに表示されます
+                {I18n.get("summarized_sentences")}
               </div>
             )}
             {loading && (

--- a/packages/web/src/pages/TranscribePage.tsx
+++ b/packages/web/src/pages/TranscribePage.tsx
@@ -4,6 +4,8 @@ import Button from '../components/Button';
 import ButtonCopy from '../components/ButtonCopy';
 import useTranscribe from '../hooks/useTranscribe';
 import Markdown from '../components/Markdown';
+import { I18n } from 'aws-amplify';
+
 
 const TranscribePage: React.FC = () => {
   const { loading, transcriptData, file, setFile, transcribe, clear } =
@@ -36,10 +38,10 @@ const TranscribePage: React.FC = () => {
   return (
     <div className="grid grid-cols-12">
       <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-        音声認識
+        {I18n.get("audio_transcription")}
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">
-        <Card label="ファイルアップロード">
+        <Card label={I18n.get("file_upload")}>
           <input
             className="file:bg-aws-squid-ink block w-full cursor-pointer rounded-lg border
             border-gray-400 text-sm text-gray-900 file:mr-4 file:cursor-pointer file:border-0
@@ -55,10 +57,10 @@ const TranscribePage: React.FC = () => {
           </p>
           <div className="flex justify-end gap-3">
             <Button outlined disabled={disabledExec} onClick={onClickClear}>
-              クリア
+              {I18n.get("clear")}
             </Button>
             <Button disabled={disabledExec} onClick={onClickExec}>
-              実行
+              {I18n.get("execute")}
             </Button>
           </div>
           <div className="mt-5 rounded border border-black/30 p-1.5">
@@ -67,7 +69,7 @@ const TranscribePage: React.FC = () => {
             )}
             {!loading && !transcriptData?.transcript && (
               <div className="text-gray-500">
-                音声認識結果がここに表示されます
+                {I18n.get("audio_transcription_results")}
               </div>
             )}
             {loading && (

--- a/packages/web/src/pages/TranslatePage.tsx
+++ b/packages/web/src/pages/TranslatePage.tsx
@@ -13,15 +13,17 @@ import { create } from 'zustand';
 import debounce from 'lodash.debounce';
 import { PiCaretDown } from 'react-icons/pi';
 import { translatePrompt } from '../prompts';
+import { I18n } from 'aws-amplify';
+
 
 const languages = [
-  { label: '英語' },
-  { label: '日本語' },
-  { label: '中国語' },
-  { label: '韓国語' },
-  { label: 'フランス語' },
-  { label: 'スペイン語' },
-  { label: 'ドイツ語' },
+  { label: I18n.get("english")},
+  { label: I18n.get("japanese")},
+  { label: I18n.get("chinese")},
+  { label: I18n.get("korean")},
+  { label: I18n.get("french")},
+  { label: I18n.get("spanish")},
+  { label: I18n.get("german")},
 ];
 
 type StateType = {
@@ -89,6 +91,7 @@ const TranslatePage: React.FC = () => {
   const { loading, messages, postChat, clear: clearChat } = useChat(pathname);
 
   // Memo 変数
+  // Memo variables
   const disabledExec = useMemo(() => {
     return sentence === '' || loading;
   }, [sentence, loading]);
@@ -103,14 +106,18 @@ const TranslatePage: React.FC = () => {
   }, [state]);
 
   // 文章の更新時にコメントを更新
+  // update comments when text is updated
   useEffect(() => {
     // debounce した後翻訳
+    // translate after debounce
     onSentenceChange(sentence, additionalContext, language, loading);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sentence, language]);
 
   // debounce した後翻訳
+  // translate after debounce
   // 入力を止めて1秒ほど待ってから翻訳リクエストを送信
+  // Stop typing and wait about 1 second before submitting the translation request
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onSentenceChange = useCallback(
     debounce(
@@ -133,6 +140,7 @@ const TranslatePage: React.FC = () => {
   );
 
   // リアルタイムにレスポンスを表示
+  // display responses in real time
   useEffect(() => {
     if (messages.length === 0) return;
     const _lastMessage = messages[messages.length - 1];
@@ -161,6 +169,7 @@ const TranslatePage: React.FC = () => {
   };
 
   // 翻訳を実行
+  // execute translation
   const onClickExec = useCallback(() => {
     if (loading) return;
     getTranslation(sentence, language, additionalContext);
@@ -177,15 +186,15 @@ const TranslatePage: React.FC = () => {
   return (
     <div className="grid grid-cols-12">
       <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
-        翻訳
+        {I18n.get("translation")}
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">
-        <Card label="翻訳したい文章">
+        <Card label={I18n.get("translation_sentences")}>
           <div className="flex w-full flex-col lg:flex-row">
             <div className="w-full lg:w-1/2">
-              <div className="py-3">言語を自動検出</div>
+              <div className="py-3">{I18n.get("translation_autodetect")}</div>
               <Textarea
-                placeholder="入力してください"
+                placeholder={I18n.get("please_enter")}
                 value={sentence}
                 onChange={setSentence}
                 maxHeight={-1}
@@ -219,9 +228,9 @@ const TranslatePage: React.FC = () => {
             </div>
           </div>
 
-          <ExpandedField label="追加コンテキスト" optional>
+          <ExpandedField label={I18n.get("additional_context")} optional>
             <Textarea
-              placeholder="追加で考慮してほしい点を入力することができます（カジュアルさ等）"
+              placeholder={I18n.get("additional_context_placeholder")}
               value={additionalContext}
               onChange={setAdditionalContext}
             />
@@ -229,11 +238,11 @@ const TranslatePage: React.FC = () => {
 
           <div className="flex justify-end gap-3">
             <Button outlined onClick={onClickClear} disabled={disabledExec}>
-              クリア
+                {I18n.get("clear")}
             </Button>
 
             <Button disabled={disabledExec} onClick={onClickExec}>
-              実行
+                  {I18n.get("execute")}
             </Button>
           </div>
         </Card>

--- a/packages/web/src/prompts/index.ts
+++ b/packages/web/src/prompts/index.ts
@@ -1,56 +1,16 @@
 import { RetrieveResultItem } from '@aws-sdk/client-kendra';
+import { I18n } from 'aws-amplify';
+
 
 const systemContexts: { [key: string]: string } = {
-  '/chat': 'あなたはチャットでユーザを支援するAIアシスタントです。',
+  '/chat': I18n.get("prompts_chat"),
   '/summarize':
-    'あなたは文章を要約するAIアシスタントです。最初のチャットで要約の指示を出すので、その後のチャットで要約結果の改善を行なってください。',
-  '/editorial': 'あなたは丁寧に細かいところまで指摘する厳しい校閲担当者です。',
-  '/generate': 'あなたは指示に従って文章を作成するライターです。',
-  '/translate': 'あなたは文章の意図を汲み取り適切な翻訳を行う翻訳者です。',
+    I18n.get("prompts_summarize"),
+  '/editorial': I18n.get("prompts_editor"),
+  '/generate': I18n.get("prompts_generator"),
+  '/translate': I18n.get("prompts_translator"),
   '/rag': '',
-  '/image': `あなたはStable Diffusionのプロンプトを生成するAIアシスタントです。
-以下の step でStableDiffusionのプロンプトを生成してください。
-
-<step>
-* rule を理解してください。ルールは必ず守ってください。例外はありません。
-* ユーザは生成して欲しい画像の要件をチャットで指示します。チャットのやり取りを全て理解してください。
-* チャットのやり取りから、生成して欲しい画像の特徴を正しく認識してください。
-* 画像生成において重要な要素をから順にプロンプトに出力してください。ルールで指定された文言以外は一切出力してはいけません。例外はありません。
-</step>
-
-<rule>
-* プロンプトは output-format の通りに、JSON形式で出力してください。JSON以外の文字列は一切出力しないでください。JSONの前にも後にも出力禁止です。
-* JSON形式以外の文言を出力することは一切禁止されています。挨拶、雑談、ルールの説明など一切禁止です。
-* 出力するプロンプトがない場合は、promptとnegativePromptを空文字にして、commentにその理由を記載してください。
-* プロンプトは単語単位で、カンマ区切りで出力してください。長文で出力しないでください。プロンプトは必ず英語で出力してください。
-* プロンプトには以下の要素を含めてください。
- * 画像のクオリティ、被写体の情報、衣装・ヘアスタイル・表情・アクセサリーなどの情報、画風に関する情報、背景に関する情報、構図に関する情報、ライティングやフィルタに関する情報
-* 画像に含めたくない要素については、negativePromptとして出力してください。なお、negativePromptは必ず出力してください。
-* フィルタリング対象になる不適切な要素は出力しないでください。
-* comment は comment-rule の通りに出力してください。
-* recommendedStylePreset は recommended-style-preset-rule の通りに出力してください。
-</rule>
-
-<comment-rule>
-* 必ず「画像を生成しました。続けて会話することで、画像を理想に近づけていくことができます。以下が改善案です。」という文言を先頭に記載してください。
-* 箇条書きで3つ画像の改善案を提案してください。
-* 改行は\\nを出力してください。
-</comment-rule>
-
-<recommended-style-preset-rule>
-* 生成した画像と相性の良いと思われるStylePresetを3つ提案してください。必ず配列で設定してください。
-* StylePresetは、以下の種類があります。必ず以下のものを提案してください。
- * 3d-model,analog-film,anime,cinematic,comic-book,digital-art,enhance,fantasy-art,isometric,line-art,low-poly,modeling-compound,neon-punk,origami,photographic,pixel-art,tile-texture
-</recommended-style-preset-rule>
-
-<output-format>
-{
-  prompt: string,
-  negativePrompt: string,
-  comment: string
-  recommendedStylePreset: string[]
-}
-</output-format>`,
+  '/image': I18n.get("prompts_image_generator"),
 };
 
 export const getSystemContextById = (id: string) => {
@@ -75,26 +35,19 @@ export type SummarizeParams = {
 };
 
 export function summarizePrompt(params: SummarizeParams) {
-  return `以下の <要約対象の文章></要約対象の文章> の xml タグで囲われた文章を要約してください。
+  return `${I18n.get("prompts_summarizer_pt1")}}
+    ${params.sentence}
+    ${I18n.get("prompts_summarizer_pt2")}
 
-<要約対象の文章>
-${params.sentence}
-</要約対象の文章>
-
-${
-  !params.context
-    ? ''
-    : `要約する際、以下の <要約時に考慮して欲しいこと></要約時に考慮して欲しいこと> の xml タグで囲われた内容を考慮してください。
-
-    <要約時に考慮して欲しいこと>
-    ${params.context}
-  </要約時に考慮して欲しいこと>
-    `
-}
-
-要約した文章だけを出力してください。それ以外の文章は一切出力しないでください。
-出力は要約内容を <output></output> の xml タグで囲って出力してください。例外はありません。
-`;
+    ${
+      !params.context
+        ? I18n.get("prompts_summarizer_pt3")
+        : `${I18n.get("prompts_summarizer_pt4")}
+        ${params.context}
+        ${I18n.get("prompts_summarizer_pt5")}`
+    }
+    ${I18n.get("prompts_summarizer_pt6")}
+  `;
 }
 
 export type EditorialParams = {
@@ -103,22 +56,19 @@ export type EditorialParams = {
 };
 
 export function editorialPrompt(params: EditorialParams) {
-  return `inputの文章において誤字脱字は修正案を提示し、根拠やデータが不足している部分は具体的に指摘してください。
-<input>
+  return `${I18n.get("prompts_editor_template_pt1")}
 ${params.sentence}
-</input>
+${I18n.get("prompts_editor_template_pt2")}
 ${
   params.context
-    ? 'ただし、修正案や指摘は以下の <その他指摘してほしいこと></その他指摘してほしいこと>の xml タグで囲われたことを考慮してください。 <その他指摘してほしいこと>' +
+    ? I18n.get("prompts_editor_template_pt3") +
       params.context +
-      '</その他指摘してほしいこと>'
+      I18n.get("prompts_editor_template_pt4")
     : ''
 }
-出力は output-format 形式の JSON Array だけを <output></output> タグで囲って出力してください。
-<output-format>
-[{excerpt: string; replace?: string; comment?: string}]
-</output-format>
-指摘事項がない場合は空配列を出力してください。「指摘事項はありません」「誤字脱字はありません」などの出力は一切不要です。
+${I18n.get("prompts_editor_template_pt5")}
+${[/*{excerpt: string, replace?: string, comment?: string}*/]}
+${I18n.get("prompts_editor_template_pt6")}
 `;
 }
 
@@ -128,14 +78,12 @@ export type GenerateTextParams = {
 };
 
 export function generateTextPrompt(params: GenerateTextParams) {
-  return `<input>の情報から指示に従って文章を作成してください。指示された形式の文章のみを出力してください。それ以外の文言は一切出力してはいけません。例外はありません。
-出力は<output></output>のxmlタグで囲んでください。
-<input>
-${params.information}
-</input>
-<作成する文章の形式>
-${params.context}
-</作成する文章の形式>`;
+  return `${I18n.get("prompts_text_gen_pt1")}
+    ${params.information}
+    ${I18n.get("prompts_text_gen_pt2")}
+    ${params.context}
+    ${I18n.get("prompts_text_gen_pt3")} 
+  `
 }
 
 export type TranslateParams = {
@@ -145,21 +93,17 @@ export type TranslateParams = {
 };
 
 export function translatePrompt(params: TranslateParams) {
-  return `<input></input>の xml タグで囲われた文章を ${
+  return `${I18n.get("prompts_translation_pt1")} ${
     params.language
-  } に翻訳してください。
-翻訳した文章だけを出力してください。それ以外の文章は一切出力してはいけません。
-<input>
+  } ${I18n.get("prompts_translation_pt2")}
 ${params.sentence}
 </input>
 ${
   !params.context
     ? ''
-    : `ただし、翻訳時に<考慮して欲しいこと></考慮して欲しいこと> の xml タグで囲われた内容を考慮してください。<考慮して欲しいこと>${params.context}</考慮して欲しいこと>`
+    : I18n.get("prompts_translation_pt3")
 }
-
-出力は翻訳結果だけを <output></output> の xml タグで囲って出力してください。
-それ以外の文章は一切出力してはいけません。例外はありません。
+${I18n.get("prompts_translation_pt4")}
 `;
 }
 
@@ -171,46 +115,12 @@ export type RagParams = {
 
 export function ragPrompt(params: RagParams) {
   if (params.promptType === 'RETRIEVE') {
-    return `あなたは、文書検索で利用するQueryを生成するAIアシスタントです。
-以下の手順通りにQueryを生成してください。
-
-<Query生成の手順>
-* 以下の<Query履歴>の内容を全て理解してください。履歴は古い順に並んでおり、一番下が最新のQueryです。
-* 「要約して」などの質問ではないQueryは全て無視してください
-* 「〜って何？」「〜とは？」「〜を説明して」というような概要を聞く質問については、「〜の概要」と読み替えてください。
-* ユーザが最も知りたいことは、最も新しいQueryの内容です。最も新しいQueryの内容を元に、30トークン以内でQueryを生成してください。
-* 出力したQueryに主語がない場合は、主語をつけてください。主語の置き換えは絶対にしないでください。
-* 主語や背景を補完する場合は、「# Query履歴」の内容を元に補完してください。
-* Queryは「〜について」「〜を教えてください」「〜について教えます」などの語尾は絶対に使わないでください
-* 出力するQueryがない場合は、「No Query」と出力してください
-* 出力は生成したQueryだけにしてください。他の文字列は一切出力してはいけません。例外はありません。
-</Query生成の手順>
-
-<Query履歴>
+    return `${I18n.get("prompts_rag_pt1")}
 ${params.retrieveQueries!.map((q) => `* ${q}`).join('\n')}
-</Query履歴>
+${I18n.get("prompts_rag_pt2")}
 `;
   } else {
-    return `あなたはユーザの質問に答えるAIアシスタントです。
-以下の手順でユーザの質問に答えてください。手順以外のことは絶対にしないでください。
-
-<回答手順>
-* 「# 参考ドキュメント」に回答の参考となるドキュメントを設定しているので、それを全て理解してください。なお、この「# 参考ドキュメント」は「# 参考ドキュメントのJSON形式」のフォーマットで設定されています。
-* 「# 回答のルール」を理解してください。このルールは絶対に守ってください。ルール以外のことは一切してはいけません。例外は一切ありません。
-* チャットでユーザから質問が入力されるので、あなたは「# 参考ドキュメント」の内容をもとに「# 回答のルール」に従って回答を行なってください。
-</回答手順>
-
-<参考ドキュメントのJSON形式>
-{
-"DocumentId": "ドキュメントを一意に特定するIDです。",
-"DocumentTitle": "ドキュメントのタイトルです。",
-"DocumentURI": "ドキュメントが格納されているURIです。",
-"Content": "ドキュメントの内容です。こちらをもとに回答してください。",
-}[]
-</参考ドキュメントのJSON形式>
-
-<参考ドキュメント>
-[
+    return `${I18n.get("prompts_rag_pt3")}
 ${params
   .referenceItems!.map((item) => {
     return `${JSON.stringify({
@@ -221,17 +131,7 @@ ${params
     })}`;
   })
   .join(',\n')}
-]
-</参考ドキュメント>
-
-<回答のルール>
-* 雑談や挨拶には応じないでください。「私は雑談はできません。通常のチャット機能をご利用ください。」とだけ出力してください。他の文言は一切出力しないでください。例外はありません。
-* 必ず<参考ドキュメント>をもとに回答してください。<参考ドキュメント>から読み取れないことは、絶対に回答しないでください。
-* 回答の最後に、回答の参考にした「# 参考ドキュメント」を出力してください。「---\n#### 回答の参考ドキュメント」と見出しを出力して、ハイパーリンク形式でDocumentTitleとDocumentURIを出力してください。
-* <参考ドキュメント>をもとに回答できない場合は、「回答に必要な情報が見つかりませんでした。」とだけ出力してください。例外はありません。
-* 質問に具体性がなく回答できない場合は、質問の仕方をアドバイスしてください。
-* 回答文以外の文字列は一切出力しないでください。回答はJSON形式ではなく、テキストで出力してください。見出しやタイトル等も必要ありません。
-</回答のルール>
+${I18n.get("prompts_rag_pt4")}
 `;
   }
 }

--- a/packages/web/src/utils/i18n.ts
+++ b/packages/web/src/utils/i18n.ts
@@ -1,0 +1,538 @@
+import { I18n } from 'aws-amplify';
+import { i18nStrings } from '../@types/i18n';
+
+export const langStrings: i18nStrings = {
+    'en': {
+        "additional_context": "Additional context",
+        "additional_context_placeholder": "You can enter additional points you'd like to point out.", //this needs better translation
+        "ai_service": "AI Service",
+        "audio_transcription": "Audio Transcription",
+        "audio_transcription_results": "Transcription results",
+        "chats_overview": "You can interact with LLM in a chat format. We can respond quickly to detailed use cases and new use cases. It is also effective as a verification environment for prompt engineering.", //translation needs improvement
+        "changing_settings_not_here": "Changing settings not on this screen.",  //needs better translation
+        "delete_confirmation": "Are you sure you'd like to delete?",
+        "be_specific": "Be sure to give specific and detailed instructions. It's important to express it accurately, using adjectives and adverbs.",
+        "bedrock_security_example_q": "Please tell me about Bedrock's security. Please explain so you can understand why Bedrock is safe to use.",
+        "bedrock_security_example_a": "Amazon Bedrock is a fully managed service that allows you to select high-performance infrastructure models (FM) provided by major AI companies such as AI21 Labs, Anthropic, Cohere, Meta, Stability AI, and Amazon with a single API. It also has a wide range of features needed to build generative AI applications, so development can be simplified while maintaining privacy and security. Using Amazon Bedrock's comprehensive functionality, you can easily experiment with different top FMs, privately customize using data using techniques such as fine tuning and search extension generation (RAG), and create managed agents to perform complex business tasks from processing travel reservations and insurance claims to creating ad campaigns and managing inventory. You can do all of this without writing any code. Amazon Bedrock is serverless, so there's no infrastructure to manage. You can also use familiar AWS services to securely integrate and deploy generative AI functionality into your applications.",
+        "bedrock_security_example_c": "For presentation, set up chapters in markdown format and explain each in a nutshell.",
+        "bedrock_summary_example_q": "Amazon Bedrock is a fully managed service that makes it possible to use infrastructure models (FM) provided by Amazon and major AI startups through APIs. So you can choose from a variety of FMs to find the model that best fits your use case. Amazon Bedrock's serverless experience allows you to get started with FM right away, easily experiment with FM, privately customize FM using your own data, and seamlessly integrate and deploy FM into your application using AWS tools and features. Amazon Bedrock's agent is a fully managed feature that makes it easy for developers to create generative AI applications that provide up-to-date answers based on unique knowledge sources and can complete tasks for a wide range of use cases. Bedrock's serverless experience allows you to start using it right away without managing infrastructure, privately customize FM using your own data, and easily integrate and deploy FM into your application using familiar AWS tools and features (experiments to test different models, pipelines for managing FM at scale, etc. Includes integration with Amazon SageMaker's ML functionality).",
+        "cancel": "Cancel",
+        "cancelled": "Cancelled",
+        "cfg_scale": "Configure scale",
+        "cfg_scale_help": "Higher values will produce images more strongly influenced by the prompt.",
+        "chat": "Chat",
+        "chats": "Chats",
+        "chinese": "Chinese",
+        "clear": "Clear",
+        "click_each_use_case": "Click each use case to try it.",
+        "click_here": "click here.", 
+        "completions": "Completions",
+        "conversational_style_example": "LLM: Since it takes into account the flow of conversation, you can also give instructions in a conversational style, such as “after all, make it a cat, not a dog.",  //this needs a better example than the raw translation from JP.
+        "could_not_be_retrieved_error": "Could not be retrieved due to an error.",
+        "cut_confirmation": "Cut confirmation", //I'm sure this is wrong
+        "delete": "Delete",
+        "demos": "Demos",
+        "dogs_playing_example": "Instead of “dogs playing,” let's give specific instructions, such as “Shiba Inus running around happily in the grassland.",
+        "editor": "Editor",
+        "editor_desc": "LLM not only checks for typographical errors, but can also suggest improvements from a more objective point of view that takes into account the flow and content of sentences. You can expect the effect of improving quality by having LLM objectively check points you weren't aware of before showing them to others.",
+        "editor_initial_greeting": "Good evening. I'm the perfect AI assistant to help with proofreading. Please enter a sentence of your choice.",
+        "editor_sentences_to_edit": "Sentences you want to edit.",
+        "english": "English",
+        "errors": "Errors",
+        "exclusion_example": "You can also indicate which elements you want to exclude. “Don't output...” (a list of undesirable behaviors or outputs)",
+        "execute": "Execute",
+        "executions": "Executions", //might mean job runs. update this.
+        "fibonacci_example": "Write a Python function that returns Fibonacci numbers. Make sure that the arguments are terms and the processing is written recursively.", // might need better translation about the terms part.
+        "file_upload": "File upload",
+        "french": "French",
+        "gen_ai": "Generative AI",
+        "gen_ai_on_aws": "Generative AI on AWS",
+        "generating_images": "Generating images...",
+        "generating_texts": "Generating text...",
+        "german": "German",
+        "image_gen_chat": "Generate images in chat",
+        "here": "here",
+        "home": "Home",
+        "image_gen": "Image Generation",
+        "image_gen_desc": "Image generation AI can generate new images based on text and images. Ideas can be immediately visualized, and efficiency in design work etc. can be expected to improve. With this feature, you can get LLM to help you create prompts.",
+        "image_gen_initial_greeting": "Please output a design proposal for a smartphone ad. Cute, stylish, easy to use, pop culture, friendly, for young people, music, photos, trendy smartphones, city backgrounds",
+        "image_gen_iterations_help": "The number of iterations in image generation. The higher the number of steps, the more refined the image, but it takes longer to generate.",
+        "image_gen_model_name": "Image generation model name",
+        "image_gen_num_images": "Number of images generated",
+        "image_gen_num_image_help": "While randomly setting seed, a specified number of images are simultaneously generated.",
+        "image_gen_prompt": "Please enter a list of words to generate an image.",
+        "image_gen_prompt_advice": "If the prompt doesn't generate the intended image, try changing the prompt or the parameters.",
+        "image_gen_strength": "Image strength",
+        "image_gen_strength_help": "An image closer to 1 is generated closer to the “initial image”, and closer to 0, an image different from the “initial image” is generated.",        "initial_image": "Initial image",
+        "initial_image_help": "You can set the image that is the initial state for image generation. By setting the initial image, you can guide the generation of an image close to the initial image.",
+        "initial_image_settings": "Initial image settings",
+        "initial_image_settings_help": "It is used as an initial state for image generation. An image close to the specified image will be generated.",
+        "it_can_be_executed_by": "It can be executed by", //translate this one better.
+        "it_will_be_done_at": "It will be done at As for the method", //needs better translation
+        "japanese": "Japanese",
+        "kendra_alert": "Amazon Kendra when a message is entered search for documents in, and LLM based on the documents you've searched will generate an answer.",  //definitely needs better translation
+        "kendra_fetch": "Retrieving reference documents from Kendra...",
+        "kendra_if_you_only_want": "If you only want to perform an Amazon Kendra search",
+        "kendra_rag_no_llm": "Semantic search with no LLM",
+        "kendra_search": "Kendra Search",
+        "kendra_search_desc": "Search Kendra with",
+        "korean": "Korean",
+        "llm_model_name": "LLM model name",
+        "llm_model_regions": "LLM & image generation model regions.",
+        "llm_model_type": "LLM model type",
+        "llm_prompt_template": "LLM prompt template",
+        "loading": "Loading",
+        "lets_experience_gen_ai": "Let's experience generative AI",
+        "meeting_resume": "Meeting Resume",
+        "negative_prompt": "Negative prompt",
+        "negative_prompt_help": "Please list the elements you don't want to generate and the elements you want to eliminate. It is not written in sentences, but in a list of words.",
+        "no_indications": "There are no indications", // this one seems like it needs better translation
+        "no_sentences_needed_example": "If writing in sentences is difficult, there is no need to write in sentences. Let's list the characteristics and give instructions, such as “doing well, playing ball, jumping.",
+        "not_set": "Not set.",
+        "please_enter": "Please enter text",
+        "please_enter_search": "Please enter a search term",
+        "please_refer_to_jp_pt1": "Please refer to",
+        "please_refer_to_jp_pt2": "for more information",
+        "prompts": "Prompts",
+        "prompts_chat": "You are an AI assistant that assists users via chat.",
+        "prompts_editor": "You're a strict reviewer who carefully points out even the smallest details.",
+        "prompts_editor_template_pt1": `Please present a correction plan for typographical errors and omissions in input sentences, and specifically point out the parts where evidence or data are lacking.
+            <input>
+        `,
+        "prompts_editor_template_pt2": "</input>",
+        "prompts_editor_template_pt3": `However, please consider that corrections and suggestions were surrounded by the following xml tags <other things I want you to point out></other things I want you to point out>. 
+        <other things I want you to point out>`,
+        "prompts_editor_template_pt4": '</other things I want you to point out>',
+        "prompts_editor_template_pt5": `The output should only be a JSON array in output-format format, surrounded by tags.<output></output>
+        <output-format>`,
+        "prompts_editor_template_pt6": `</output-format>
+        If there are no notes, output an empty array. There is no need for output such as “there are no pointed out matters” or “there are no typos or omissions.”
+        `,
+        "prompts_gen": "Prompts are automatically generated and set in a chat format, and images are generated.", //needs less awkward translation
+        "prompts_gen_error": "An error occurred while generating.",
+        "prompts_generator": "You're a writer who creates sentences according to instructions.",
+        "prompts_image_generator": `
+            You're an AI assistant that generates prompts for Stable Diffusion.
+            Follow the steps below to generate a StableDiffusion prompt.
+
+            <step>
+            * Please understand the rules. Please make sure to follow the rules. There are no exceptions.
+            * Users indicate the requirements for the images they want generated via chat. Make sure you understand all of the chat conversations.
+            * Please correctly recognize the characteristics of the image you want to generate from chat exchanges.
+            * Please output the important elements in image generation to the prompt in order starting from the beginning. Do not output anything other than the words specified in the rules. There are no exceptions.</step>
+
+            <rule>
+            * Please output the prompt in JSON format according to output-format. Do not output any strings other than JSON. It is prohibited to output JSON before or after.
+            * Outputting text other than JSON format is prohibited at all. Greetings, small talk, explanation of rules, etc. are prohibited at all.
+            * If there are no prompts to output, leave prompt and negativePrompt empty and state the reason in the comments.
+            * Prompts should be output word by word and separated by commas. Please do not output long sentences. Be sure to print the prompts in English.
+            * The prompt must include the following elements:
+            * Image quality, subject information, clothing, hairstyles, facial expressions, accessories, etc., information on painting style, background information, composition information, information on lighting and filters
+            * For elements you don't want included in the image, output them as negativePrompt. Note that negativePrompt must be output.
+            * Do not output inappropriate elements to be filtered.
+            * Please output comments as per comment-rule.
+            * Please output the recommendedStylePreset according to the recommended-style-preset-rule</rule>.
+
+            <comment-rule>
+            * Always “An image has been generated. By continuing the conversation, you can bring the image closer to the ideal one. The following is an improvement plan.” Please write the phrase “” at the beginning.
+            * Please suggest improvements to the 3 images in bullet points.
+            * Please output\\nfor line breaks</comment-rule>.
+
+            <recommended-style-preset-rule>
+            * Please suggest 3 StylePresets that you think are compatible with the generated images. Be sure to set it in an array.
+            * StylePresets are available in the following types. Be sure to suggest the following:
+            * 3d-model, analog-film, animation, cinematic, comic-book, digital-art, enhance, fantasy-art, isometric, line-art, low-poly, modeling-compound, neon-punk, origami, photographic, pixel-art, tile-texture
+            </recommended-style-preset-rule>
+
+            <output-format>
+            {
+            prompt: string,
+            negativePrompt: string,
+            comment: string
+            recommendedStylePreset: string []
+            </output-format>}
+        `,
+        "prompts_rag_pt1": `You are an AI assistant that generates queries for use in document searches.
+        Follow the steps below to generate a query.
+        
+        <procedure for generating a query>
+        * Please make sure you understand all of the following <query history></query history>. The history is arranged in oldest order, with the most recent Queries at the bottom.
+        * Ignore all queries that aren't “Summarize” or the like
+        * “What is ~?” “What is...?” For questions that ask for an overview such as “explain ~”, please replace it with “overview of ~.”
+        * What users want to know most is the content of the newest Queries. Generate a query within 30 tokens, based on the content of the most recent query.
+        * If there is no subject in the output query, add a subject. Never replace the subject.
+        * When complementing the subject or background, please supplement it based on the content of “# Query History”.
+        * Never use endings such as “about ~,” “please tell me about ~,” or “I'll teach you about ~” in Query
+        * If there is no query to output, output “No Query”
+        * Please output only the generated query. Do not output any other strings. There are no exceptions. </procedure for generating a query>
+        
+        <query history>`,
+        "prompts_rag_pt2": `</query history>`,
+        "prompts_rag_pt3": `You are an AI assistant that answers user questions.
+        Please follow the steps below to answer the user's questions. Never do anything other than the steps.
+        
+        <response procedure>
+        * Documents that serve as reference for answers are set in “# reference documents”, so please understand all of them. Note that this “# reference document” is set in the “# reference document JSON format” format.
+        * Please understand the “# answer rule.” Please abide by this rule at all costs. Don't do anything other than the rules. There are no exceptions.
+        * Since questions are entered from users in the chat, please answer according to the “# answer rules” based on the contents of “# reference documents.” 
+        </response procedure>
+        
+        <reference_document_json_format>
+        {
+        “documentId”: “An ID that uniquely identifies a document.” ,
+        “documentTitle”: “The title of the document.” ,
+        “documentURI”: “The URI where the document is stored.” ,
+        “Content”: “This is the content of the document. Please use this as a basis for your answers.” ,
+        } [] </reference_document_json_format>
+        
+        <reference_documents>
+        [`,
+        "prompts_rag_pt4": `</reference_documents>]
+
+        <answer_rules>
+        * Please do not respond to small talk or greetings. “I can't chat. Please use the normal chat function.” Please output just that. Do not output any other words. There are no exceptions.
+        <reference_documents>* Please be sure to base your answers. Never answer anything you<reference_documents> can't read from.
+        * At the end of the answer, please output the “# reference document” that you used as a reference for your answer. Please output the heading “---\n#### Reference documentation for answers” and output DocumentTitle and DocumentURI in hyperlink format.
+        If you are unable to answer based on*, “The information required to answer was not found. <reference_documents>” Please output just that. There are no exceptions.
+        * If your question isn't specific and you can't answer it, please give advice on how to ask the question.
+        * Please do not output any strings other than the answer text. Please output your answers in text, not in JSON format. There is no need for headings, titles, etc </answer_rules>.
+        `,
+        "prompts_summarize": "You're an AI assistant who summarizes sentences. Summarization instructions will be given in the first chat, so please improve the summary results in subsequent chats.",
+        "prompts_summarizer_pt1": `
+            Please summarize the sentences surrounded <sentences to be summarized></sentences to be summarized> by xml tags below.
+
+            <sentences to be summarized>
+        `,
+        "prompts_summarizer_pt2": "</sentences to be summarized>",
+        "prompts_summarizer_pt3": "",
+        "prompts_summarizer_pt4": `When summarizing, please consider the content surrounded by the following xml tags. <things I want you to consider when summarizing></things I want you to consider when summarizing>
+
+            <things I want you to consider when summarizing>
+        `,
+        "prompts_summarizer_pt5": "</things I want you to consider summarizing>",
+        "prompts_summarizer_pt6": `Please output only summarized sentences. Please do not output any other sentences.
+            For output, please surround the summary content with xml tags.<output></output> There are no exceptions.
+        `,
+        "prompts_text_gen_pt1": `<input>Please create a sentence according to the instructions from the information. Please output only sentences in the format indicated. Do not output any other words. There are no exceptions.
+        Surround the output<output></output> with xml tags.
+        <input>`,
+        "prompts_text_gen_pt2": `</input>
+        <format of sentences to be created>
+        `,
+        "prompts_text_gen_pt3": "</format of sentences to be created>",
+        "prompts_translation_pt1": "<input></input>Sentences surrounded by xml tags",
+        "prompts_translation_pt2": `Please translate it to
+        Please output only translated sentences. Do not output any other sentences.
+        <input>`,
+        "prompts_translation_pt3": `However, please take into account<things I want you to consider></things I want you to consider> the content surrounded by xml tags when translating. <things I want you to consider>`,
+        "prompts_translation_pt4": `As for the output, please surround only the translation results<output></output> with xml tags.
+        Do not output any other sentences. There are no exceptions.`,
+        "prompts_translator": "You are a translator who captures the intent of sentences and translates them appropriately.",
+        "prompt_gen_complete": "Prompt generation complete.",
+        "rag_chat": "RAG Chat",
+        "rag_alert": "RAG (Retrieval Augmented Generation) You can do method chats.",  // needs better translation
+        "rag_desc": "RAG (Retrieval Augmented Generation) is a method that combines information retrieval and LLM sentence generation, so effective information access can be achieved. Since LLM generates answers based on reference documents obtained from Amazon Kendra, it is possible to easily implement an “LLM chat compatible with internal information.”",
+        "rag_enabled": "Rag enabled",
+        "rerun": "Re-run",
+        "seed_help": "The seed value for random numbers. If the same seed value is specified, the same image will be generated.",
+        "seed_button_text": "Set random seed",
+        "settings": "Settings",
+        "sign_out": "Sign Out",
+        "spanish": "Spanish",
+        "start_over": "Start over",
+        "step": "Step",
+        "summarize": "Summarize",
+        "summarize_desc": "LLM excels at the task of summarizing large amounts of sentences. When summarizing, you can give context such as “in one line” or “in words that even children can understand.”",
+        "summarize_sentences": "Sentences to summarize",
+        "summarized_sentences": "Summarized sentences",
+        "text_gen": "Text Generation",
+        "text_gen_desc": "Generating sentences in every context is one of the tasks LLM excels at. It supports all kinds of contexts, such as articles, reports, emails, etc.",
+        "text_gen_display_label": "Generated text",
+        "text_gen_format": "Please indicate the format of the text. (markdown, blogs, business emails, etc.)",
+        "text_gen_source": "Information that is the source of the text", // this needs better translation
+        "tips": "Tips",
+        "tool": "Tool",
+        "translation": "Translation",
+        "translation_autodetect": "Autodetect languages",
+        "translation_desc": "LLM learned in multiple languages can also be translated. Also, in addition to simply translating, it is possible to reflect various specified context information such as casuality and target groups in the translation.",
+        "translation_initial_greeting": "Hello. I'm an AI assistant that helps with translations. Please enter a sentence of your choice.",
+        "translation_sentences": "Sentences to translate",
+        "upload_image": "Upload an image",
+        "use_case": "Use Case",
+        "use_case_list": "List of use cases",
+        "use_case_if_error_pt1": "If you get an error when running a use case, be sure to enable",
+        "use_case_if_error_pt3": "(LLM) and",
+        "use_case_if_error_pt4": "(image generation) For more information on how to enable it, please refer to ",
+        "use_case_if_error_pt5": "",
+    },
+    'jp': {
+        "additional_context": "追加コンテキスト",
+        "additional_context_placeholder": "追加で指摘してほしい点を入力することができます",
+        "ai_service": "AIサービス",
+        "appointment": "要約",
+        "audio_transcription": "音声認識",
+        "audio_transcription_results": "音声認識結果がここに表示されます",
+        "be_specific": "具体的かつ詳細な指示を出すようにしましょう。形容詞や副詞を使って、正確に表現することが重要です。",
+        "bedrock_security_example_q": "Bedrock のセキュリティについて、教えてください。なぜ Bedrock が安全に利用できるのかわかるように説明してください。",
+        "bedrock_security_example_a": "Amazon Bedrock は、AI21 Labs、Anthropic、Cohere、Meta、Stability AI、Amazon などの大手 AI 企業が提供する高性能な基盤モデル (FM) を単一の API で選択できるフルマネージド型サービスです。また、生成系 AI アプリケーションの構築に必要な幅広い機能も備えているため、プライバシーとセキュリティを維持しながら開発を簡素化できます。Amazon Bedrock の包括的な機能を使用すると、さまざまなトップ FM を簡単に試したり、微調整や検索拡張生成 (RAG) などの手法を使用してデータを使用してプライベートにカスタマイズしたり、旅行の予約や保険金請求の処理から広告キャンペーンの作成や在庫管理まで、複雑なビジネスタスクを実行するマネージドエージェントを作成したりできます。これらはすべて、コードを記述することなく行えます。Amazon Bedrock はサーバーレスであるため、インフラストラクチャを管理する必要がありません。また、使い慣れた AWS サービスを使用して、生成系 AI 機能をアプリケーションに安全に統合してデプロイできます。",
+        "bedrock_security_example_c": "プレゼンテーションのために、マークダウン形式で章立てして、それぞれ端的に説明を",
+        "bedrock_summary_example_q": "Amazon Bedrock は、Amazon や主要な AI スタートアップ企業が提供する基盤モデル (FM) を API を通じて利用できるようにする完全マネージド型サービスです。そのため、さまざまな FM から選択して、ユースケースに最も適したモデルを見つけることができます。Amazon Bedrock のサーバーレスエクスペリエンスにより、すぐに FM を開始したり、FM を簡単に試したり、独自のデータを使用して FM をプライベートにカスタマイズしたり、AWS のツールや機能を使用して FM をアプリケーションにシームレスに統合してデプロイしたりできます。Amazon Bedrock のエージェントは、開発者が独自の知識源に基づいて最新の回答を提供し、幅広いユースケースのタスクを完了できるジェネレーティブ AI アプリケーションを開発者が簡単に作成できるようにする完全マネージド機能です。Bedrock のサーバーレスエクスペリエンスにより、インフラストラクチャを管理することなく、すぐに使用を開始し、独自のデータを使用して FM をプライベートにカスタマイズし、使い慣れた AWS ツールや機能を使用してそれらをアプリケーションに簡単に統合してデプロイできます (さまざまなモデルをテストするための実験や FM を大規模に管理するためのパイプラインなどの Amazon SageMaker の ML 機能との統合を含みます)。",        
+        "cancel": "[キャンセル]",  //this one was English in the original code and Translate provided the Japanese. Please confirm this one.
+        "cancelled": "キャンセル",
+        "cfg_scale": "CFG スケール",
+        "changing_settings_not_here": "設定の変更はこの画面ではなく",
+        "chats_overview": "LLM とチャット形式で対話することができます。細かいユースケースや新しいユースケースに迅速に対応することができます。プロンプトエンジニアリングの検証用環境としても有効です。", //I'm not sure on this. needs checking.
+        "click_each_use_case": "をクリックすることで、各ユースケースを体験できます。",
+        "cfg_scale_help": "この値が高いほどプロンプトに対して忠実な画像を生成します。",
+        "chat": 'チャット',
+        "chats": 'チャット',
+        "chinese": "中国語",
+        "clear": "クリア",
+        "click_here": "のページに遷移してください。",
+        "completions": "完了",
+        "conversational_style_example": "LLM  が会話の流れを考慮してくれるので、「やっぱり犬じゃなくて猫にして」などの会話形式の指示もできます。",
+        "could_not_be_retrieved_error": "エラーで取得できませんでした",
+        "cut_confirmation": "削除確認", //i'm sure this is wrong, but waiting to find it in the UI before fixing it.
+        "delete": "削除",
+        "delete_confirmation": "を削除しますか？",
+        "demos": "デモ",
+        "dogs_playing_example": "「犬が遊んでいる」ではなく、「柴犬が草原で楽しそうに走り回っている」のように具体的に指示をしましょう",
+        "editor": "校正",  // Amazon Translate translated this as "corrects" but the path is /editor. Not sure what to call this.
+        "editor_desc": "LLM は、誤字脱字のチェックだけでなく、文章の流れや内容を考慮したより客観的な視点から改善点を提案できます。人に見せる前に LLM に自分では気づかなかった点を客観的にチェックしてもらいクオリティを上げる効果が期待できます。",
+        "editor_initial_greeting": "こんちは。私は校正を支援する完璧な AI アシスタントです。お好きな文章を入力してくさい。",
+        "editor_sentences_to_edit": "校正したい文章", //this one should be fixed to match what the editor string gets updated to.
+        "english": "英語",
+        "errors": "エラー",
+        "execute": "実行",
+        "exclusion_example": "除外して欲しい要素も指示することができます。「人間は出力しない」など。",
+        "executions": "実行",
+        "fibonacci_example": "フィボナッチ数を返す Python の関数を書いてください。引数が項で、処理は再帰で書くようにしてください。",
+        "file_upload": "ファイルアップロード",
+        "french": "フランス語",
+        "gen_ai": "生成系AI",
+        "gen_ai_on_aws": "AWS でのジェネレーティブ AI",  //Amazon translate came up with this one. Please confirm.
+        "generating_images": "画像生成中",
+        "generating_text": "プロンプト生成中",
+        "german": "ドイツ語",
+        "image_gen_chat": "チャット形式で画像生成",
+        "here": "こちら",
+        "home": "ホーム",
+        "image_gen": "画像生成",
+        "image_gen_desc": "画像生成 AI は、テキストや画像を元に新しい画像を生成できます。アイデアを即座に可視化することができ、デザイン作業などの効率化を期待できます。こちらの機能では、プロンプトの作成を LLM に支援してもらうことができます。",
+        "image_gen_initial_greeting": "スマホ広告のデザイン案を出力してください。可愛い、おしゃれ、使いやすい、POPカルチャー、親しみやすい、若者向け、音楽、写真、流行のスマホ、背景が街",
+        "image_gen_iterations_help": "画像生成の反復回数です。Step 数が多いほど画像が洗練されますが、生成に時間がかかります。", 
+        "image_gen_model_name": "画像生成 モデル名",
+        "image_gen_num_images": "画像生成数",
+        "image_gen_num_images_help": "Seed をランダム設定しながら画像を指定の数だけ同時に生成します。",
+        "image_gen_prompt": "生成したい画像の説明を記載してください。文章ではなく、単語の羅列で記載します。",
+        "image_gen_prompt_advice": "プロンプトで意図した画像が生成できない場合は、初期画像の設定やパラメータの変更を試してみましょう。",
+        "image_gen_strength": "画像強度",
+        "image_gen_strength_help": "1に近いほど「初期画像」に近い画像が生成され、0に近いほど「初期画像」とは異なる画像が生成されます。",
+        "initial_image": "初期画像",
+        "inital_image_help": "画像生成の初期状態となる画像を設定できます。初期画像を設定することで、初期画像に近い画像を生成するように誘導できます。",
+        "initial_image_settings": "初期画像の設定",
+        "initial_image_settings_help": "画像生成の初期状態として使われます。指定した画像に近い画像が生成されます。",
+        "it_can_be_executed_by": "で実行できます。",  //this one might need better translation
+        "it_will_be_done_at": "で行います。方法については",
+        "japanese": "日本語",
+        "kendra_alert": "メッセージが入力されると Amazon Kendra でドキュメントを検索し、検索したドキュメントをもとに LLM が回答を生成します。",
+        "kendra_fetch": "Kendra から参照ドキュメントを取得中",
+        "kendra_if_you_only_want": "Amazon Kendra の検索のみを実行する場合は",
+        "kendra_rag_no_llm": "生成系 AI は利用していません。RAG は",
+        "kendra_search": "Kendra 検索",
+        "kendra_search_desc": "この機能は、Amazon Kendra の標準機能である Query API で検索を行います。",
+        "korean": "韓国語",
+        "lets_experience_gen_ai": "生成系 AI を体験してみましょう。",
+        "llm_model_name": "LLM モデル名",
+        "llm_model_regions": "LLM & 画像生成 モデルリージョン",
+        "llm_model_type": "LLM モデルタイプ",
+        "llm_prompt_template": "LLM プロンプトテンプレート",
+        "loading": "読み込み中",
+        "meeting_resume": "会話履歴",  // might need fixing
+        "negative_prompt": "ネガティブプロンプト",
+        "negative_prompt_help": "生成したくない要素、排除したい要素を記載してください。文章ではなく、単語の羅列で記載します。",
+        "no_indications": "指摘事項はありません",
+        "no_sentences_needed_example": "文章で書くことが難しい場合は、文章で書く必要はありません。「元気、ボール遊び、ジャンプしている」のように、特徴を羅列して指示をしましょう。",
+        "not_set": "未設定",
+        "please_enter": "入力してください",
+        "please_enter_search": "検索ワードを入力してください",
+        "please_refer_to_jp_pt1": "で行います。方法については",
+        "please_refer_to_jp_pt2": "をご参照ください。",
+        "prompts": "プロンプト",
+        "prompts_chat": "あなたはチャットでユーザを支援するAIアシスタントです。",
+        "prompts_editor": "あなたは丁寧に細かいところまで指摘する厳しい校閲担当者です。",
+        "prompts_editor_template_pt1": `inputの文章において誤字脱字は修正案を提示し、根拠やデータが不足している部分は具体的に指摘してください。
+            <input>
+        `,
+        "prompts_editor_template_pt2": "</input>",
+        "prompts_editor_template_pt3": "ただし、修正案や指摘は以下の <その他指摘してほしいこと></その他指摘してほしいこと>の xml タグで囲われたことを考慮してください。 <その他指摘してほしいこと>",
+        "prompts_editor_template_pt4": '</その他指摘してほしいこと>',
+        "prompts_editor_template_pt5": `出力は output-format 形式の JSON Array だけを <output></output> タグで囲って出力してください。
+        <output-format>
+        `,
+        "prompts_editor_template_pt6": `</output-format>
+            指摘事項がない場合は空配列を出力してください。「指摘事項はありません」「誤字脱字はありません」などの出力は一切不要です。
+        `,
+        "prompts_gen": "チャット形式でプロンプトの生成と設定、画像生成を自動で行います。",
+        "prompts_generator": "あなたは指示に従って文章を作成するライターです。",
+        "prompts_gen_error": "プロンプト生成中にエラーが発生しました。",
+        "prompts_image_generator": `あなたはStable Diffusionのプロンプトを生成するAIアシスタントです。
+            以下の step でStableDiffusionのプロンプトを生成してください。
+            
+            <step>
+            * rule を理解してください。ルールは必ず守ってください。例外はありません。
+            * ユーザは生成して欲しい画像の要件をチャットで指示します。チャットのやり取りを全て理解してください。
+            * チャットのやり取りから、生成して欲しい画像の特徴を正しく認識してください。
+            * 画像生成において重要な要素をから順にプロンプトに出力してください。ルールで指定された文言以外は一切出力してはいけません。例外はありません。
+            </step>
+            
+            <rule>
+            * プロンプトは output-format の通りに、JSON形式で出力してください。JSON以外の文字列は一切出力しないでください。JSONの前にも後にも出力禁止です。
+            * JSON形式以外の文言を出力することは一切禁止されています。挨拶、雑談、ルールの説明など一切禁止です。
+            * 出力するプロンプトがない場合は、promptとnegativePromptを空文字にして、commentにその理由を記載してください。
+            * プロンプトは単語単位で、カンマ区切りで出力してください。長文で出力しないでください。プロンプトは必ず英語で出力してください。
+            * プロンプトには以下の要素を含めてください。
+            * 画像のクオリティ、被写体の情報、衣装・ヘアスタイル・表情・アクセサリーなどの情報、画風に関する情報、背景に関する情報、構図に関する情報、ライティングやフィルタに関する情報
+            * 画像に含めたくない要素については、negativePromptとして出力してください。なお、negativePromptは必ず出力してください。
+            * フィルタリング対象になる不適切な要素は出力しないでください。
+            * comment は comment-rule の通りに出力してください。
+            * recommendedStylePreset は recommended-style-preset-rule の通りに出力してください。
+            </rule>
+            
+            <comment-rule>
+            * 必ず「画像を生成しました。続けて会話することで、画像を理想に近づけていくことができます。以下が改善案です。」という文言を先頭に記載してください。
+            * 箇条書きで3つ画像の改善案を提案してください。
+            * 改行は\\nを出力してください。
+            </comment-rule>
+            
+            <recommended-style-preset-rule>
+            * 生成した画像と相性の良いと思われるStylePresetを3つ提案してください。必ず配列で設定してください。
+            * StylePresetは、以下の種類があります。必ず以下のものを提案してください。
+            * 3d-model,analog-film,anime,cinematic,comic-book,digital-art,enhance,fantasy-art,isometric,line-art,low-poly,modeling-compound,neon-punk,origami,photographic,pixel-art,tile-texture
+            </recommended-style-preset-rule>
+            
+            <output-format>
+            {
+            prompt: string,
+            negativePrompt: string,
+            comment: string
+            recommendedStylePreset: string[]
+            }
+            </output-format>
+        `,
+        "prompts_rag_pt1": `あなたは、文書検索で利用するQueryを生成するAIアシスタントです。
+        以下の手順通りにQueryを生成してください。
+        
+        <Query生成の手順>
+        * 以下の<Query履歴>の内容を全て理解してください。履歴は古い順に並んでおり、一番下が最新のQueryです。
+        * 「要約して」などの質問ではないQueryは全て無視してください
+        * 「〜って何？」「〜とは？」「〜を説明して」というような概要を聞く質問については、「〜の概要」と読み替えてください。
+        * ユーザが最も知りたいことは、最も新しいQueryの内容です。最も新しいQueryの内容を元に、30トークン以内でQueryを生成してください。
+        * 出力したQueryに主語がない場合は、主語をつけてください。主語の置き換えは絶対にしないでください。
+        * 主語や背景を補完する場合は、「# Query履歴」の内容を元に補完してください。
+        * Queryは「〜について」「〜を教えてください」「〜について教えます」などの語尾は絶対に使わないでください
+        * 出力するQueryがない場合は、「No Query」と出力してください
+        * 出力は生成したQueryだけにしてください。他の文字列は一切出力してはいけません。例外はありません。
+        </Query生成の手順>
+        
+        <Query履歴>`,
+        "prompts_rag_pt2": "</Query履歴>",
+        "prompts_rag_pt3": `あなたはユーザの質問に答えるAIアシスタントです。
+        以下の手順でユーザの質問に答えてください。手順以外のことは絶対にしないでください。
+        
+        <回答手順>
+        * 「# 参考ドキュメント」に回答の参考となるドキュメントを設定しているので、それを全て理解してください。なお、この「# 参考ドキュメント」は「# 参考ドキュメントのJSON形式」のフォーマットで設定されています。
+        * 「# 回答のルール」を理解してください。このルールは絶対に守ってください。ルール以外のことは一切してはいけません。例外は一切ありません。
+        * チャットでユーザから質問が入力されるので、あなたは「# 参考ドキュメント」の内容をもとに「# 回答のルール」に従って回答を行なってください。
+        </回答手順>
+        
+        <参考ドキュメントのJSON形式>
+        {
+        "DocumentId": "ドキュメントを一意に特定するIDです。",
+        "DocumentTitle": "ドキュメントのタイトルです。",
+        "DocumentURI": "ドキュメントが格納されているURIです。",
+        "Content": "ドキュメントの内容です。こちらをもとに回答してください。",
+        }[]
+        </参考ドキュメントのJSON形式>
+        
+        <参考ドキュメント>
+        [`,
+        "prompts_rag_pt4": `]
+        </参考ドキュメント>
+        
+        <回答のルール>
+        * 雑談や挨拶には応じないでください。「私は雑談はできません。通常のチャット機能をご利用ください。」とだけ出力してください。他の文言は一切出力しないでください。例外はありません。
+        * 必ず<参考ドキュメント>をもとに回答してください。<参考ドキュメント>から読み取れないことは、絶対に回答しないでください。
+        * 回答の最後に、回答の参考にした「# 参考ドキュメント」を出力してください。「---\n#### 回答の参考ドキュメント」と見出しを出力して、ハイパーリンク形式でDocumentTitleとDocumentURIを出力してください。
+        * <参考ドキュメント>をもとに回答できない場合は、「回答に必要な情報が見つかりませんでした。」とだけ出力してください。例外はありません。
+        * 質問に具体性がなく回答できない場合は、質問の仕方をアドバイスしてください。
+        * 回答文以外の文字列は一切出力しないでください。回答はJSON形式ではなく、テキストで出力してください。見出しやタイトル等も必要ありません。
+        </回答のルール>`,
+        "prompts_summarize": "あなたは文章を要約するAIアシスタントです。最初のチャットで要約の指示を出すので、その後のチャットで要約結果の改善を行なってください。",
+        "prompts_summarizer_pt1": `
+            以下の <要約対象の文章></要約対象の文章> の xml タグで囲われた文章を要約してください。
+            <要約対象の文章>
+        `,
+        "prompts_summarizer_pt2": "</要約対象の文章>",
+        "prompts_summarizer_pt3": "",
+        "prompts_summarizer_pt4": `要約する際、以下の <要約時に考慮して欲しいこと></要約時に考慮して欲しいこと> の xml タグで囲われた内容を考慮してください。
+                <要約時に考慮して欲しいこと>
+        `,
+        "prompts_summarizer_pt5": "</要約時に考慮して欲しいこと>",
+        "prompts_summarizer_pt6":  `要約した文章だけを出力してください。それ以外の文章は一切出力しないでください。
+            出力は要約内容を <output></output> の xml タグで囲って出力してください。例外はありません。
+        `,
+        "prompts_text_gen_pt1": `<input>の情報から指示に従って文章を作成してください。指示された形式の文章のみを出力してください。それ以外の文言は一切出力してはいけません。例外はありません。
+        出力は<output></output>のxmlタグで囲んでください。
+        <input>`,
+        "prompts_text_gen_pt2": `</input>
+        <作成する文章の形式>
+        `,
+        "prompts_text_gen_pt3":"</作成する文章の形式>",
+        "prompts_translation_pt1": "<input></input>の xml タグで囲われた文章を",
+        "prompts_translation_pt2": `に翻訳してください。
+        翻訳した文章だけを出力してください。それ以外の文章は一切出力してはいけません。
+        <input>`,
+        "prompts_translation_pt3": "ただし、翻訳時に<考慮して欲しいこと></考慮して欲しいこと> の xml タグで囲われた内容を考慮してください。<考慮して欲しいこと>",
+        "prompts_translation_pt4": `出力は翻訳結果だけを <output></output> の xml タグで囲って出力してください。
+        それ以外の文章は一切出力してはいけません。例外はありません。`,
+        "prompts_translator": "あなたは文章の意図を汲み取り適切な翻訳を行う翻訳者です。",
+        "prompt_gen_complete": "プロンプト生成完了",
+        "rag_chat": "RAG チャット",
+        "rag_alert": "RAG (Retrieval Augmented Generation) 手法のチャットを行うことができます。",  // might need better translation
+        "rag_desc": "RAG (Retrieval Augmented Generation) は、情報の検索と LLM の文章生成を組み合わせる手法のことで、効果的な情報アクセスを実現できます。Amazon Kendra から取得した参考ドキュメントをベースに LLM が回答を生成してくれるため、「社内情報に対応した LLM チャット」を簡単に実現することが可能です。",
+        "rag_enabled": "RAG 有効",
+        "rerun": "再実行",
+        "seed_help": "乱数のシード値です。同じシード値を指定すると同じ画像が生成されます。",
+        "seed_button_text": "Seed をランダム設定",
+        "start_over": "最初からやり直す",
+        "settings": "設定情報",
+        "spanish": "スペイン語",
+        "step": "ステップ",
+        "sign_out": "サインアウト",
+        "summarize": "要約",
+        "summarize_desc": "LLM は、大量の文章を要約するタスクを得意としています。要約する際に「1行で」や「子供でもわかる言葉で」などコンテキストを与えることができます。",
+        "summarize_sentences": "要約したい文章",
+        "summarized_sentences": "要約された文章がここに表示されます",
+        "text_gen": "文章生成",
+        "text_gen_desc": "あらゆるコンテキストで文章を生成することは LLM が最も得意とするタスクの 1 つです。記事・レポート・メールなど、あらゆるコンテキストに対応します。",
+        "text_gen_display_label": "生成された文章がここに表示されます",
+        "text_gen_format": "文章の形式を指示してください。(マークダウン、ブログ、ビジネスメールなど)",
+        "text_gen_source": "入力してください",
+        "tips": "ヒント",
+        "tool": "ツール",  // this might need fixing.
+        "translation": "翻訳",
+        "translation_autodetect": "言語を自動検出",
+        "translation_desc": "多言語で学習した LLM は、翻訳を行うことも可能です。また、ただ翻訳するだけではなく、カジュアルさ・対象層など様々な指定されたコンテキスト情報を翻訳に反映させることが可能です。",
+        "translation_initial_greeting": "こんにちは。私は翻訳を支援する AI アシスタントです。お好きな文章を入力してください。",
+        "translation_sentences": "翻訳したい文章",
+        "upload_image": "画像をアップロード",
+        "use_case": "ユースケース", 
+        "use_case_list": "ユースケース一覧",
+        "use_case_if_error_pt1": "ユースケース実行時にエラーになる場合は、必ず",
+        "use_case_if_error_pt2": "にて",
+        "use_case_if_error_pt3": "(LLM) と",
+        "use_case_if_error_pt4": "(画像生成) を有効化しているか確認してください。有効化する方法については",
+        "use_case_if_error_pt5": "をご参照ください。"
+    }
+}


### PR DESCRIPTION
I'm an AWS Sr. SA working on gen AI projects and I've added  English support. Please feel free to review and pull to merge. It looked like you had some i18n settings and a list of supported languages, but it wasn't working for me and it was all in Japanese. I saw it might have been set up to have an auto translation library, but I'm new to i18n so I got it working manually with the Amplify I18n library and a dict to look up English and Japanese. I also replaced all the strings I could find with i18n lookups, and added English comments next to Japanese comments in the code.

I'm looking forward to customizing this stack for use with my customers. My next updates are to add OpenSearch and PgVector support.

I look forward to collaborating with you and contributing to this great project! :)
