### PR TITLE
Knowledge base for Amazon Bedrock 向けにデプロイ手順を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ npm run cdk:deploy
   - [RAG チャットユースケースの有効化](/docs/DEPLOY_OPTION.md#rag-チャットユースケースの有効化)
     - [既存の Amazon Kendra Index を利用したい場合](/docs/DEPLOY_OPTION.md#既存の-amazon-kendra-index-を利用したい場合)
   - [Agent チャットユースケースの有効化](/docs/DEPLOY_OPTION.md#agent-チャットユースケースの有効化)
+    - [検索エージェントのデプロイ](/docs/DEPLOY_OPTION.md#検索エージェントのデプロイ)
+    - [Knowledge base エージェントのデプロイ](/docs/DEPLOY_OPTION.md#knowledge-base-エージェントのデプロイ)
 - [Amazon Bedrock のモデルを変更する](/docs/DEPLOY_OPTION.md#amazon-bedrock-のモデルを変更する)
   - [us-east-1 (バージニア) の Amazon Bedrock のモデルを利用する例](/docs/DEPLOY_OPTION.md#us-east-1-バージニア-の-amazon-bedrock-のモデルを利用する例)
   - [ap-northeast-1 (東京) の Amazon Bedrock のモデルを利用する例](/docs/DEPLOY_OPTION.md#ap-northeast-1-東京-の-amazon-bedrock-のモデルを利用する例)

--- a/packages/cdk/bin/generative-ai-use-cases.ts
+++ b/packages/cdk/bin/generative-ai-use-cases.ts
@@ -5,7 +5,7 @@ import { IConstruct } from 'constructs';
 import { GenerativeAiUseCasesStack } from '../lib/generative-ai-use-cases-stack';
 import { CloudFrontWafStack } from '../lib/cloud-front-waf-stack';
 import { DashboardStack } from '../lib/dashboard-stack';
-import { BedrockAgentStack } from '../lib/bedrock-agent-stack';
+import { SearchAgentStack } from '../lib/search-agent-stack';
 
 class DeletionPolicySetter implements cdk.IAspect {
   constructor(private readonly policy: cdk.RemovalPolicy) {}
@@ -78,11 +78,11 @@ cdk.Aspects.of(generativeAiUseCasesStack).add(
 
 // Agent
 
-const agentEnabled = app.node.tryGetContext('agentEnabled') || false;
+const searchAgentEnabled = app.node.tryGetContext('searchAgentEnabled') || false;
 const agentRegion = app.node.tryGetContext('agentRegion') || 'us-east-1';
 
-if (agentEnabled) {
-  new BedrockAgentStack(app, 'BedrockAgentStack', {
+if (searchAgentEnabled) {
+  new SearchAgentStack(app, 'WebSearchAgentStack', {
     env: {
       region: agentRegion,
     },

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -32,6 +32,7 @@
     "endpointNames": [],
     "agentEnabled": false,
     "agentRegion": "us-east-1",
+    "searchAgentEnabled": false,
     "searchApiKey": "",
     "agents": [
     ],

--- a/packages/cdk/lib/search-agent-stack.ts
+++ b/packages/cdk/lib/search-agent-stack.ts
@@ -2,10 +2,10 @@ import { CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Agent } from './construct';
 
-interface BedrockAgentStackProps extends StackProps {}
+interface SearchAgentStackProps extends StackProps {}
 
-export class BedrockAgentStack extends Stack {
-  constructor(scope: Construct, id: string, props: BedrockAgentStackProps) {
+export class SearchAgentStack extends Stack {
+  constructor(scope: Construct, id: string, props: SearchAgentStackProps) {
     super(scope, id, props);
 
     const agent = new Agent(this, 'Agent');


### PR DESCRIPTION
*Issue #, if available:*
#226 

*Description of changes:*
- Knowledge base for Amazon Bedrock デプロイ方法のドキュメント更新
- `agentEnabled` はエージェントの利用、`searchAgentEnabled` は検索エージェント用のスタックのデプロイに役割を変更
- 検索エージェント用のスタックの名前を変更

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
