### PR TITLE
feat: ファイルアップロード機能で既存のVPCにデプロイできるようにする

### DIFF
--- a/.github/workflows/deny-cdk-context-json.yml
+++ b/.github/workflows/deny-cdk-context-json.yml
@@ -1,0 +1,17 @@
+name: Deny cdk.context.json
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-cdk-context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for cdk.context.json
+        run: |
+          if [ -f "packages/cdk/cdk.context.json" ]; then
+            echo "cdk.context.json file found in the PR. This is not allowed."
+            exit 1
+          fi

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -359,12 +359,26 @@ context の `dashboard` に `true` を設定します。(デフォルトは `fal
 PDF や Excel などのファイルをアップロードしてテキストを抽出する、ファイルアップロード機能を利用することができます。対応しているファイルは、csv, doc, docx, md, pdf, ppt, pptx, tsv, xlsx です。
 
 **[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
-```
+```json
 {
   "context": {
-    "recognizeFileEnabled": true
+    "recognizeFileEnabled": true,
+    "vpcId": null
   }
 }
 ```
 
-ファイルアップロード機能は ECS (Fargate) 上で実行されます。そのため、有効化すると VPC が新たに作成されます。また、Fargate 上で動くコンテナのビルドを行うために、デプロイ用のマシンでは Docker がインストールされている必要があり、Docker デーモンが起動している必要があります。
+ファイルアップロード機能は ECS (Fargate) 上で実行されます。`vpcId`を指定しない場合は、VPC が新たに作成されます。また、Fargate 上で動くコンテナのビルドを行うために、デプロイ用のマシンでは Docker がインストールされている必要があり、Docker デーモンが起動している必要があります。
+
+既存の VPC を使用する場合は、`vpcId` を指定してください。
+
+
+```json
+{
+  "context": {
+    "recognizeFileEnabled": true,
+    "vpcId": "vpc-xxxxxxxxxxxxxxxxx"
+  }
+}
+```
+

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -44,6 +44,7 @@
     "dashboard": false,
     "anonymousUsageTracking": true,
     "recognizeFileEnabled": false,
+    "vpcId": null,
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": [

--- a/packages/cdk/lib/construct/recognize-file.ts
+++ b/packages/cdk/lib/construct/recognize-file.ts
@@ -59,7 +59,9 @@ export class RecognizeFile extends Construct {
     if (props.vpcId) {
       vpc = Vpc.fromLookup(this, 'Vpc', { vpcId: props.vpcId });
     } else {
-      vpc = new Vpc(this, 'Vpc', {});
+      vpc = new Vpc(this, 'Vpc', {
+        maxAzs: 2,
+      });
     }
     // ECS
     const cluster = new Cluster(this, 'Cluster', {
@@ -119,7 +121,9 @@ export class RecognizeFile extends Construct {
         cpu: 512,
         taskDefinition: taskDefinition,
         publicLoadBalancer: false,
-        taskSubnets: vpc.selectSubnets({ subnetType: SubnetType.PRIVATE_WITH_EGRESS })
+        taskSubnets: vpc.selectSubnets({
+          subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        }),
       }
     );
 

--- a/packages/cdk/lib/construct/recognize-file.ts
+++ b/packages/cdk/lib/construct/recognize-file.ts
@@ -15,7 +15,7 @@ import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
-import { Peer, Port, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { IVpc, Peer, Port, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import {
   Cluster,
   ContainerImage,
@@ -33,6 +33,7 @@ export interface RecognizeFileProps {
   userPool: UserPool;
   api: RestApi;
   fileBucket: Bucket;
+  vpcId?: string;
 }
 
 export class RecognizeFile extends Construct {
@@ -54,8 +55,12 @@ export class RecognizeFile extends Construct {
       props.api.root.getResource('file') || props.api.root.addResource('file');
 
     // VPC
-    const vpc = new Vpc(this, 'Vpc', {});
-
+    let vpc: IVpc;
+    if (props.vpcId) {
+      vpc = Vpc.fromLookup(this, 'Vpc', { vpcId: props.vpcId });
+    } else {
+      vpc = new Vpc(this, 'Vpc', {});
+    }
     // ECS
     const cluster = new Cluster(this, 'Cluster', {
       vpc: vpc,
@@ -114,6 +119,7 @@ export class RecognizeFile extends Construct {
         cpu: 512,
         taskDefinition: taskDefinition,
         publicLoadBalancer: false,
+        taskSubnets: vpc.selectSubnets({ subnetType: SubnetType.PRIVATE_WITH_EGRESS })
       }
     );
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -26,6 +26,7 @@ interface GenerativeAiUseCasesStackProps extends StackProps {
   allowedIpV4AddressRanges: string[] | null;
   allowedIpV6AddressRanges: string[] | null;
   allowedCountryCodes: string[] | null;
+  vpcId?: string;
 }
 
 export class GenerativeAiUseCasesStack extends Stack {
@@ -154,6 +155,7 @@ export class GenerativeAiUseCasesStack extends Stack {
         userPool: auth.userPool,
         api: api.api,
         fileBucket: file.fielBucket,
+        vpcId: props.vpcId,
       });
     }
 


### PR DESCRIPTION
cdk.jsonでVPC IDを指定した場合、既存のVPCにECSクラスタとNLBをデプロイします。これはVPCの数やElastic IPの数などのクォータによってデプロイできないケースを回避し、NAT Gatewayのコストを節約します。

既存のVPCは `Vpc.fromLookup` で参照します。これを使用するためには、デプロイ先のAWSアカウントとリージョンが指定されている必要があるため、スタックの`env`プロパティを指定しました。また、cdk.context.jsonが生成されます。このファイルはユーザーが使用する場合はGitにコミットすべきですが、このリポジトリは公開されたサンプルであるため、コントリビューターのcdk.context.jsonが誤ってコミットされるべきではありません。セキュリティリスクと意図しない挙動を回避するために、cdk.context.jsonが含まれるPRを拒否するためのGitHub Actionsを含めました。

既存のVPCを `Vpc.fromVpcAttributes` で参照することも検討しましたが、指定しなければならない項目が多く、誤った指定をした場合の挙動がデバッグしづらいため、採用しませんでした。

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
