### PR TITLE
DynamoDB を provisioned から on demand に変更

### DIFF
--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -18,6 +18,7 @@ export class Database extends Construct {
         name: 'createdDate',
         type: ddb.AttributeType.STRING,
       },
+      billingMode: ddb.BillingMode.PAY_PER_REQUEST,
     });
 
     table.addGlobalSecondaryIndex({


### PR DESCRIPTION
デプロイ時に table が再生成されることはない (アップデートされる) ことは確認済みです。