### PR TITLE
Claude 3 系で画像生成時にエラーになる件

### DIFF
--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -59,10 +59,10 @@ const systemContexts: { [key: string]: string } = {
 
 <output>
 {
-  prompt: string,
-  negativePrompt: string,
-  comment: string
-  recommendedStylePreset: string[]
+  "prompt": string,
+  "negativePrompt": string,
+  "comment": string,
+  "recommendedStylePreset": string[]
 }
 </output>
 


### PR DESCRIPTION
- Claude 3 がタイポのある prompt を忠実に再現するおかげで json parse 時にエラーになる
- prompt を有効な json に修正

![スクリーンショット 2024-05-02 10 40 14](https://github.com/aws-samples/generative-ai-use-cases-jp/assets/3483230/84fe6216-8908-4dba-8aff-4c1691b02d51)

