### PR TITLE
小さい画面での横スクロール幅を変更

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,3 +32,10 @@ input[type='number'] {
 pre {
   width: 50vw;
 }
+
+/* スマートフォンや小さい画面デバイス用のスタイル */
+@media (max-width: 1020px) {
+  pre {
+    width: 80vw;
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
以下の Pull Request では、一律で width を 50vw としていた。
https://github.com/aws-samples/generative-ai-use-cases-jp/commit/a5546aae28c02a420a6f1411b208621f84673b83

小さい画面だと、code 要素の横幅が小さく違和感があった

*Description of changes:*
一律で 50vw ではなく、小さい画面の場合は width 80vw にする変更。


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
