### PR TITLE
Fix/claude 2.1 support image generation

### DIFF
--- a/packages/web/src/components/GenerateImageAssistant.tsx
+++ b/packages/web/src/components/GenerateImageAssistant.tsx
@@ -38,11 +38,9 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading]);
 
-  const getJsonString = (text: string) => 
-  text.slice(
-    text.indexOf("{"),
-    text.lastIndexOf("}") + 1
-  );
+  // LLM の出力に JSON 文字列があった場合に出力から JSON 文字列だけ({と}を探してその間だけ抜く)を抜き出す処理
+  const getJsonString = (text: string) =>
+    text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1);
 
   const contents = useMemo<
     (

--- a/packages/web/src/components/GenerateImageAssistant.tsx
+++ b/packages/web/src/components/GenerateImageAssistant.tsx
@@ -38,6 +38,12 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading]);
 
+  const getJsonString = (text: string) => 
+  text.slice(
+    text.indexOf("{"),
+    text.lastIndexOf("}") + 1
+  );
+
   const contents = useMemo<
     (
       | {
@@ -77,7 +83,7 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
         try {
           return {
             role: 'assistant',
-            content: JSON.parse(m.content),
+            content: JSON.parse(getJsonString(m.content)),
           };
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
JSON フォーマット自体はいずれのモデルでも出力しており、前後に余計な文言が出るケースがあるので、`{` と `}` を検索し、その間だけを抜き出す処理を追加