### PR TITLE
IdentityPool の IAM ロールの Condition に SourceIP を追加

### DIFF
--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -8,12 +8,15 @@ import {
   IdentityPool,
   UserPoolAuthenticationProvider,
 } from '@aws-cdk/aws-cognito-identitypool-alpha';
+import { Effect, Policy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 
 export interface AuthProps {
   selfSignUpEnabled: boolean;
+  allowedIpV4AddressRanges: string[] | null;
+  allowedIpV6AddressRanges: string[] | null;
   allowedSignUpEmailDomains: string[] | null | undefined;
   samlAuthEnabled: boolean;
 }
@@ -57,6 +60,28 @@ export class Auth extends Construct {
         ],
       },
     });
+
+    if (props.allowedIpV4AddressRanges || props.allowedIpV6AddressRanges) {
+      const ipRanges = [
+        ...(props.allowedIpV4AddressRanges ? props.allowedIpV4AddressRanges : []),
+        ...(props.allowedIpV6AddressRanges ? props.allowedIpV6AddressRanges : []),
+      ];
+
+      idPool.authenticatedRole.attachInlinePolicy(new Policy(this, 'SourceIpPolicy', {
+        statements: [
+          new PolicyStatement({
+            effect: Effect.DENY,
+            resources: ['*'],
+            actions: ['*'],
+            conditions: {
+              NotIpAddress: {
+                'aws:SourceIp': ipRanges,
+              },
+            },
+          }),
+        ]
+      }));
+    }
 
     // Lambda
     if (props.allowedSignUpEmailDomains) {

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -75,6 +75,8 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     const auth = new Auth(this, 'Auth', {
       selfSignUpEnabled,
+      allowedIpV4AddressRanges: props.allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges: props.allowedIpV6AddressRanges,
       allowedSignUpEmailDomains,
       samlAuthEnabled,
     });


### PR DESCRIPTION
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/301

自分の IP で正常に設定 & 動作していることを確認しています。
<img width="1012" alt="スクリーンショット 2024-02-20 11 40 29" src="https://github.com/aws-samples/generative-ai-use-cases-jp/assets/3483230/2bcfd74e-c41d-4b48-a73f-869bf1f48650">
