### PR TITLE
UI を微修正 (Web コンテンツ抽出・画像生成)

### DIFF
--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -597,7 +597,8 @@ const GenerateImagePage: React.FC = () => {
                 setSelectedImageIndex(0);
                 generateImage(prompt, negativePrompt);
               }}
-              loading={generating || loadingChat}>
+              loading={generating || loadingChat}
+              disabled={prompt.length === 0}>
               生成
             </Button>
 

--- a/packages/web/src/pages/WebContent.tsx
+++ b/packages/web/src/pages/WebContent.tsx
@@ -268,12 +268,12 @@ const WebContent: React.FC = () => {
 
           <div className="mt-2 rounded border border-black/30 p-1.5">
             <Markdown>{typingTextOutput}</Markdown>
-            {!loading && content === '' && (
+            {!loading && !fetching && content === '' && (
               <div className="text-gray-500">
                 抽出された文章がここに表示されます
               </div>
             )}
-            {loading && (
+            {(loading || fetching) && (
               <div className="border-aws-sky size-5 animate-spin rounded-full border-4 border-t-transparent"></div>
             )}
             <div className="flex w-full justify-end">


### PR DESCRIPTION
気になったところを微修正しました
- Web コンテンツ抽出で元文章を fetch している時に loading を表示するように変更
- Prompt がない時に画像生成の「生成」ボタンがクリックできないように変更