### PR TITLE
タイピングスピードを残りの文字列数に応じて変化させる

### DIFF
--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -70,7 +70,10 @@ export class Api extends Construct {
       'mistral.mistral-7b-instruct-v0:2',
       'mistral.mixtral-8x7b-instruct-v0:1',
     ];
-    const multiModalModelIds = ['anthropic.claude-3-sonnet-20240229-v1:0','anthropic.claude-3-haiku-20240307-v1:0'];
+    const multiModalModelIds = [
+      'anthropic.claude-3-sonnet-20240229-v1:0',
+      'anthropic.claude-3-haiku-20240307-v1:0',
+    ];
     for (const modelId of modelIds) {
       if (!supportedModelIds.includes(modelId)) {
         throw new Error(`Unsupported Model Name: ${modelId}`);

--- a/packages/web/src/hooks/useTyping.ts
+++ b/packages/web/src/hooks/useTyping.ts
@@ -21,11 +21,28 @@ const useTyping = (typing?: boolean) => {
     }
   }, [typing, animating, setAnimating, setCurrentIndex]);
 
+  // 入力が必要な残りの文字列数
+  const remainingTextLength = useMemo(() => {
+    return typingTextInput.length - currentIndex;
+  }, [currentIndex, typingTextInput]);
+
+  // 一度に入力する文字列の単位
+  const inputUnit = useMemo(() => {
+    // タイピング中は残りの文字列数に応じて入力文字列数を変化させる
+    // 入力文字数の単位は最大でも 10 文字とする
+    if (typing) {
+      return Math.min(Math.floor(remainingTextLength / 10) + 1, 10);
+    } else {
+      // タイピング中ではない場合は 10 文字を 1 単位で入力する (最速で入力する)
+      return 10;
+    }
+  }, [remainingTextLength]);
+
   useEffect(() => {
     if (animating && currentIndex <= typingTextInput.length + 1) {
       const timeout = setTimeout(() => {
         if (currentIndex < typingTextInput.length + 1) {
-          setCurrentIndex(currentIndex + 1);
+          setCurrentIndex(currentIndex + inputUnit);
         } else {
           // 入力文字列の末尾に追いついた時に typing が false になっていたらアニメーションを終了
           if (!typing) {

--- a/packages/web/src/hooks/useTyping.ts
+++ b/packages/web/src/hooks/useTyping.ts
@@ -36,7 +36,7 @@ const useTyping = (typing?: boolean) => {
       // タイピング中ではない場合は 10 文字を 1 単位で入力する (最速で入力する)
       return 10;
     }
-  }, [remainingTextLength]);
+  }, [typing, remainingTextLength]);
 
   useEffect(() => {
     if (animating && currentIndex <= typingTextInput.length + 1) {
@@ -60,6 +60,7 @@ const useTyping = (typing?: boolean) => {
     typing,
     setCurrentIndex,
     setAnimating,
+    inputUnit,
   ]);
 
   const typingTextOutput = useMemo(() => {


### PR DESCRIPTION
- Claude 3 Haiku の出力が早く、現状の TYPING_DELAY=10 だけでは逆に UX を損ねている
- 現状は固定で 1 文字ずつタイピングアニメーションしているが、入力が必要な文字列の増加に応じて入力文字列単位も増加させる
- なお、TYPING_DELAY を 10 から減らしても UX は改善しなかった (おそらくすでに delay ではなく処理そのものに律速している)