### PR TITLE
RAGの検索結果が空の場合に、生成動作を切り替える

### DIFF
--- a/packages/cdk/bin/generative-ai-use-cases.ts
+++ b/packages/cdk/bin/generative-ai-use-cases.ts
@@ -78,7 +78,8 @@ cdk.Aspects.of(generativeAiUseCasesStack).add(
 
 // Agent
 
-const searchAgentEnabled = app.node.tryGetContext('searchAgentEnabled') || false;
+const searchAgentEnabled =
+  app.node.tryGetContext('searchAgentEnabled') || false;
 const agentRegion = app.node.tryGetContext('agentRegion') || 'us-east-1';
 
 if (searchAgentEnabled) {

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -28,7 +28,9 @@ export class Auth extends Construct {
 
     const userPool = new UserPool(this, 'UserPool', {
       // SAML 認証を有効化する場合、UserPool を利用したセルフサインアップは利用しない。セキュリティを意識して閉じる。
-      selfSignUpEnabled: props.samlAuthEnabled ? false : props.selfSignUpEnabled, 
+      selfSignUpEnabled: props.samlAuthEnabled
+        ? false
+        : props.selfSignUpEnabled,
       signInAliases: {
         username: false,
         email: true,

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -117,8 +117,10 @@ export class Web extends Construct {
         VITE_APP_IMAGE_MODEL_IDS: JSON.stringify(props.imageGenerationModelIds),
         VITE_APP_ENDPOINT_NAMES: JSON.stringify(props.endpointNames),
         VITE_APP_SAMLAUTH_ENABLED: props.samlAuthEnabled.toString(),
-        VITE_APP_SAML_COGNITO_DOMAIN_NAME: props.samlCognitoDomainName.toString(),
-        VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME: props.samlCognitoFederatedIdentityProviderName.toString(),
+        VITE_APP_SAML_COGNITO_DOMAIN_NAME:
+          props.samlCognitoDomainName.toString(),
+        VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME:
+          props.samlCognitoFederatedIdentityProviderName.toString(),
         VITE_APP_AGENT_NAMES: JSON.stringify(props.agentNames),
       },
     });

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -44,9 +44,13 @@ export class GenerativeAiUseCasesStack extends Stack {
       this.node.tryGetContext('selfSignUpEnabled')!;
     const allowedSignUpEmailDomains: string[] | null | undefined =
       this.node.tryGetContext('allowedSignUpEmailDomains');
-    const samlAuthEnabled: boolean = this.node.tryGetContext('samlAuthEnabled')!;
-    const samlCognitoDomainName: string = this.node.tryGetContext('samlCognitoDomainName')!;
-    const samlCognitoFederatedIdentityProviderName: string = this.node.tryGetContext('samlCognitoFederatedIdentityProviderName')!;
+    const samlAuthEnabled: boolean =
+      this.node.tryGetContext('samlAuthEnabled')!;
+    const samlCognitoDomainName: string = this.node.tryGetContext(
+      'samlCognitoDomainName'
+    )!;
+    const samlCognitoFederatedIdentityProviderName: string =
+      this.node.tryGetContext('samlCognitoFederatedIdentityProviderName')!;
     const agentEnabled = this.node.tryGetContext('agentEnabled') || false;
 
     if (typeof ragEnabled !== 'boolean') {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -144,7 +144,7 @@ const App: React.FC = () => {
   return (
     <div className="screen:w-screen screen:h-screen overflow-x-hidden">
       <main className="flex-1">
-        <header className="bg-aws-squid-ink visible flex h-12 w-full items-center justify-between text-lg text-white print:hidden lg:invisible lg:h-0">
+        <header className="bg-aws-squid-ink visible flex h-12 w-full items-center justify-between text-lg text-white lg:invisible lg:h-0 print:hidden">
           <div className="flex w-10 items-center justify-start">
             <button
               className="focus:ring-aws-sky mr-2 rounded-full  p-2 hover:opacity-50 focus:outline-none focus:ring-1"
@@ -170,9 +170,7 @@ const App: React.FC = () => {
 
         <div
           id="smallDrawerFiller"
-          className={`${
-            isOpenDrawer ? 'visible' : 'invisible'
-          } lg:invisible`}>
+          className={`${isOpenDrawer ? 'visible' : 'invisible'} lg:invisible`}>
           <div
             className="screen:h-screen fixed top-0 z-40 w-screen bg-gray-900/90"
             onClick={switchDrawer}></div>

--- a/packages/web/src/components/AuthWithSAML.tsx
+++ b/packages/web/src/components/AuthWithSAML.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import App from '../App.tsx'
+import App from '../App.tsx';
 import { Button, Text, Loader } from '@aws-amplify/ui-react';
 import { Amplify, Auth } from 'aws-amplify';
 import '@aws-amplify/ui-react/styles.css';
 
-const samlCognitoDomainName: string = import.meta.env.VITE_APP_SAML_COGNITO_DOMAIN_NAME;
-const samlCognitoFederatedIdentityProviderName: string = import.meta.env.VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME;
+const samlCognitoDomainName: string = import.meta.env
+  .VITE_APP_SAML_COGNITO_DOMAIN_NAME;
+const samlCognitoFederatedIdentityProviderName: string = import.meta.env
+  .VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME;
 
 const AuthWithSAML: React.FC = () => {
   const [authenticated, setAuthenticated] = useState(false);
@@ -26,7 +28,9 @@ const AuthWithSAML: React.FC = () => {
   }, []);
 
   const signIn = () => {
-    Auth.federatedSignIn({ customProvider: samlCognitoFederatedIdentityProviderName }); // cdk.json の値を指定
+    Auth.federatedSignIn({
+      customProvider: samlCognitoFederatedIdentityProviderName,
+    }); // cdk.json の値を指定
   };
 
   Amplify.configure({
@@ -49,21 +53,19 @@ const AuthWithSAML: React.FC = () => {
   return (
     <>
       {loading ? (
-        <div className="grid grid-cols-1 gap-4 justify-items-center">
-          <Text className="text-center mt-12">
-            Loading...
-          </Text>
+        <div className="grid grid-cols-1 justify-items-center gap-4">
+          <Text className="mt-12 text-center">Loading...</Text>
           <Loader width="5rem" height="5rem" />
         </div>
       ) : !authenticated ? (
-        <div className="grid grid-cols-1 gap-4 justify-items-center">
-          <Text className="text-center text-3xl mt-12">
+        <div className="grid grid-cols-1 justify-items-center gap-4">
+          <Text className="mt-12 text-center text-3xl">
             Generative AI Use Cases on AWS
           </Text>
           <Button
             variation="primary"
             onClick={() => signIn()}
-            className="w-60 mt-6">
+            className="mt-6 w-60">
             ログイン
           </Button>
         </div>

--- a/packages/web/src/components/AuthWithUserpool.tsx
+++ b/packages/web/src/components/AuthWithUserpool.tsx
@@ -1,10 +1,9 @@
 import { Amplify, I18n } from 'aws-amplify';
 import { Authenticator, translations } from '@aws-amplify/ui-react';
-import App from '../App.tsx'
+import App from '../App.tsx';
 
 const selfSignUpEnabled: boolean =
   import.meta.env.VITE_APP_SELF_SIGN_UP_ENABLED === 'true';
-
 
 const AuthWithUserpool: React.FC = () => {
   Amplify.configure({

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -117,7 +117,7 @@ const ChatMessage: React.FC<Props> = (props) => {
           </div>
         </div>
 
-        <div className="flex items-start justify-end print:hidden lg:-mr-24">
+        <div className="flex items-start justify-end lg:-mr-24 print:hidden">
           {(chatContent?.role === 'user' || chatContent?.role === 'system') && (
             <div className="lg:w-8"></div>
           )}

--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -30,7 +30,7 @@ const useRag = (id: string) => {
       // Kendra から Retrieve する際に、ローディング表示する
       setLoading(true);
       pushMessage('user', content);
-      pushMessage('assistant', '[Kendra から参照ドキュメントを取得中...]');
+      pushMessage('assistant', 'Kendra から参照ドキュメントを取得中...');
 
       const query = await predict({
         model: model,
@@ -47,6 +47,20 @@ const useRag = (id: string) => {
 
       // Kendra から 参考ドキュメントを Retrieve してシステムコンテキストとして設定する
       const items = await retrieve(query);
+
+      if (items.data.ResultItems.length === 0) {
+        popMessage();
+        pushMessage(
+          'assistant',
+          `参考ドキュメントが見つかりませんでした。次の対応を検討してください。
+- Amazon Kendra の data source に対象のドキュメントが追加されているか確認する
+- Amazon Kendra の data source が sync されているか確認する
+- 入力の表現を変更する`
+        );
+        setLoading(false);
+        return;
+      }
+
       updateSystemContext(
         ragPrompt.generatePrompt({
           promptType: 'SYSTEM_CONTEXT',

--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -48,7 +48,7 @@ const useRag = (id: string) => {
       // Kendra から 参考ドキュメントを Retrieve してシステムコンテキストとして設定する
       const items = await retrieve(query);
 
-      if (items.data.ResultItems.length === 0) {
+      if ((items.data.ResultItems ?? []).length === 0) {
         popMessage();
         pushMessage(
           'assistant',

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -25,7 +25,8 @@ import TranscribePage from './pages/TranscribePage';
 import AgentChatPage from './pages/AgentChatPage.tsx';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
-const samlAuthEnabled: boolean = import.meta.env.VITE_APP_SAMLAUTH_ENABLED === 'true';
+const samlAuthEnabled: boolean =
+  import.meta.env.VITE_APP_SAMLAUTH_ENABLED === 'true';
 const agentEnabled: boolean = import.meta.env.VITE_APP_AGENT_ENABLED === 'true';
 
 const routes: RouteObject[] = [

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -108,7 +108,7 @@ const AgentChatPage: React.FC = () => {
   return (
     <>
       <div className={`${!isEmpty ? 'screen:pb-36' : ''} relative`}>
-        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
           {title}
         </div>
 
@@ -150,7 +150,7 @@ const AgentChatPage: React.FC = () => {
             </div>
           ))}
 
-        <div className="fixed bottom-0 z-0 flex w-full flex-col items-center justify-center print:hidden lg:pr-64">
+        <div className="fixed bottom-0 z-0 flex w-full flex-col items-center justify-center lg:pr-64 print:hidden">
           <InputChatContent
             content={content}
             disabled={loading}

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -189,7 +189,7 @@ const ChatPage: React.FC = () => {
   return (
     <>
       <div className={`${!isEmpty ? 'screen:pb-36' : ''} relative`}>
-        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
           {title}
         </div>
 
@@ -263,7 +263,7 @@ const ChatPage: React.FC = () => {
             </div>
           ))}
 
-        <div className="fixed bottom-0 z-0 flex w-full flex-col items-center justify-center print:hidden lg:pr-64">
+        <div className="fixed bottom-0 z-0 flex w-full flex-col items-center justify-center lg:pr-64 print:hidden">
           {isEmpty && !loadingMessages && !chatId && (
             <ExpandableField
               label="システムコンテキスト"

--- a/packages/web/src/pages/EditorialPage.tsx
+++ b/packages/web/src/pages/EditorialPage.tsx
@@ -250,7 +250,7 @@ const EditorialPage: React.FC = () => {
 
   return (
     <div className="grid grid-cols-12">
-      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         校正
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">

--- a/packages/web/src/pages/GenerateTextPage.tsx
+++ b/packages/web/src/pages/GenerateTextPage.tsx
@@ -140,7 +140,7 @@ const GenerateTextPage: React.FC = () => {
 
   return (
     <div className="grid grid-cols-12">
-      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         文章生成
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">

--- a/packages/web/src/pages/KendraSearchPage.tsx
+++ b/packages/web/src/pages/KendraSearchPage.tsx
@@ -33,7 +33,7 @@ const KendraSearchPage: React.FC = () => {
 
   return (
     <div className="flex flex-col items-center">
-      <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         Kendra 検索
       </div>
       <div className="text-sm text-gray-600">

--- a/packages/web/src/pages/RagPage.tsx
+++ b/packages/web/src/pages/RagPage.tsx
@@ -78,7 +78,7 @@ const RagPage: React.FC = () => {
   return (
     <>
       <div className={`${!isEmpty ? 'screen:pb-36' : ''} relative`}>
-        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
           RAG チャット
         </div>
 
@@ -141,7 +141,7 @@ const RagPage: React.FC = () => {
           </div>
         ))}
 
-        <div className="fixed bottom-0 z-0 flex w-full items-end justify-center print:hidden lg:pr-64">
+        <div className="fixed bottom-0 z-0 flex w-full items-end justify-center lg:pr-64 print:hidden">
           <InputChatContent
             content={content}
             disabled={loading}

--- a/packages/web/src/pages/Setting.tsx
+++ b/packages/web/src/pages/Setting.tsx
@@ -45,7 +45,7 @@ const Setting = () => {
 
   return (
     <div>
-      <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         設定情報
       </div>
 

--- a/packages/web/src/pages/SharedChatPage.tsx
+++ b/packages/web/src/pages/SharedChatPage.tsx
@@ -42,7 +42,7 @@ const SharedChatPage: React.FC = () => {
   return (
     <>
       <div className="relative">
-        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
           {title}
         </div>
 

--- a/packages/web/src/pages/SummarizePage.tsx
+++ b/packages/web/src/pages/SummarizePage.tsx
@@ -139,7 +139,7 @@ const SummarizePage: React.FC = () => {
 
   return (
     <div className="grid grid-cols-12">
-      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         要約
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">

--- a/packages/web/src/pages/TranscribePage.tsx
+++ b/packages/web/src/pages/TranscribePage.tsx
@@ -99,7 +99,7 @@ const TranscribePage: React.FC = () => {
 
   return (
     <div className="grid grid-cols-12">
-      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         音声認識
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">

--- a/packages/web/src/pages/TranslatePage.tsx
+++ b/packages/web/src/pages/TranslatePage.tsx
@@ -204,7 +204,7 @@ const TranslatePage: React.FC = () => {
 
   return (
     <div className="grid grid-cols-12">
-      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         翻訳
       </div>
       <div className="col-span-12 col-start-1 mx-2 lg:col-span-10 lg:col-start-2 xl:col-span-10 xl:col-start-2">

--- a/packages/web/src/pages/WebContent.tsx
+++ b/packages/web/src/pages/WebContent.tsx
@@ -191,7 +191,7 @@ const WebContent: React.FC = () => {
 
   return (
     <div className="grid grid-cols-12">
-      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold print:visible print:my-5 print:h-min lg:visible lg:my-5 lg:h-min">
+      <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
         Web コンテンツ抽出
       </div>
 


### PR DESCRIPTION
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/293

ファイルの変更数が多いですが、lint 漏れがあったみたいで、実際に変更したのは packages/web/src/hooks/useRag.ts のみです！
