### PR TITLE
左カラムのメニューを expandable に

### DIFF
--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -5,8 +5,15 @@ import useDrawer from '../hooks/useDrawer';
 import useVersion from '../hooks/useVersion';
 import ButtonIcon from './ButtonIcon';
 import IconWithDot from './IconWithDot';
-import { PiSignOut, PiX, PiGithubLogo, PiGear } from 'react-icons/pi';
+import {
+  PiSignOut,
+  PiX,
+  PiGithubLogo,
+  PiGear,
+  PiBookOpen,
+} from 'react-icons/pi';
 import { ReactComponent as BedrockIcon } from '../assets/bedrock.svg';
+import ExpandableMenu from './ExpandableMenu';
 import ChatList from './ChatList';
 
 export type ItemProps = BaseProps & {
@@ -122,55 +129,60 @@ const Drawer: React.FC<Props> = (props) => {
         <div className="border-b" />
         {tools.length > 0 && (
           <>
-            <div className="text-aws-smile mx-3 my-2 text-xs">
-              ツール <span className="text-gray-400">(AIサービス)</span>
-            </div>
-            <div className="mb-1 ml-2 mr-1">
-              {tools.map((item, idx) => (
-                <Item
-                  key={idx}
-                  label={item.label}
-                  icon={item.icon}
-                  to={item.to}
-                  display={item.display}
-                />
-              ))}
-            </div>
+            <ExpandableMenu title="ツール" subTitle="(AIサービス)">
+              <div className="mb-2 ml-2 mr-1">
+                {tools.map((item, idx) => (
+                  <Item
+                    key={idx}
+                    label={item.label}
+                    icon={item.icon}
+                    to={item.to}
+                    display={item.display}
+                  />
+                ))}
+              </div>
+            </ExpandableMenu>
             <div className="border-b" />
           </>
         )}
-        <div className="text-aws-smile mx-3 my-2  text-xs">会話履歴</div>
-        <div className="scrollbar-thin scrollbar-thumb-white ml-2 mr-1 h-full overflow-y-auto">
-          <ChatList className="mr-1" />
-        </div>
+        <ExpandableMenu title="会話履歴">
+          <div className="scrollbar-thin scrollbar-thumb-white ml-2 mr-1 h-full overflow-y-auto">
+            <ChatList className="mr-1" />
+          </div>
+        </ExpandableMenu>
         <div className="border-b" />
-        <div className="mb-2">
-          <div className="text-aws-smile mx-3 my-2 text-xs">リンク</div>
-
-          <RefLink
-            to="https://aws.amazon.com/jp/bedrock/"
-            icon={<BedrockIcon className="w-4 fill-white" />}
-            label="Bedrock"
-          />
-          <RefLink
-            to="https://github.com/aws-samples/generative-ai-use-cases-jp"
-            icon={<PiGithubLogo className="text-base" />}
-            label="GitHub"
-          />
-        </div>
-        <div className="flex justify-between border-t border-gray-400 px-1 py-2">
+        <ExpandableMenu title="リンク" defaultOpened={false}>
+          <div className="mb-2 ml-2">
+            <RefLink
+              to="https://aws.amazon.com/jp/bedrock/"
+              icon={<BedrockIcon className="w-4 fill-white" />}
+              label="Bedrock"
+            />
+            <RefLink
+              to="https://github.com/aws-samples/generative-ai-use-cases-jp"
+              icon={<PiGithubLogo className="text-base" />}
+              label="GitHub"
+            />
+            <RefLink
+              to="https://docs.anthropic.com/claude/docs"
+              icon={<PiBookOpen className="text-base" />}
+              label="Claude Prompt Engineering"
+            />
+          </div>
+        </ExpandableMenu>
+        <div className="flex justify-between border-t border-gray-400 px-3 py-2">
           <ButtonIcon
             onClick={() => {
               navigate('/setting');
             }}>
-            <IconWithDot showDot={hasUpdate} className="mr-1">
-              <PiGear className="text-base" />
+            <IconWithDot showDot={hasUpdate} className="mr-2">
+              <PiGear className="text-sm" />
             </IconWithDot>
-            <span className="ml-1 text-sm">設定情報</span>
+            <span className="text-sm">設定情報</span>
           </ButtonIcon>
           <ButtonIcon onClick={props.signOut}>
-            <PiSignOut className="mr-1 text-base" />
-            <span className="ml-1 text-sm">サインアウト</span>
+            <PiSignOut className="mr-1 text-sm" />
+            <span className="text-sm">サインアウト</span>
           </ButtonIcon>
         </div>
       </nav>

--- a/packages/web/src/components/ExpandableField.tsx
+++ b/packages/web/src/components/ExpandableField.tsx
@@ -9,7 +9,7 @@ type Props = RowItemProps & {
   children: React.ReactNode;
 };
 
-const ExpandedField: React.FC<Props> = (props) => {
+const ExpandableField: React.FC<Props> = (props) => {
   const [expanded, setExpanded] = useState(props.defaultOpened ?? false);
 
   return (
@@ -34,4 +34,4 @@ const ExpandedField: React.FC<Props> = (props) => {
   );
 };
 
-export default ExpandedField;
+export default ExpandableField;

--- a/packages/web/src/components/ExpandableField.tsx
+++ b/packages/web/src/components/ExpandableField.tsx
@@ -19,7 +19,7 @@ const ExpandableField: React.FC<Props> = (props) => {
         onClick={() => {
           setExpanded(!expanded);
         }}>
-        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} `} />
+        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} transition`} />
         {props.label}
         {props.optional && (
           <>

--- a/packages/web/src/components/ExpandableField.tsx
+++ b/packages/web/src/components/ExpandableField.tsx
@@ -19,7 +19,9 @@ const ExpandableField: React.FC<Props> = (props) => {
         onClick={() => {
           setExpanded(!expanded);
         }}>
-        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} transition`} />
+        <PiCaretRightFill
+          className={`mr-1 ${expanded && 'rotate-90'} transition`}
+        />
         {props.label}
         {props.optional && (
           <>

--- a/packages/web/src/components/ExpandableMenu.tsx
+++ b/packages/web/src/components/ExpandableMenu.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { BaseProps } from '../@types/common';
+import { PiCaretRightFill } from 'react-icons/pi';
+
+type Props = BaseProps & {
+  title: string;
+  subTitle?: string;
+  children: React.ReactNode;
+  defaultOpened?: boolean;
+};
+
+const ExpandableMenu: React.FC<Props> = (props) => {
+  const [expanded, setExpanded] = useState(props.defaultOpened ?? true);
+
+  return (
+    <>
+      <div
+        className="text-aws-smile mx-3 my-2 flex cursor-pointer text-xs"
+        onClick={() => {
+          setExpanded(!expanded);
+        }}>
+        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} `} />
+        <span className="mr-1">{props.title}</span>
+        {props.subTitle && (
+          <span className="text-gray-400">{props.subTitle}</span>
+        )}
+      </div>
+
+      {expanded && <>{props.children}</>}
+    </>
+  );
+};
+
+export default ExpandableMenu;

--- a/packages/web/src/components/ExpandableMenu.tsx
+++ b/packages/web/src/components/ExpandableMenu.tsx
@@ -15,11 +15,11 @@ const ExpandableMenu: React.FC<Props> = (props) => {
   return (
     <>
       <div
-        className="text-aws-smile mx-3 my-2 flex cursor-pointer text-xs"
+        className="text-aws-smile mx-3 my-2 flex items-center cursor-pointer text-xs"
         onClick={() => {
           setExpanded(!expanded);
         }}>
-        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} `} />
+        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} transition`} />
         <span className="mr-1">{props.title}</span>
         {props.subTitle && (
           <span className="text-gray-400">{props.subTitle}</span>

--- a/packages/web/src/components/ExpandableMenu.tsx
+++ b/packages/web/src/components/ExpandableMenu.tsx
@@ -15,11 +15,13 @@ const ExpandableMenu: React.FC<Props> = (props) => {
   return (
     <>
       <div
-        className="text-aws-smile mx-3 my-2 flex items-center cursor-pointer text-xs"
+        className="text-aws-smile mx-3 my-2 flex cursor-pointer items-center text-xs"
         onClick={() => {
           setExpanded(!expanded);
         }}>
-        <PiCaretRightFill className={`mr-1 ${expanded && 'rotate-90'} transition`} />
+        <PiCaretRightFill
+          className={`mr-1 ${expanded && 'rotate-90'} transition`}
+        />
         <span className="mr-1">{props.title}</span>
         {props.subTitle && (
           <span className="text-gray-400">{props.subTitle}</span>

--- a/packages/web/src/pages/EditorialPage.tsx
+++ b/packages/web/src/pages/EditorialPage.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import Card from '../components/Card';
 import Button from '../components/Button';
 import Textarea from '../components/Textarea';
-import ExpandedField from '../components/ExpandedField';
+import ExpandableField from '../components/ExpandableField';
 import useChat from '../hooks/useChat';
 import { create } from 'zustand';
 import Texteditor from '../components/TextEditor';
@@ -239,13 +239,13 @@ const EditorialPage: React.FC = () => {
             removeComment={removeComment}
           />
 
-          <ExpandedField label="追加コンテキスト" optional>
+          <ExpandableField label="追加コンテキスト" optional>
             <Textarea
               placeholder="追加で指摘してほしい点を入力することができます"
               value={additionalContext}
               onChange={setAdditionalContext}
             />
-          </ExpandedField>
+          </ExpandableField>
 
           <div className="flex justify-end gap-3">
             <Button outlined onClick={onClickClear} disabled={disabledExec}>

--- a/packages/web/src/pages/SummarizePage.tsx
+++ b/packages/web/src/pages/SummarizePage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import Card from '../components/Card';
 import Button from '../components/Button';
-import ExpandedField from '../components/ExpandedField';
+import ExpandableField from '../components/ExpandableField';
 import Textarea from '../components/Textarea';
 import Markdown from '../components/Markdown';
 import ButtonCopy from '../components/ButtonCopy';
@@ -124,13 +124,13 @@ const SummarizePage: React.FC = () => {
             maxHeight={-1}
           />
 
-          <ExpandedField label="追加コンテキスト" optional>
+          <ExpandableField label="追加コンテキスト" optional>
             <Textarea
               placeholder="追加で考慮してほしい点を入力することができます（カジュアルさ等）"
               value={additionalContext}
               onChange={setAdditionalContext}
             />
-          </ExpandedField>
+          </ExpandableField>
 
           <div className="flex justify-end gap-3">
             <Button outlined onClick={onClickClear} disabled={disabledExec}>

--- a/packages/web/src/pages/TranslatePage.tsx
+++ b/packages/web/src/pages/TranslatePage.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import Card from '../components/Card';
 import Button from '../components/Button';
 import Textarea from '../components/Textarea';
-import ExpandedField from '../components/ExpandedField';
+import ExpandableField from '../components/ExpandableField';
 import MenuDropdown from '../components/MenuDropdown';
 import MenuItem from '../components/MenuItem';
 import Markdown from '../components/Markdown';
@@ -219,13 +219,13 @@ const TranslatePage: React.FC = () => {
             </div>
           </div>
 
-          <ExpandedField label="追加コンテキスト" optional>
+          <ExpandableField label="追加コンテキスト" optional>
             <Textarea
               placeholder="追加で考慮してほしい点を入力することができます（カジュアルさ等）"
               value={additionalContext}
               onChange={setAdditionalContext}
             />
-          </ExpandedField>
+          </ExpandableField>
 
           <div className="flex justify-end gap-3">
             <Button outlined onClick={onClickClear} disabled={disabledExec}>


### PR DESCRIPTION
- https://github.com/aws-samples/generative-ai-use-cases-jp/issues/188
- https://github.com/aws-samples/generative-ai-use-cases-jp/issues/183

リンクだけデフォルトで閉じているようにしました
ExpandedField を継承しようと思いましたが、label や RowItem などの仕様と合わせるのが厳しく別にコンポーネントを作成しました
ExpandedField を ExpandableMenu に合わせて rename しました



<!-- This is an auto-generated comment: release notes by AI reviewer -->
### Summary (generated)

 <summary>

左カラムのメニューを展開可能な形式に変更しました。

Drawer、ExpandableField、各ページコンポーネントを修正して展開動作を実装。

新規にExpandableMenuコンポーネントを作成し、展開メニューの再利用性を高めました。

</summary>
<!-- end of auto-generated comment: release notes by AI reviewer -->