### PR TITLE
ローカル開発環境構築用のカスタムスクリプトが、一部の環境で動作しない問題の修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "run-s root:lint web:lint cdk:lint",
     "root:lint": "npx prettier --write .",
-    "web:devw": "source setup-env.sh && VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev",
+    "web:devw": "source ./setup-env.sh && VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev",
     "web:dev": "VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev",
     "web:build": "VITE_APP_VERSION=${npm_package_version} npm -w packages/web run build",
     "web:lint": "npm -w packages/web run lint",


### PR DESCRIPTION
*Issue #, if available:*
ローカル開発環境の構築用のカスタムスクリプトが、一部の環境で動作しない問題の修正です。
具体的な原因までは特定できていないですが、以下の環境では動作しませんでした
- OS : Amazon Linux 2023
- Shell : fish

*Description of changes:*
「source ./setup-env.sh」と変更することで動作しました。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
