### PR TITLE
predictStream でLLMの出力が終わったあとに lambda がすぐに停止するように変更

### DIFF
--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -1,4 +1,4 @@
-import { Handler } from 'aws-lambda';
+import { Handler, Context } from 'aws-lambda';
 import { PredictRequest } from 'generative-ai-use-cases-jp';
 import api from './utils/api';
 
@@ -7,18 +7,20 @@ declare global {
     function streamifyResponse(
       f: (
         event: PredictRequest,
-        responseStream: NodeJS.WritableStream
+        responseStream: NodeJS.WritableStream,
+        context: Context
       ) => Promise<void>
     ): Handler;
   }
 }
 
 export const handler = awslambda.streamifyResponse(
-  async (event, responseStream) => {
+  async (event, responseStream, context) => {
+    context.callbackWaitsForEmptyEventLoop = false;
     for await (const token of api.invokeStream(event.messages)) {
       responseStream.write(token);
     }
-
+    
     responseStream.end();
   }
 );

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -20,7 +20,6 @@ export const handler = awslambda.streamifyResponse(
     for await (const token of api.invokeStream(event.messages)) {
       responseStream.write(token);
     }
-    
     responseStream.end();
   }
 );


### PR DESCRIPTION
#238