### PR TITLE
add functions to check emal domain of signup user

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ npm run cdk:deploy
   - [ELYZA-japanese-Llama-2-7b-instruct を利用する例](/docs/DEPLOY_OPTION.md#elyza-japanese-llama-2-7b-instruct-を利用する例)
 - [セキュリティ関連設定](/docs/DEPLOY_OPTION.md#セキュリティ関連設定)
   - [セルフサインアップを無効化する](/docs/DEPLOY_OPTION.md#セルフサインアップを無効化する)
+  - [サインアップできるメールアドレスのドメインを制限する](/docs/DEPLOY_OPTION.md#サインアップできるメールアドレスのドメインを制限する)
   - [AWS WAF による IP 制限を有効化する](/docs/DEPLOY_OPTION.md#aws-waf-による-ip-制限を有効化する)
 
 ## その他

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -149,7 +149,7 @@ context の `selfSignUpEnabled` に `false` を指定します。(デフォル�
 ```
 
 ### サインアップできるメールアドレスのドメインを制限する
-context の allowedSingUpEmailDomains に 許可するドメインのリストを指定します（デフォルトは`null`）。
+context の allowedSignUpEmailDomains に 許可するドメインのリストを指定します（デフォルトは`null`）。
 
 値はstringのlist形式で指定し、各stringには"@"を含めないでください。メールアドレスのドメインが、許可ドメインのいずれか同じであればサインアップできます。`null` を指定すると何も制限されず、すべてのドメインを許可します。`[]` を指定するとすべて禁止し、どのドメインのメールアドレスでも登録できません。
 
@@ -167,7 +167,7 @@ context の allowedSingUpEmailDomains に 許可するドメインのリスト�
 ```json
 {
   "context": {
-    "allowedSingUpEmailDomains": ["amazon.com"], // null から、許可ドメインを指定することで有効化
+    "allowedSignUpEmailDomains": ["amazon.com"], // null から、許可ドメインを指定することで有効化
   }
 }
 ```
@@ -177,7 +177,7 @@ context の allowedSingUpEmailDomains に 許可するドメインのリスト�
 ```json
 {
   "context": {
-    "allowedSingUpEmailDomains": ["amazon.com", "amazon.jp"], // null から、許可ドメインを指定することで有効化
+    "allowedSignUpEmailDomains": ["amazon.com", "amazon.jp"], // null から、許可ドメインを指定することで有効化
   }
 }
 ```

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -148,6 +148,40 @@ context の `selfSignUpEnabled` に `false` を指定します。(デフォル�
 }
 ```
 
+### サインアップできるメールアドレスのドメインを制限する
+context の allowedSingUpEmailDomains に 許可するドメインのリストを指定します（デフォルトは`null`）。
+
+値はstringのlist形式で指定し、各stringには"@"を含めないでください。メールアドレスのドメインが、許可ドメインのいずれか同じであればサインアップできます。`null` を指定すると何も制限されず、すべてのドメインを許可します。`[]` を指定するとすべて禁止し、どのドメインのメールアドレスでも登録できません。
+
+設定すると、許可ドメインでないユーザは、Webのサインアップ画面で「アカウントを作る」を実行したときにエラーになり、サービスに進むことができなくなります。また、AWSマネジメントコンソールで、Cognitoのページで「ユーザを作成」を実行したときにエラーになります。
+
+既にCognitoに作成されているユーザには影響ありません。新規にサインアップ・作成しようとしているユーザのみに適用されます。
+
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+
+設定例
+
+- `amazon.com` のドメインのメールアドレスであればサインアップできるように設定する例
+
+```json
+{
+  "context": {
+    "allowedSingUpEmailDomains": ["amazon.com"], // null から、許可ドメインを指定することで有効化
+  }
+}
+```
+
+- `amazon.com` か `amazon.jp` のどちらかのドメインのメールアドレスであればサインアップできるように設定する例
+
+```json
+{
+  "context": {
+    "allowedSingUpEmailDomains": ["amazon.com", "amazon.jp"], // null から、許可ドメインを指定することで有効化
+  }
+}
+```
+
 ### AWS WAF による IP 制限を有効化する
 
 Web ページへのアクセスを IP で制限したい場合、AWS WAF による IP 制限を有効化することができます。[packages/cdk/cdk.json](/packages/cdk/cdk.json) の `allowedIpV4AddressRanges` では許可する IPv4 の CIDR を配列で指定することができ、`allowedIpV6AddressRanges` では許可する IPv6 の CIDR を配列で指定することができます。

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -20,6 +20,7 @@
     "ragEnabled": false,
     "kendraIndexArn": null,
     "selfSignUpEnabled": true,
+    "allowedSingUpEmailDomains": null, 
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -20,7 +20,7 @@
     "ragEnabled": false,
     "kendraIndexArn": null,
     "selfSignUpEnabled": true,
-    "allowedSingUpEmailDomains": null, 
+    "allowedSignUpEmailDomains": null, 
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,

--- a/packages/cdk/lambda/checkEmailDomain.ts
+++ b/packages/cdk/lambda/checkEmailDomain.ts
@@ -1,10 +1,10 @@
 import { PreSignUpTriggerEvent, Context, Callback } from 'aws-lambda';
 
-const ALLOWED_SING_UP_EMAIL_DOMAINS_STR =
-  process.env.ALLOWED_SING_UP_EMAIL_DOMAINS_STR;
-const ALLOWED_SING_UP_EMAIL_DOMAINS: string[] =
-  ALLOWED_SING_UP_EMAIL_DOMAINS_STR
-    ? JSON.parse(ALLOWED_SING_UP_EMAIL_DOMAINS_STR)
+const ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR =
+  process.env.ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR;
+const ALLOWED_SIGN_UP_EMAIL_DOMAINS: string[] =
+  ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR
+    ? JSON.parse(ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR)
     : []; // 環境変数で設定されていない場合は、空の配列を設定しどのドメインも許可しない
 
 // メールアドレスのドメインを許可するかどうかを判定する
@@ -16,9 +16,9 @@ const checkEmailDomain = (email: string): boolean => {
 
   // メールアドレスのドメイン部分が、許可ドメインの"いずれか"と一致すれば許可する
   // それ以外の場合は、許可しない
-  // (ALLOWED_SING_UP_EMAIL_DOMAINSが空の場合は、常に許可しない)
+  // (ALLOWED_SIGN_UP_EMAIL_DOMAINSが空の場合は、常に許可しない)
   const domain = email.split('@')[1];
-  return ALLOWED_SING_UP_EMAIL_DOMAINS.includes(domain);
+  return ALLOWED_SIGN_UP_EMAIL_DOMAINS.includes(domain);
 };
 
 /**

--- a/packages/cdk/lambda/checkEmailDomain.ts
+++ b/packages/cdk/lambda/checkEmailDomain.ts
@@ -1,0 +1,57 @@
+import { PreSignUpTriggerEvent, Context, Callback } from 'aws-lambda';
+
+const ALLOWED_SING_UP_EMAIL_DOMAINS_STR =
+  process.env.ALLOWED_SING_UP_EMAIL_DOMAINS_STR;
+const ALLOWED_SING_UP_EMAIL_DOMAINS: string[] =
+  ALLOWED_SING_UP_EMAIL_DOMAINS_STR
+    ? JSON.parse(ALLOWED_SING_UP_EMAIL_DOMAINS_STR)
+    : []; // 環境変数で設定されていない場合は、空の配列を設定しどのドメインも許可しない
+
+// メールアドレスのドメインを許可するかどうかを判定する
+const checkEmailDomain = (email: string): boolean => {
+  // メールアドレスの中の @ の数が1つでない場合は、常に許可しない
+  if (email.split('@').length !== 2) {
+    return false;
+  }
+
+  // メールアドレスのドメイン部分が、許可ドメインの"いずれか"と一致すれば許可する
+  // それ以外の場合は、許可しない
+  // (ALLOWED_SING_UP_EMAIL_DOMAINSが空の場合は、常に許可しない)
+  const domain = email.split('@')[1];
+  return ALLOWED_SING_UP_EMAIL_DOMAINS.includes(domain);
+};
+
+/**
+ * Cognito Pre Sign-up Lambda Trigger.
+ *
+ * @param event - The event from Cognito.
+ * @param context - The Lambda execution context.
+ * @param callback - The callback function to return data or error.
+ */
+exports.handler = async (
+  event: PreSignUpTriggerEvent,
+  context: Context,
+  callback: Callback
+) => {
+  try {
+    console.log('Received event:', JSON.stringify(event, null, 2));
+
+    const isAllowed = checkEmailDomain(event.request.userAttributes.email);
+    if (isAllowed) {
+      // 成功した場合、イベントオブジェクトをそのまま返す
+      callback(null, event);
+    } else {
+      // 失敗した場合、エラーメッセージを返す
+      callback(new Error('Invalid email domain'));
+    }
+  } catch (error) {
+    console.log('Error ocurred:', error);
+    // エラーがError型であるか確認し、適切なエラーメッセージを返す
+    if (error instanceof Error) {
+      callback(error);
+    } else {
+      // エラーがError型ではない場合、一般的なエラーメッセージを返す
+      callback(new Error('An unknown error occurred.'));
+    }
+  }
+};

--- a/packages/cdk/lambda/checkEmailDomain.ts
+++ b/packages/cdk/lambda/checkEmailDomain.ts
@@ -2,10 +2,9 @@ import { PreSignUpTriggerEvent, Context, Callback } from 'aws-lambda';
 
 const ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR =
   process.env.ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR;
-const ALLOWED_SIGN_UP_EMAIL_DOMAINS: string[] =
-  ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR
-    ? JSON.parse(ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR)
-    : []; // 環境変数で設定されていない場合は、空の配列を設定しどのドメインも許可しない
+const ALLOWED_SIGN_UP_EMAIL_DOMAINS: string[] = JSON.parse(
+  ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR!
+);
 
 // メールアドレスのドメインを許可するかどうかを判定する
 const checkEmailDomain = (email: string): boolean => {

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -14,7 +14,7 @@ import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 
 export interface AuthProps {
   selfSignUpEnabled: boolean;
-  allowedSignUpEmailDomains: string[] | null;
+  allowedSignUpEmailDomains: string[] | null | undefined;
 }
 
 export class Auth extends Construct {
@@ -55,22 +55,22 @@ export class Auth extends Construct {
     });
 
     // Lambda
-    const checkEmailDomainFunction = new NodejsFunction(
-      this,
-      'CheckEmailDomain',
-      {
-        runtime: Runtime.NODEJS_18_X,
-        entry: './lambda/checkEmailDomain.ts',
-        timeout: Duration.minutes(15),
-        environment: {
-          ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR: JSON.stringify(
-            props.allowedSignUpEmailDomains
-          ),
-        },
-      }
-    );
+    if (!(props.allowedSignUpEmailDomains === undefined || props.allowedSignUpEmailDomains === null)) {
+      const checkEmailDomainFunction = new NodejsFunction(
+        this,
+        'CheckEmailDomain',
+        {
+          runtime: Runtime.NODEJS_18_X,
+          entry: './lambda/checkEmailDomain.ts',
+          timeout: Duration.minutes(15),
+          environment: {
+            ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR: JSON.stringify(
+              props.allowedSignUpEmailDomains
+            ),
+          },
+        }
+      );
 
-    if (props.allowedSignUpEmailDomains !== null) {
       userPool.addTrigger(
         UserPoolOperation.PRE_SIGN_UP,
         checkEmailDomainFunction

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -55,7 +55,7 @@ export class Auth extends Construct {
     });
 
     // Lambda
-    if (!(props.allowedSignUpEmailDomains === undefined || props.allowedSignUpEmailDomains === null)) {
+    if (props.allowedSignUpEmailDomains) {
       const checkEmailDomainFunction = new NodejsFunction(
         this,
         'CheckEmailDomain',

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -21,7 +21,6 @@ export class Auth extends Construct {
   readonly userPool: UserPool;
   readonly client: UserPoolClient;
   readonly idPool: IdentityPool;
-  readonly checkEmailDomainFunction: NodejsFunction;
 
   constructor(scope: Construct, id: string, props: AuthProps) {
     super(scope, id);
@@ -81,6 +80,5 @@ export class Auth extends Construct {
     this.client = client;
     this.userPool = userPool;
     this.idPool = idPool;
-    this.checkEmailDomainFunction = checkEmailDomainFunction;
   }
 }

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -14,7 +14,7 @@ import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 
 export interface AuthProps {
   selfSignUpEnabled: boolean;
-  allowedSingUpEmailDomains: string[] | null;
+  allowedSignUpEmailDomains: string[] | null;
 }
 
 export class Auth extends Construct {
@@ -64,14 +64,14 @@ export class Auth extends Construct {
         entry: './lambda/checkEmailDomain.ts',
         timeout: Duration.minutes(15),
         environment: {
-          ALLOWED_SING_UP_EMAIL_DOMAINS_STR: JSON.stringify(
-            props.allowedSingUpEmailDomains
+          ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR: JSON.stringify(
+            props.allowedSignUpEmailDomains
           ),
         },
       }
     );
 
-    if (props.allowedSingUpEmailDomains !== null) {
+    if (props.allowedSignUpEmailDomains !== null) {
       userPool.addTrigger(
         UserPoolOperation.PRE_SIGN_UP,
         checkEmailDomainFunction

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -26,7 +26,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     const ragEnabled: boolean = this.node.tryGetContext('ragEnabled')!;
     const selfSignUpEnabled: boolean =
       this.node.tryGetContext('selfSignUpEnabled')!;
-    const allowedSignUpEmailDomains: string[] | null = this.node.tryGetContext(
+    const allowedSignUpEmailDomains: string[] | null | undefined = this.node.tryGetContext(
       'allowedSignUpEmailDomains'
     );
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -26,11 +26,11 @@ export class GenerativeAiUseCasesStack extends Stack {
     const ragEnabled: boolean = this.node.tryGetContext('ragEnabled')!;
     const selfSignUpEnabled: boolean =
       this.node.tryGetContext('selfSignUpEnabled')!;
-    const allowedSingUpEmailDomains: string[] | null = this.node.tryGetContext(
-      'allowedSingUpEmailDomains'
+    const allowedSignUpEmailDomains: string[] | null = this.node.tryGetContext(
+      'allowedSignUpEmailDomains'
     );
 
-    console.log(allowedSingUpEmailDomains);
+    console.log(allowedSignUpEmailDomains);
 
     if (typeof ragEnabled !== 'boolean') {
       throw new Error(errorMessageForBooleanContext('ragEnabled'));
@@ -42,7 +42,7 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,
-      allowedSingUpEmailDomains,
+      allowedSignUpEmailDomains,
     });
     const database = new Database(this, 'Database');
     const api = new Api(this, 'API', {

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -26,6 +26,11 @@ export class GenerativeAiUseCasesStack extends Stack {
     const ragEnabled: boolean = this.node.tryGetContext('ragEnabled')!;
     const selfSignUpEnabled: boolean =
       this.node.tryGetContext('selfSignUpEnabled')!;
+    const allowedSingUpEmailDomains: string[] | null = this.node.tryGetContext(
+      'allowedSingUpEmailDomains'
+    );
+
+    console.log(allowedSingUpEmailDomains);
 
     if (typeof ragEnabled !== 'boolean') {
       throw new Error(errorMessageForBooleanContext('ragEnabled'));
@@ -37,6 +42,7 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,
+      allowedSingUpEmailDomains,
     });
     const database = new Database(this, 'Database');
     const api = new Api(this, 'API', {

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -30,8 +30,6 @@ export class GenerativeAiUseCasesStack extends Stack {
       'allowedSignUpEmailDomains'
     );
 
-    console.log(allowedSignUpEmailDomains);
-
     if (typeof ragEnabled !== 'boolean') {
       throw new Error(errorMessageForBooleanContext('ragEnabled'));
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

ユーザの登録時にメールアドレスを制限できる機能を作成しました。こうしたプルリクを送るようなことが不慣れなため、おかしな点があれば、遠慮なくお伝えください

目的
- 社内のユーザのみが使用できる設定を追加したい
- 管理者がCognitoでユーザを作成しなくて済む方法が良い
- 社内のユーザであれば、誰でも自由に登録できるようにしたい

実装内容
- 特定のメールアドレスのドメインを持ったユーザのみサインアップできるようにするために、以下をCDK（バックエンド）に追加した
  - 許可するドメインをStringのリストで設定するデプロイ時のオプションを追加した
  - ドメイン判定用のLambda関数を作成した
    - メールアドレスと許可ドメインを受け取り、メールアドレスの@以降がいずれかに該当するかチェックする
  - Cognitoのサインアップ前 Lambdaトリガーとして、上記のLambda関数を設定する処理を追加した

動作確認
- npm run cdk:deployで、自分のAWSアカウントにデプロイできることを確認した
  - Lambda関数が作成された（GenerativeAiUseCasesStack-AuthCheckEmailDomainxxxx）
  - Cognitoのユーザプールのサインアップ前 Lambda トリガーとして、Lambda関数が登録された
- 以下のように、allowedSingUpEmailDomainsを変えながらデプロイし、該当するドメインのメールアドレスで登録が可能か不可能かをチェックし、想定通りであることを確認した（ユーザの削除は毎回Cognitoのユーザーのリストから手動で行いました）
  - OK：Web画面の「アカウントを作る」と、Cognitoの「ユーザ作成」でユーザを登録できた
  - NG：Web画面の「アカウントを作る」と、Cognitoの「ユーザ作成」でユーザを登録できなかった
    - Web画面のNG：「アカウントを作る」を押すと、「PreSignUp failed with error Invalid email domain.」というエラーメッセージが表示され、先に進めない
    - CognitoのNG：「[UserLambdaValidationException] ユーザー作成中にエラーが発生しました。エラーを確認して再試行してください。」というエラーメッセージが表示される
 
| 設定 | classmethod.jpユーザ | gmail.comユーザ |
| --- | --- | --- |
| null | OK | OK |
| [] | NG | NG |
| ["classmethod.jp"] | OK | NG |
| ["classmethod", "gmail.com"] | OK | OK |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
