### PR TITLE
RAGチャットのS3のファイルをダウンロードする際にローディング表示する、Kendra 検索でもドキュメントを開けるようにする

### DIFF
--- a/packages/web/src/components/Markdown.tsx
+++ b/packages/web/src/components/Markdown.tsx
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import ButtonCopy from './ButtonCopy';
 import useRagFile from '../hooks/useRagFile';
+import { PiSpinnerGap } from 'react-icons/pi';
 
 type Props = BaseProps & {
   children: string;
@@ -18,7 +19,7 @@ const LinkRenderer: React.FC<
   any
 > = (props) => {
   // 現状、S3 からのファイルダウンロード機能は RAG チャットしか利用しない
-  const { downloadDoc, isS3Url } = useRagFile();
+  const { downloadDoc, isS3Url, downloading } = useRagFile();
   const isS3 = useMemo(() => {
     return isS3Url(props.href);
   }, [isS3Url, props.href]);
@@ -29,10 +30,15 @@ const LinkRenderer: React.FC<
         <a
           id={props.id}
           onClick={() => {
-            downloadDoc(props.href);
+            if (!downloading) {
+              downloadDoc(props.href);
+            }
           }}
-          className="cursor-pointer">
+          className={`cursor-pointer ${downloading ? 'text-gray-400' : ''}`}>
           {props.children}
+          {downloading && (
+            <PiSpinnerGap className="mx-2 inline-block animate-spin" />
+          )}
         </a>
       ) : (
         <a
@@ -78,7 +84,6 @@ const Markdown: React.FC<Props> = ({ className, prefix, children }) => {
                 children={codeText}
                 style={vscDarkPlus}
                 language={isCodeBlock ? language : 'plaintext'}
-                PreTag="div"
               />
             </>
           );

--- a/packages/web/src/hooks/useRagFile.ts
+++ b/packages/web/src/hooks/useRagFile.ts
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import useRagApi from './useRagApi';
 
 const useRagFile = () => {
   const { getDocDownloadSignedUrl } = useRagApi();
+  const [downloading, setDownloading] = useState(false);
 
   return {
     isS3Url: (url: string) => {
@@ -10,36 +12,45 @@ const useRagFile = () => {
         : false;
     },
     downloadDoc: async (url: string) => {
-      // S3 データソースの設定項目である S3 field mapping の s3_document_id のチェック有無で、
-      // Document_URI が異なるためそれぞれの URI に対応できるようにする
-      let result =
-        /^https:\/\/s3.[\w\\-]+.amazonaws.com\/(?<bucketName>.+?)\/(?<prefix>.+)$/.exec(
-          url
-        );
-      if (!result) {
-        result =
-          /^https:\/\/(?<bucketName>.+?).s3.[\w\\-]+.amazonaws.com\/(?<prefix>.+)$/.exec(
+      setDownloading(true);
+
+      try {
+        // S3 データソースの設定項目である S3 field mapping の s3_document_id のチェック有無で、
+        // Document_URI が異なるためそれぞれの URI に対応できるようにする
+        let result =
+          /^https:\/\/s3.[\w\\-]+.amazonaws.com\/(?<bucketName>.+?)\/(?<prefix>.+)$/.exec(
             url
           );
-      }
-      const groups = result?.groups as {
-        bucketName: string;
-        prefix: string;
-      };
+        if (!result) {
+          result =
+            /^https:\/\/(?<bucketName>.+?).s3.[\w\\-]+.amazonaws.com\/(?<prefix>.+)$/.exec(
+              url
+            );
+        }
+        const groups = result?.groups as {
+          bucketName: string;
+          prefix: string;
+        };
 
-      const [filePrefix, anchorLink] = groups.prefix.split('#');
-      const signedUrl = await getDocDownloadSignedUrl(
-        groups.bucketName,
-        // 日本語ファイル名の場合は URI エンコードされたファイル名が URL に設定されているため、
-        // デコードしてから署名付き URL を取得する（二重で URI エンコードされるのを防止する）
-        decodeURIComponent(filePrefix)
-      );
-      window.open(
-        `${signedUrl}${anchorLink ? `#${anchorLink}` : ''}`,
-        '_blank',
-        'noopener,noreferrer'
-      );
+        const [filePrefix, anchorLink] = groups.prefix.split('#');
+        const signedUrl = await getDocDownloadSignedUrl(
+          groups.bucketName,
+          // 日本語ファイル名の場合は URI エンコードされたファイル名が URL に設定されているため、
+          // デコードしてから署名付き URL を取得する（二重で URI エンコードされるのを防止する）
+          decodeURIComponent(filePrefix)
+        );
+        window.open(
+          `${signedUrl}${anchorLink ? `#${anchorLink}` : ''}`,
+          '_blank',
+          'noopener,noreferrer'
+        );
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setDownloading(false);
+      }
     },
+    downloading,
   };
 };
 

--- a/packages/web/src/pages/KendraSearchPage.tsx
+++ b/packages/web/src/pages/KendraSearchPage.tsx
@@ -4,9 +4,11 @@ import { Link } from 'react-router-dom';
 import useRag from '../hooks/useSearch';
 import HighlightText from '../components/HighlightText';
 import ButtonIcon from '../components/ButtonIcon';
+import useRagFile from '../hooks/useRagFile';
 
 const KendraSearchPage: React.FC = () => {
   const { loading, resultItems, query, setQuery, search } = useRag();
+  const { downloadDoc, isS3Url, downloading } = useRagFile();
 
   const searchKendra = useCallback(() => {
     search();
@@ -66,24 +68,50 @@ const KendraSearchPage: React.FC = () => {
         <PiSpinnerGap className="animate-spin text-3xl text-gray-400" />
       )}
       <div className="mb-12 grid w-3/4 gap-6">
-        {resultItems.map((result) => (
-          <div key={result.Id}>
-            <Link
-              className="text-aws-sky font-semibold"
-              to={result.DocumentURI!}>
-              {result.DocumentTitle?.Text}
-            </Link>
-            <div className="mb-2 text-xs">{result.DocumentURI}</div>
-            <HighlightText
-              textWithHighlights={
-                result.DocumentExcerpt ?? {
-                  Text: '',
-                  Highlights: [],
+        {resultItems.map((result) =>
+          isS3Url(result.DocumentURI!) ? (
+            <div key={result.Id}>
+              <a
+                className={`${downloading ? 'text-gray-400' : 'text-aws-sky'} cursor-pointer font-semibold`}
+                onClick={() => {
+                  if (!downloading) {
+                    downloadDoc(result.DocumentURI!);
+                  }
+                }}>
+                {result.DocumentTitle?.Text}
+                {downloading && (
+                  <PiSpinnerGap className="ml-2 inline-block animate-spin" />
+                )}
+              </a>
+              <div className="mb-2 text-xs">{result.DocumentURI}</div>
+              <HighlightText
+                textWithHighlights={
+                  result.DocumentExcerpt ?? {
+                    Text: '',
+                    Highlights: [],
+                  }
                 }
-              }
-            />
-          </div>
-        ))}
+              />
+            </div>
+          ) : (
+            <div key={result.Id}>
+              <Link
+                className="text-aws-sky font-semibold"
+                to={result.DocumentURI!}>
+                {result.DocumentTitle?.Text}
+              </Link>
+              <div className="mb-2 text-xs">{result.DocumentURI}</div>
+              <HighlightText
+                textWithHighlights={
+                  result.DocumentExcerpt ?? {
+                    Text: '',
+                    Highlights: [],
+                  }
+                }
+              />
+            </div>
+          )
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/297

また、表題の通り Kendra 検索で S3 のドキュメントリンクがクリックできなかったので、これも併せて修正しました