### PR TITLE
[新規ユースケース] 映像分析

### DIFF
--- a/packages/cdk/bin/generative-ai-use-cases.ts
+++ b/packages/cdk/bin/generative-ai-use-cases.ts
@@ -54,7 +54,7 @@ const anonymousUsageTracking: boolean = !!app.node.tryGetContext(
 );
 
 const vpcId = app.node.tryGetContext('vpcId');
-if (typeof vpcId != 'undefined' && vpcId != null && typeof vpcId != 'string' ) {
+if (typeof vpcId != 'undefined' && vpcId != null && typeof vpcId != 'string') {
   throw new Error('vpcId must be string or undefined');
 }
 if (typeof vpcId == 'string' && !vpcId.match(/^vpc-/)) {

--- a/packages/web/src/@types/navigate.d.ts
+++ b/packages/web/src/@types/navigate.d.ts
@@ -62,3 +62,7 @@ export type WebContentPageQueryParams = BaseQueryParams & {
   url?: string;
   context?: string;
 };
+
+export type VideoAnalyzerPageQueryParams = BaseQueryParams & {
+  content: string;
+};

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -17,6 +17,7 @@ import {
   PiX,
   PiRobot,
   PiUploadSimple,
+  PiVideoCamera,
 } from 'react-icons/pi';
 import { Outlet } from 'react-router-dom';
 import Drawer, { ItemProps } from './components/Drawer';
@@ -101,6 +102,12 @@ const items: ItemProps[] = [
     label: '画像生成',
     to: '/image',
     icon: <PiImages />,
+    display: 'usecase' as const,
+  },
+  {
+    label: '映像分析',
+    to: '/video',
+    icon: <PiVideoCamera />,
     display: 'usecase' as const,
   },
   {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -27,11 +27,14 @@ import useDrawer from './hooks/useDrawer';
 import useConversation from './hooks/useConversation';
 import PopupInterUseCasesDemo from './components/PopupInterUseCasesDemo';
 import useInterUseCases from './hooks/useInterUseCases';
+import { MODELS } from './hooks/useModel';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const agentEnabled: boolean = import.meta.env.VITE_APP_AGENT_ENABLED === 'true';
 const recognizeFileEnabled: boolean =
   import.meta.env.VITE_APP_RECOGNIZE_FILE_ENABLED === 'true';
+const { multiModalModelIds } = MODELS;
+const multiModalEnabled: boolean = multiModalModelIds.length > 0;
 
 const items: ItemProps[] = [
   {
@@ -104,12 +107,14 @@ const items: ItemProps[] = [
     icon: <PiImages />,
     display: 'usecase' as const,
   },
-  {
-    label: '映像分析',
-    to: '/video',
-    icon: <PiVideoCamera />,
-    display: 'usecase' as const,
-  },
+  multiModalEnabled
+    ? {
+        label: '映像分析',
+        to: '/video',
+        icon: <PiVideoCamera />,
+        display: 'usecase' as const,
+      }
+    : null,
   {
     label: '音声認識',
     to: '/transcribe',

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -3,7 +3,7 @@ import useFileApi from './useFileApi';
 import { UploadedFileType } from 'generative-ai-use-cases-jp';
 import { produce } from 'immer';
 
-const extractBaseURL = (url: string) => {
+export const extractBaseURL = (url: string) => {
   return url.split(/[?#]/)[0];
 };
 const useFilesState = create<{

--- a/packages/web/src/hooks/useTyping.ts
+++ b/packages/web/src/hooks/useTyping.ts
@@ -75,7 +75,6 @@ const useTyping = (typing?: boolean) => {
   return {
     setTypingTextInput,
     typingTextOutput,
-    animating,
   };
 };
 

--- a/packages/web/src/hooks/useTyping.ts
+++ b/packages/web/src/hooks/useTyping.ts
@@ -75,6 +75,7 @@ const useTyping = (typing?: boolean) => {
   return {
     setTypingTextInput,
     typingTextOutput,
+    animating,
   };
 };
 

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -25,6 +25,7 @@ import GenerateImagePage from './pages/GenerateImagePage';
 import TranscribePage from './pages/TranscribePage';
 import AgentChatPage from './pages/AgentChatPage.tsx';
 import FileUploadPage from './pages/FileUploadPage.tsx';
+import { MODELS } from './hooks/useModel';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const samlAuthEnabled: boolean =
@@ -32,6 +33,8 @@ const samlAuthEnabled: boolean =
 const agentEnabled: boolean = import.meta.env.VITE_APP_AGENT_ENABLED === 'true';
 const recognizeFileEnabled: boolean =
   import.meta.env.VITE_APP_RECOGNIZE_FILE_ENABLED === 'true';
+const { multiModalModelIds } = MODELS;
+const multiModalEnabled: boolean = multiModalModelIds.length > 0;
 
 const routes: RouteObject[] = [
   {
@@ -82,10 +85,12 @@ const routes: RouteObject[] = [
     path: '/transcribe',
     element: <TranscribePage />,
   },
-  {
-    path: '/video',
-    element: <VideoAnalyzerPage />,
-  },
+  multiModalEnabled
+    ? {
+        path: '/video',
+        element: <VideoAnalyzerPage />,
+      }
+    : null,
   recognizeFileEnabled
     ? {
         path: '/file',

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -16,6 +16,7 @@ import SummarizePage from './pages/SummarizePage';
 import GenerateTextPage from './pages/GenerateTextPage';
 import EditorialPage from './pages/EditorialPage';
 import TranslatePage from './pages/TranslatePage';
+import VideoAnalyzerPage from './pages/VideoAnalyzerPage';
 import NotFound from './pages/NotFound';
 import KendraSearchPage from './pages/KendraSearchPage';
 import RagPage from './pages/RagPage';
@@ -80,6 +81,10 @@ const routes: RouteObject[] = [
   {
     path: '/transcribe',
     element: <TranscribePage />,
+  },
+  {
+    path: '/video',
+    element: <VideoAnalyzerPage />,
   },
   recognizeFileEnabled
     ? {

--- a/packages/web/src/pages/VideoAnalyzerPage.tsx
+++ b/packages/web/src/pages/VideoAnalyzerPage.tsx
@@ -110,21 +110,26 @@ const VideoAnalyzerPage: React.FC = () => {
   useEffect(() => {
     const getDevices = async () => {
       // 新規で画面を開いたユーザーにカメラの利用を要求する (ダミーのリクエスト)
-      await navigator.mediaDevices.getUserMedia({
+      const dummyStream = await navigator.mediaDevices.getUserMedia({
         audio: false,
         video: true,
       });
 
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      const videoDevices = devices
-        .filter((device) => device.kind === 'videoinput')
-        .map((device) => {
-          return {
-            value: device.deviceId,
-            label: device.label.replace(/\s\(.*?\)/g, ''),
-          };
-        });
-      setDevices(videoDevices);
+      if (dummyStream) {
+        // 録画ボタンがついてしまうため消す
+        dummyStream.getTracks().forEach((track) => track.stop());
+
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const videoDevices = devices
+          .filter((device) => device.kind === 'videoinput')
+          .map((device) => {
+            return {
+              value: device.deviceId,
+              label: device.label.replace(/\s\(.*?\)/g, ''),
+            };
+          });
+        setDevices(videoDevices);
+      }
     };
 
     getDevices();

--- a/packages/web/src/pages/VideoAnalyzerPage.tsx
+++ b/packages/web/src/pages/VideoAnalyzerPage.tsx
@@ -1,0 +1,187 @@
+import React, {
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+  useMemo,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+import useChat from '../hooks/useChat';
+import useFileApi from '../hooks/useFileApi';
+import { UploadedFileType } from 'generative-ai-use-cases-jp';
+import { extractBaseURL } from '../hooks/useFiles';
+import { create } from 'zustand';
+import { getPrompter } from '../prompts';
+import { MODELS } from '../hooks/useModel';
+import Textarea from '../components/Textarea';
+
+type StateType = {
+  content: string;
+  setContent: (c: string) => void;
+  clear: () => void;
+};
+
+const useVideoAnalyzerPageState = create<StateType>((set) => {
+  const INIT_STATE = {
+    content: '',
+  };
+  return {
+    ...INIT_STATE,
+    setContent: (c: string) => {
+      set(() => ({
+        content: c,
+      }));
+    },
+    clear: () => {
+      set(INIT_STATE);
+    },
+  };
+});
+
+const VideoAnalyzerPage: React.FC = () => {
+  const { content, setContent } = useVideoAnalyzerPageState();
+  const [intervalId, setIntervalId] = useState(null);
+  const [mediaStream, setMediaStream] = useState(null);
+  const videoElement = useRef(null);
+  const callbackRef = React.useRef<() => void>();
+  const { getSignedUrl, uploadFile } = useFileApi();
+  const { pathname } = useLocation();
+  const { getModelId, setModelId, loading, messages, postChat } =
+    useChat(pathname);
+  const modelId = getModelId();
+  const prompter = useMemo(() => {
+    return getPrompter(modelId);
+  }, [modelId]);
+
+  // もしマルチモーダルではないモデルが選択されていたら、マルチモーダルのモデルにする
+  useEffect(() => {
+    if (!MODELS.multiModalModelIds.includes(modelId)) {
+      setModelId(MODELS.multiModalModelIds[0]);
+    }
+  }, [modelId, setModelId]);
+
+  // TODO: query string 対応
+
+  const startPreview = useCallback(async () => {
+    try {
+      if (videoElement.current) {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+        });
+        videoElement.current.srcObject = stream;
+        videoElement.current.play();
+
+        setMediaStream(stream);
+
+        const interval = setInterval(() => {
+          // streaming 中は処理をしない
+          if (loading) {
+            return;
+          }
+
+          const canvas = document.createElement('canvas');
+          canvas.width = videoElement.current.videoWidth;
+          canvas.height = videoElement.current.videoHeight;
+          const context = canvas.getContext('2d');
+          context.drawImage(
+            videoElement.current,
+            0,
+            0,
+            canvas.width,
+            canvas.height
+          );
+          // toDataURL() で返す値は以下の形式 (;base64, 以降のみを使う)
+          // ```
+          // data:image/png;base64,<以下base64...>
+          // ```
+          const imageBase64 = canvas
+            .toDataURL('image/png')
+            .split(';base64,')[1];
+
+          canvas.toBlob(async (blob) => {
+            const file = new File([blob], 'tmp.png', { type: 'image/png' });
+            const signedUrl = (await getSignedUrl({ mediaFormat: 'png' })).data;
+            await uploadFile(signedUrl, { file });
+            const baseUrl = extractBaseURL(signedUrl);
+            const uploadedFiles: UploadedFileType[] = [
+              {
+                file,
+                s3Url: baseUrl,
+                base64EncodedImage: imageBase64,
+              },
+            ];
+
+            postChat(
+              prompter.videoAnalyzerPrompt({
+                content,
+              }),
+              true, // 履歴は考慮しない
+              undefined,
+              undefined,
+              undefined,
+              uploadedFiles
+            );
+          });
+        }, 10000);
+        setIntervalId(interval);
+      }
+    } catch (e) {
+      console.error('ウェブカメラにアクセスできませんでした:', e);
+    }
+  }, [
+    videoElement,
+    setIntervalId,
+    content,
+    loading,
+    getSignedUrl,
+    postChat,
+    prompter,
+    uploadFile,
+  ]);
+
+  const stopPreview = useCallback(() => {
+    if (mediaStream) {
+      mediaStream.getTracks().forEach((track) => track.stop());
+    }
+    if (intervalId) {
+      clearInterval(intervalId);
+    }
+  }, [mediaStream, intervalId]);
+
+  // Callback 関数を常に最新にしておく
+  useEffect(() => {
+    callbackRef.current = stopPreview;
+  }, [stopPreview]);
+
+  // Unmount 時の処理
+  useEffect(() => {
+    return () => {
+      if (callbackRef.current) {
+        callbackRef.current();
+        callbackRef.current = undefined;
+      }
+    };
+  }, []);
+
+  const shownMessages = useMemo(() => {
+    return messages.reverse().filter((m) => m.role === 'assistant');
+  }, [messages]);
+
+  return (
+    <div>
+      <video ref={videoElement} width={640} height={480} />
+      <button onClick={startPreview}>start</button>
+      <button onClick={stopPreview}>stop</button>
+
+      <Textarea
+        placeholder="分析内容を指示してください"
+        value={content}
+        onChange={setContent}
+      />
+
+      {shownMessages.length > 0 && <div>{shownMessages[0].content}</div>}
+    </div>
+  );
+};
+
+export default VideoAnalyzerPage;

--- a/packages/web/src/pages/VideoAnalyzerPage.tsx
+++ b/packages/web/src/pages/VideoAnalyzerPage.tsx
@@ -89,7 +89,6 @@ const VideoAnalyzerPage: React.FC = () => {
 
   useEffect(() => {
     const _modelId = !modelId ? availableMultiModalModels[0] : modelId;
-    console.log(_modelId);
     if (search !== '') {
       const params = queryString.parse(search) as VideoAnalyzerPageQueryParams;
       setContent(params.content);
@@ -109,7 +108,14 @@ const VideoAnalyzerPage: React.FC = () => {
   }, [analysis, setTypingTextInput]);
 
   useEffect(() => {
-    navigator.mediaDevices.enumerateDevices().then((devices) => {
+    const getDevices = async () => {
+      // 新規で画面を開いたユーザーにカメラの利用を要求する (ダミーのリクエスト)
+      await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: true,
+      });
+
+      const devices = await navigator.mediaDevices.enumerateDevices();
       const videoDevices = devices
         .filter((device) => device.kind === 'videoinput')
         .map((device) => {
@@ -119,7 +125,9 @@ const VideoAnalyzerPage: React.FC = () => {
           };
         });
       setDevices(videoDevices);
-    });
+    };
+
+    getDevices();
   }, []);
 
   useEffect(() => {
@@ -286,7 +294,7 @@ const VideoAnalyzerPage: React.FC = () => {
 
               <div className="relative h-48 overflow-y-scroll rounded border border-black/30 p-1.5 xl:h-96">
                 <Markdown>{typingTextOutput}</Markdown>
-                {loading && (
+                {(loading || sending) && (
                   <div className="border-aws-sky size-5 animate-spin rounded-full border-4 border-t-transparent"></div>
                 )}
 

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -8,6 +8,7 @@ import {
   SetTitleParams,
   SummarizeParams,
   TranslateParams,
+  VideoAnalyzerParams,
   WebContentParams,
 } from './index';
 
@@ -17,7 +18,8 @@ const systemContexts: { [key: string]: string } = {
     'あなたは文章を要約するAIアシスタントです。最初のチャットで要約の指示を出すので、その後のチャットで要約結果の改善を行なってください。',
   '/editorial': 'あなたは丁寧に細かいところまで指摘する厳しい校閲担当者です。',
   '/generate': 'あなたは指示に従って文章を作成するライターです。',
-  '/translate': '以下は文章を翻訳したいユーザーと、ユーザーの意図と文章を理解して適切に翻訳する AI のやりとりです。ユーザーは <input> タグで翻訳する文章と、<language> タグで翻訳先の言語を与えます。また、<考慮してほしいこと> タグで翻訳時に考慮してほしいことを与えることもあります。AI は <考慮してほしいこと> がある場合は考慮しつつ、<input> で与えるテキストを <language> で与える言語に翻訳してください。出力は<output>{翻訳結果}</output>の形で翻訳した文章だけを出力してください。それ以外の文章は一切出力してはいけません。',
+  '/translate':
+    '以下は文章を翻訳したいユーザーと、ユーザーの意図と文章を理解して適切に翻訳する AI のやりとりです。ユーザーは <input> タグで翻訳する文章と、<language> タグで翻訳先の言語を与えます。また、<考慮してほしいこと> タグで翻訳時に考慮してほしいことを与えることもあります。AI は <考慮してほしいこと> がある場合は考慮しつつ、<input> で与えるテキストを <language> で与える言語に翻訳してください。出力は<output>{翻訳結果}</output>の形で翻訳した文章だけを出力してください。それ以外の文章は一切出力してはいけません。',
   '/web-content': 'あなたはHTMLからコンテンツを抽出する仕事に従事してます。',
   '/rag': '',
   '/image': `あなたはStable Diffusionのプロンプトを生成するAIアシスタントです。
@@ -64,6 +66,8 @@ const systemContexts: { [key: string]: string } = {
 </output>
 
 出力は必ず prompt キー、 negativePrompt キー, comment キー, recommendedStylePreset キーを包有した JSON 文字列だけで終えてください。それ以外の情報を出力してはいけません。もちろん挨拶や説明を前後に入れてはいけません。例外はありません。`,
+  '/video':
+    'あなたは映像分析を支援するAIアシスタントです。これから映像のフレーム画像とユーザーの入力 <input> を与えるので、<input> の指示に従って答えを出力してください。出力は<output>{答え}</output>の形で出力してください。それ以外の文章は一切出力してはいけません。',
 };
 
 export const claudePrompter: Prompter = {
@@ -232,6 +236,9 @@ ${params
 </回答のルール>
 `;
     }
+  },
+  videoAnalyzerPrompt(params: VideoAnalyzerParams): string {
+    return `<input>${params.content}</input>`;
   },
   setTitlePrompt(params: SetTitleParams): string {
     return `以下はユーザーとAIアシスタントの会話です。まずはこちらを読み込んでください。<conversation>${JSON.stringify(

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -67,7 +67,7 @@ const systemContexts: { [key: string]: string } = {
 
 出力は必ず prompt キー、 negativePrompt キー, comment キー, recommendedStylePreset キーを包有した JSON 文字列だけで終えてください。それ以外の情報を出力してはいけません。もちろん挨拶や説明を前後に入れてはいけません。例外はありません。`,
   '/video':
-    'あなたは映像分析を支援するAIアシスタントです。これから映像のフレーム画像とユーザーの入力 <input> を与えるので、<input> の指示に従って答えを出力してください。出力は<output>{答え}</output>の形で出力してください。それ以外の文章は一切出力してはいけません。',
+    'あなたは映像分析を支援するAIアシスタントです。これから映像のフレーム画像とユーザーの入力 <input> を与えるので、<input> の指示に従って答えを出力してください。出力は<output>{答え}</output>の形で出力してください。それ以外の文章は一切出力してはいけません。また出力は {} で囲わないでください。',
 };
 
 export const claudePrompter: Prompter = {

--- a/packages/web/src/prompts/index.ts
+++ b/packages/web/src/prompts/index.ts
@@ -50,6 +50,10 @@ export type RagParams = {
   referenceItems?: RetrieveResultItem[];
 };
 
+export type VideoAnalyzerParams = {
+  content: string;
+};
+
 export type SetTitleParams = {
   messages: UnrecordedMessage[];
 };
@@ -75,6 +79,7 @@ export interface Prompter {
   translatePrompt(params: TranslateParams): string;
   webContentPrompt(params: WebContentParams): string;
   ragPrompt(params: RagParams): string;
+  videoAnalyzerPrompt(params: VideoAnalyzerParams): string;
   setTitlePrompt(params: SetTitleParams): string;
   promptList(): PromptList;
 }


### PR DESCRIPTION
- 映像分析のユースケースを追加
- 分析テキスト送信時にウェブカメラのフレーム画像をマルチモーダルモデルに送信
- useChat と連携しているため、分析したフレームは後から会話履歴から見れる
- 同じ命令を複数回送信する可能性を考慮し、送信後に入力をリセットしていない

README.md 等のドキュメント対応はこちらの PR が merge されたら別で対応します！