### PR TITLE
会話履歴の簡易検索機能

### DIFF
--- a/packages/web/src/components/ChatList.tsx
+++ b/packages/web/src/components/ChatList.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { BaseProps } from '../@types/common';
 import useConversation from '../hooks/useConversation';
 import { useNavigate, useParams } from 'react-router-dom';
 import ChatListItem from './ChatListItem';
 import { decomposeChatId } from '../utils/ChatUtils';
 
-type Props = BaseProps;
+type Props = BaseProps & {
+  searchWords: string[];
+};
 
 const ChatList: React.FC<Props> = (props) => {
   const {
@@ -34,6 +36,19 @@ const ChatList: React.FC<Props> = (props) => {
     [updateConversationTitle]
   );
 
+  const searchedConversations = useMemo(() => {
+    if (props.searchWords.length === 0) {
+      return conversations;
+    }
+
+    // OR 検索にしています
+    return conversations.filter((c) => {
+      return props.searchWords.some((w) =>
+        c.title.toLowerCase().includes(w.toLowerCase())
+      );
+    });
+  }, [props.searchWords, conversations]);
+
   return (
     <>
       <div
@@ -48,7 +63,7 @@ const ChatList: React.FC<Props> = (props) => {
                 key={idx}
                 className="bg-aws-sky/20 h-8 w-full animate-pulse rounded"></div>
             ))}
-        {conversations.map((chat) => {
+        {searchedConversations.map((chat) => {
           const _chatId = decomposeChatId(chat.chatId);
           return (
             <ChatListItem
@@ -58,6 +73,7 @@ const ChatList: React.FC<Props> = (props) => {
               chat={chat}
               onDelete={onDelete}
               onUpdateTitle={onUpdateTitle}
+              highlightWords={props.searchWords}
             />
           );
         })}

--- a/packages/web/src/components/ChatListItem.tsx
+++ b/packages/web/src/components/ChatListItem.tsx
@@ -13,6 +13,7 @@ import ButtonIcon from './ButtonIcon';
 import { Chat } from 'generative-ai-use-cases-jp';
 import { decomposeChatId } from '../utils/ChatUtils';
 import DialogConfirmDeleteChat from './DialogConfirmDeleteChat';
+import HighlightWithinTextarea from 'react-highlight-within-textarea';
 
 type Props = BaseProps & {
   active: boolean;
@@ -21,6 +22,7 @@ type Props = BaseProps & {
   onDelete: (chatId: string) => Promise<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onUpdateTitle: (chatId: string, title: string) => Promise<any>;
+  highlightWords: string[];
 };
 
 const ChatListItem: React.FC<Props> = (props) => {
@@ -74,6 +76,15 @@ const ChatListItem: React.FC<Props> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editing]);
 
+  const highlight = useMemo(() => {
+    return props.highlightWords.map((w) => {
+      return {
+        highlight: w,
+        className: 'text-aws-smile bg-inherit',
+      };
+    });
+  }, [props.highlightWords]);
+
   return (
     <>
       {openDialog && (
@@ -112,7 +123,11 @@ const ChatListItem: React.FC<Props> = (props) => {
                 }}
               />
             ) : (
-              <>{props.chat.title}</>
+              <HighlightWithinTextarea
+                value={props.chat.title}
+                highlight={highlight}
+                readOnly
+              />
             )}
             {!editing && (
               <div

--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -160,6 +160,7 @@ const Drawer: React.FC<Props> = (props) => {
               className="bg-aws-squid-ink h-7 w-full rounded-full border border-white pl-8 text-sm text-white focus:border-white focus:ring-0"
               type="text"
               value={searchQuery}
+              placeholder="件名で検索"
               onChange={(event) => {
                 setSearchQuery(event.target.value ?? '');
               }}

--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { BaseProps } from '../@types/common';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import useDrawer from '../hooks/useDrawer';
@@ -11,6 +11,7 @@ import {
   PiGithubLogo,
   PiGear,
   PiBookOpen,
+  PiMagnifyingGlass,
 } from 'react-icons/pi';
 import { ReactComponent as BedrockIcon } from '../assets/bedrock.svg';
 import ExpandableMenu from './ExpandableMenu';
@@ -106,6 +107,14 @@ const Drawer: React.FC<Props> = (props) => {
     return props.items.filter((i) => i.display === 'tool');
   }, [props.items]);
 
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchWords = useMemo(() => {
+    return searchQuery
+      .split(' ')
+      .flatMap((q) => q.split('　'))
+      .filter((q) => q !== '');
+  }, [searchQuery]);
+
   return (
     <>
       <nav
@@ -146,8 +155,19 @@ const Drawer: React.FC<Props> = (props) => {
           </>
         )}
         <ExpandableMenu title="会話履歴">
+          <div className="relative mb-2 ml-2 mr-1 w-full pl-1.5 pr-7 pt-1">
+            <input
+              className="bg-aws-squid-ink h-7 w-full rounded-full border border-white pl-8 text-sm text-white focus:border-white focus:ring-0"
+              type="text"
+              value={searchQuery}
+              onChange={(event) => {
+                setSearchQuery(event.target.value ?? '');
+              }}
+            />
+            <PiMagnifyingGlass className="bg-aws-squid-ink absolute left-1.5 top-1 h-7 w-7 rounded-l-full border border-white p-1.5" />
+          </div>
           <div className="scrollbar-thin scrollbar-thumb-white ml-2 mr-1 h-full overflow-y-auto">
-            <ChatList className="mr-1" />
+            <ChatList className="mr-1" searchWords={searchWords} />
           </div>
         </ExpandableMenu>
         <div className="border-b" />

--- a/packages/web/src/components/TextEditor.tsx
+++ b/packages/web/src/components/TextEditor.tsx
@@ -38,7 +38,12 @@ const Texteditor: React.FC<Props> = (props) => {
           <HighlightWithinTextarea
             placeholder={props.placeholder}
             value={props.value}
-            highlight={props.comments?.map((comment) => comment.excerpt)}
+            highlight={props.comments?.map((comment) => {
+              return {
+                highlight: comment.excerpt,
+                className: 'text-aws-smile bg-inherit',
+              };
+            })}
             onChange={(value) => {
               props.onChange(value);
             }}


### PR DESCRIPTION
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/194

<!-- This is an auto-generated comment: release notes by AI reviewer -->
### Summary (generated)

 <summary>
<changeSet>

---
packages/web/src/components/ChatList.tsx
packages/web/src/components/ChatListItem.tsx  
packages/web/src/components/Drawer.tsx:
会話履歴一覧にキーワード検索機能を追加しました。stateフックとuseMemoフックで入力キーワードに基づき会話履歴をフィルタリングしています。また、検索語にマッチする部分をハイライト表示するコンポーネントを導入しました。インターフェイスや動作への影響はありません。

---
packages/web/src/components/TextEditor.tsx:  
会話履歴内のコメントにキーワード検索機能を追加しました。要約文にクラス名を付与して検索語にマッチする部分をハイライト表示できるようにしました。これによりユーザーはコメントを簡単に検索できるようになります。インターフェイスや動作への影響はありません。

</changeSet> 
</summary>
<!-- end of auto-generated comment: release notes by AI reviewer -->