### PR TITLE
画像生成 use case の prompt 生成に stop_sequences を追加する

### DIFF
--- a/packages/cdk/lambda/predict.ts
+++ b/packages/cdk/lambda/predict.ts
@@ -9,7 +9,11 @@ export const handler = async (
   try {
     const req: PredictRequest = JSON.parse(event.body!);
     const model = req.model || defaultModel;
-    const response = await api[model.type].invoke(model, req.messages, req.stopSequences);
+    const response = await api[model.type].invoke(
+      model,
+      req.messages,
+      req.stopSequences
+    );
 
     return {
       statusCode: 200,

--- a/packages/cdk/lambda/predict.ts
+++ b/packages/cdk/lambda/predict.ts
@@ -9,7 +9,7 @@ export const handler = async (
   try {
     const req: PredictRequest = JSON.parse(event.body!);
     const model = req.model || defaultModel;
-    const response = await api[model.type].invoke(model, req.messages);
+    const response = await api[model.type].invoke(model, req.messages, req.stopSequences);
 
     return {
       statusCode: 200,

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -22,7 +22,7 @@ export const handler = awslambda.streamifyResponse(
     for await (const token of api[model.type].invokeStream(
       model,
       event.messages,
-      event.stopSequences,
+      event.stopSequences
     )) {
       responseStream.write(token);
     }

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -21,7 +21,8 @@ export const handler = awslambda.streamifyResponse(
     const model = event.model || defaultModel;
     for await (const token of api[model.type].invokeStream(
       model,
-      event.messages
+      event.messages,
+      event.stopSequences,
     )) {
       responseStream.write(token);
     }

--- a/packages/cdk/lambda/utils/bedrockApi.ts
+++ b/packages/cdk/lambda/utils/bedrockApi.ts
@@ -19,10 +19,11 @@ const client = new BedrockRuntimeClient({
 
 const createBodyText = (
   model: string,
-  messages: UnrecordedMessage[]
+  messages: UnrecordedMessage[],
+  stopSequences?: string[],
 ): string => {
   const modelConfig = BEDROCK_MODELS[model];
-  return modelConfig.createBodyText(messages);
+  return modelConfig.createBodyText(messages, stopSequences);
 };
 
 const createBodyImage = (
@@ -42,20 +43,20 @@ const extractOutputImage = (
 };
 
 const bedrockApi: ApiInterface = {
-  invoke: async (model, messages) => {
+  invoke: async (model, messages, stopSequences) => {
     const command = new InvokeModelCommand({
       modelId: model.modelId,
-      body: createBodyText(model.modelId, messages),
+      body: createBodyText(model.modelId, messages, stopSequences),
       contentType: 'application/json',
     });
     const data = await client.send(command);
     return JSON.parse(data.body.transformToString()).completion;
   },
-  invokeStream: async function* (model, messages) {
+  invokeStream: async function* (model, messages, stopSequences) {
     try {
       const command = new InvokeModelWithResponseStreamCommand({
         modelId: model.modelId,
-        body: createBodyText(model.modelId, messages),
+        body: createBodyText(model.modelId, messages, stopSequences),
         contentType: 'application/json',
       });
       const res = await client.send(command);

--- a/packages/cdk/lambda/utils/bedrockApi.ts
+++ b/packages/cdk/lambda/utils/bedrockApi.ts
@@ -20,7 +20,7 @@ const client = new BedrockRuntimeClient({
 const createBodyText = (
   model: string,
   messages: UnrecordedMessage[],
-  stopSequences?: string[],
+  stopSequences?: string[]
 ): string => {
   const modelConfig = BEDROCK_MODELS[model];
   return modelConfig.createBodyText(messages, stopSequences);

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -93,7 +93,8 @@ const CLAUDE_DEFAULT_PARAMS: ClaudeParams = {
 
 // Model Config
 
-const createBodyTextClaude = (messages: UnrecordedMessage[]) => {
+const createBodyTextClaude = (messages: UnrecordedMessage[], /* stopSequences: string[] | undefined*/) => {
+  // if (stopSequences) CLAUDE_DEFAULT_PARAMS.stop_sequences = ['\n\nHuman:', ...stopSequences]
   const body: ClaudeParams = {
     prompt: generatePrompt(CLAUDE_PROMPT, messages),
     ...CLAUDE_DEFAULT_PARAMS,
@@ -101,7 +102,8 @@ const createBodyTextClaude = (messages: UnrecordedMessage[]) => {
   return JSON.stringify(body);
 };
 
-const createBodyTextClaudev21 = (messages: UnrecordedMessage[]) => {
+const createBodyTextClaudev21 = (messages: UnrecordedMessage[], stopSequences: string[] | undefined) => {
+  if (stopSequences) CLAUDE_DEFAULT_PARAMS.stop_sequences = ['\n\nHuman:', ...stopSequences]
   const body: ClaudeParams = {
     prompt: generatePrompt(CLAUDEV21_PROMPT, messages),
     ...CLAUDE_DEFAULT_PARAMS,
@@ -180,7 +182,7 @@ const extractOutputImageTitanImage = (
 export const BEDROCK_MODELS: {
   [key: string]: {
     promptTemplate: PromptTemplate;
-    createBodyText: (messages: UnrecordedMessage[]) => string;
+    createBodyText: (messages: UnrecordedMessage[], stopSequences?:string[]) => string;
   };
 } = {
   'anthropic.claude-v2:1': {

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -93,8 +93,8 @@ const CLAUDE_DEFAULT_PARAMS: ClaudeParams = {
 
 // Model Config
 
-const createBodyTextClaude = (messages: UnrecordedMessage[], /* stopSequences: string[] | undefined*/) => {
-  // if (stopSequences) CLAUDE_DEFAULT_PARAMS.stop_sequences = ['\n\nHuman:', ...stopSequences]
+const createBodyTextClaude = (messages: UnrecordedMessage[],  stopSequences: string[] | undefined) => {
+  if (stopSequences) CLAUDE_DEFAULT_PARAMS.stop_sequences = ['\n\nHuman:', ...stopSequences]
   const body: ClaudeParams = {
     prompt: generatePrompt(CLAUDE_PROMPT, messages),
     ...CLAUDE_DEFAULT_PARAMS,

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -93,20 +93,26 @@ const CLAUDE_DEFAULT_PARAMS: ClaudeParams = {
 
 // Model Config
 
-const createBodyTextClaude = (messages: UnrecordedMessage[],  stopSequences: string[] | undefined) => {
-  if (stopSequences) CLAUDE_DEFAULT_PARAMS.stop_sequences = ['\n\nHuman:', ...stopSequences]
+const createBodyTextClaude = (
+  messages: UnrecordedMessage[],
+  stopSequences: string[] | undefined
+) => {
   const body: ClaudeParams = {
     prompt: generatePrompt(CLAUDE_PROMPT, messages),
     ...CLAUDE_DEFAULT_PARAMS,
+    ...{ stop_sequences: stopSequences },
   };
   return JSON.stringify(body);
 };
 
-const createBodyTextClaudev21 = (messages: UnrecordedMessage[], stopSequences: string[] | undefined) => {
-  if (stopSequences) CLAUDE_DEFAULT_PARAMS.stop_sequences = ['\n\nHuman:', ...stopSequences]
+const createBodyTextClaudev21 = (
+  messages: UnrecordedMessage[],
+  stopSequences: string[] | undefined
+) => {
   const body: ClaudeParams = {
-    prompt: generatePrompt(CLAUDEV21_PROMPT, messages),
+    prompt: generatePrompt(CLAUDE_PROMPT, messages),
     ...CLAUDE_DEFAULT_PARAMS,
+    ...{ stop_sequences: stopSequences },
   };
   return JSON.stringify(body);
 };
@@ -182,7 +188,10 @@ const extractOutputImageTitanImage = (
 export const BEDROCK_MODELS: {
   [key: string]: {
     promptTemplate: PromptTemplate;
-    createBodyText: (messages: UnrecordedMessage[], stopSequences?:string[]) => string;
+    createBodyText: (
+      messages: UnrecordedMessage[],
+      stopSequences?: string[]
+    ) => string;
   };
 } = {
   'anthropic.claude-v2:1': {

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -57,6 +57,7 @@ export type UpdateTitleResponse = {
 export type PredictRequest = {
   model?: Model;
   messages: UnrecordedMessage[];
+  stopSequences?: string[];
 };
 
 export type PredictResponse = string;

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -7,13 +7,13 @@ import {
 export type InvokeInterface = (
   model: Model,
   messages: UnrecordedMessage[],
-  stopSequences: string[] | undefined,
+  stopSequences: string[] | undefined
 ) => Promise<string>;
 
 export type InvokeStreamInterface = (
   model: Model,
   messages: UnrecordedMessage[],
-  stopSequences: string[] | undefined,
+  stopSequences: string[] | undefined
 ) => AsyncIterable<string>;
 
 // Base64 にエンコードした画像を Return する

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -6,12 +6,14 @@ import {
 
 export type InvokeInterface = (
   model: Model,
-  messages: UnrecordedMessage[]
+  messages: UnrecordedMessage[],
+  stopSequences: string[] | undefined,
 ) => Promise<string>;
 
 export type InvokeStreamInterface = (
   model: Model,
-  messages: UnrecordedMessage[]
+  messages: UnrecordedMessage[],
+  stopSequences: string[] | undefined,
 ) => AsyncIterable<string>;
 
 // Base64 にエンコードした画像を Return する

--- a/packages/web/src/components/GenerateImageAssistant.tsx
+++ b/packages/web/src/components/GenerateImageAssistant.tsx
@@ -124,7 +124,10 @@ const GenerateImageAssistant: React.FC<Props> = (props) => {
     postChat(
       props.content,
       false,
-      props.textModels.find((m) => m.modelId === props.modelId)!
+      props.textModels.find((m) => m.modelId === props.modelId)!,
+      undefined,
+      undefined,
+      ['</output>']
     );
     props.onChangeContent('');
   }, [postChat, props]);

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -42,7 +42,8 @@ const useChatState = create<{
     ignoreHistory: boolean,
     model: Model | undefined,
     preProcessInput: ((message: ShownMessage[]) => ShownMessage[]) | undefined,
-    postProcessOutput: ((message: string) => string) | undefined
+    postProcessOutput: ((message: string) => string) | undefined,
+    stopSequences: string[] | undefined,
   ) => void;
   sendFeedback: (
     id: string,
@@ -271,7 +272,8 @@ const useChatState = create<{
       preProcessInput:
         | ((message: ShownMessage[]) => ShownMessage[])
         | undefined = undefined,
-      postProcessOutput: ((message: string) => string) | undefined = undefined
+      postProcessOutput: ((message: string) => string) | undefined = undefined,
+      stopSequences: string[] | undefined = undefined,
     ) => {
       setLoading(id, true);
 
@@ -314,6 +316,7 @@ const useChatState = create<{
       const stream = predictStream({
         model: model,
         messages: omitUnusedMessageProperties(inputMessages),
+        stopSequences: stopSequences,
       });
 
       // Assistant の発言を更新
@@ -466,7 +469,8 @@ const useChat = (id: string, chatId?: string) => {
       preProcessInput:
         | ((message: ShownMessage[]) => ShownMessage[])
         | undefined = undefined,
-      postProcessOutput: ((message: string) => string) | undefined = undefined
+      postProcessOutput: ((message: string) => string) | undefined = undefined,
+      stopSequences: string[] | undefined = undefined,
     ) => {
       post(
         id,
@@ -475,7 +479,8 @@ const useChat = (id: string, chatId?: string) => {
         ignoreHistory,
         model,
         preProcessInput,
-        postProcessOutput
+        postProcessOutput,
+        stopSequences,
       );
     },
     sendFeedback: async (createdDate: string, feedback: string) => {

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -43,7 +43,7 @@ const useChatState = create<{
     model: Model | undefined,
     preProcessInput: ((message: ShownMessage[]) => ShownMessage[]) | undefined,
     postProcessOutput: ((message: string) => string) | undefined,
-    stopSequences: string[] | undefined,
+    stopSequences: string[] | undefined
   ) => void;
   sendFeedback: (
     id: string,
@@ -273,7 +273,7 @@ const useChatState = create<{
         | ((message: ShownMessage[]) => ShownMessage[])
         | undefined = undefined,
       postProcessOutput: ((message: string) => string) | undefined = undefined,
-      stopSequences: string[] | undefined = undefined,
+      stopSequences: string[] | undefined = undefined
     ) => {
       setLoading(id, true);
 
@@ -470,7 +470,7 @@ const useChat = (id: string, chatId?: string) => {
         | ((message: ShownMessage[]) => ShownMessage[])
         | undefined = undefined,
       postProcessOutput: ((message: string) => string) | undefined = undefined,
-      stopSequences: string[] | undefined = undefined,
+      stopSequences: string[] | undefined = undefined
     ) => {
       post(
         id,
@@ -480,7 +480,7 @@ const useChat = (id: string, chatId?: string) => {
         model,
         preProcessInput,
         postProcessOutput,
-        stopSequences,
+        stopSequences
       );
     },
     sendFeedback: async (createdDate: string, feedback: string) => {


### PR DESCRIPTION
#270 
stop_sequences に </output> を入れることで、json を出力し終わった後に、テキストを出力させないようにする。
テキスト出力で JSON から出力させる仕組みはまた別途。