### PR TITLE
既存の Kendra Index を利用する

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Sync run history の Status / Summary に Completed が表示されれば完了�
 - デプロイのオプション
   - [Amazon Bedrock の違うモデル・リージョンを利用したい場合](/docs/BEDROCK.md)
   - [Amazon SageMaker を利用したい場合](/docs/SAGEMAKER.md)
+  - [既存の Amazon Kendra Index を利用したい場合](/docs/KENDRA.md)
   - [セキュリティ関連](/docs/SECURITY.md)
 - 開発
   - [ローカル開発環境構築手順](/docs/DEVELOPMENT.md)

--- a/docs/KENDRA.md
+++ b/docs/KENDRA.md
@@ -1,0 +1,29 @@
+# 既存の Amazon Kendra Index を利用したい場合
+
+> 既存の Amazon Kendra Index を利用する場合も、`packages/cdk/cdk.json` の `ragEnabled` は `true` である必要があります。
+
+既存の Amazon Kendra Index を利用する場合、`packages/cdk/cdk.json` の `kendraArn` に Index の ARN を指定します。
+
+ARN は以下のような形式です。(`<>` で囲まれた箇所は置き換えが必要です。)
+
+```
+arn:aws:kendra:<Region>:<AWS Account ID>:index/<Index ID>
+```
+
+具体的には以下のような文字列です。
+
+```
+arn:aws:kendra:ap-northeast-1:333333333333:index/77777777-3333-4444-aaaa-111111111111
+```
+
+ARN を `packages/cdk/cdk.json` に設定した後、以下のコマンドでデプロイして反映させます。
+
+```bash
+npm run cdk:deploy
+```
+
+あるいは、`packages/cdk/cdk.json` の値は変更せず、デプロイ時に `-c` オプションで指定することも可能です。
+
+```bash
+npm run cdk:deploy -- -c kendraArn=arn:aws:kendra:<Region>:<AWS Account ID>:index/<Index ID>
+```

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -18,6 +18,7 @@
   },
   "context": {
     "ragEnabled": false,
+    "kendraArn": null,
     "selfSignUpEnabled": true,
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,


### PR DESCRIPTION
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/170

- [x] 既存のものを指定した場合も正常に動作することは確認できています。
- [x] null を指定した場合に新規で index と datasource が作成されることも確認できています。