### PR TITLE
#184 fix

### DIFF
--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -12,6 +12,12 @@ export class GenerativeAiUseCasesStack extends Stack {
     const selfSignUpEnabled: boolean =
       this.node.tryGetContext('selfSignUpEnabled')!;
 
+    if (typeof selfSignUpEnabled !== 'boolean') {
+      throw new Error(
+        'cdk.json の selfSignUpEnabled には true か false を設定してください。'
+      );
+    }
+
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,
     });


### PR DESCRIPTION
#184 
<!-- This is an auto-generated comment: release notes by AI reviewer -->
### Summary (generated)

 このプルリクエストは、CDK.jsonファイルのselfSignUpEnabledプロパティの型チェックを追加しています。新しいコードでは、selfSignUpEnabledがブール値ではない場合にエラーを投げるようになっています。この変更により、設定値の型が意図した通りになることを保証できるようになります。外部インターフェイスや動作への変更はありません。
<!-- end of auto-generated comment: release notes by AI reviewer -->