### PR TITLE
自動翻訳・自動校正の state を local storage に保存するように

### DIFF
--- a/packages/web/src/pages/EditorialPage.tsx
+++ b/packages/web/src/pages/EditorialPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import Card from '../components/Card';
 import Button from '../components/Button';
@@ -7,6 +7,7 @@ import ExpandableField from '../components/ExpandableField';
 import Switch from '../components/Switch';
 import Select from '../components/Select';
 import useChat from '../hooks/useChat';
+import useLocalStorageBoolean from '../hooks/useLocalStorageBoolean';
 import { create } from 'zustand';
 import Texteditor from '../components/TextEditor';
 import { DocumentComment } from 'generative-ai-use-cases-jp';
@@ -106,7 +107,7 @@ const EditorialPage: React.FC = () => {
   const prompter = useMemo(() => {
     return getPrompter(modelId);
   }, [modelId]);
-  const [auto, setAuto] = useState(true);
+  const [auto, setAuto] = useLocalStorageBoolean('Auto_Editorial', true);
 
   useEffect(() => {
     updateSystemContextByModel();

--- a/packages/web/src/pages/TranslatePage.tsx
+++ b/packages/web/src/pages/TranslatePage.tsx
@@ -11,6 +11,7 @@ import Switch from '../components/Switch';
 import useChat from '../hooks/useChat';
 import useMicrophone from '../hooks/useMicrophone';
 import useTyping from '../hooks/useTyping';
+import useLocalStorageBoolean from '../hooks/useLocalStorageBoolean';
 import { PiMicrophoneBold, PiStopCircleBold } from 'react-icons/pi';
 import { create } from 'zustand';
 import debounce from 'lodash.debounce';
@@ -112,7 +113,7 @@ const TranslatePage: React.FC = () => {
   const prompter = useMemo(() => {
     return getPrompter(modelId);
   }, [modelId]);
-  const [auto, setAuto] = useState(true);
+  const [auto, setAuto] = useLocalStorageBoolean('Auto_Translate', true);
   const [audio, setAudioInput] = useState(false); // 音声入力フラグ
 
   useEffect(() => {


### PR DESCRIPTION
毎度自動が ON になるのが嫌だったので実装しました。
Auto_xxx の書式は https://github.com/aws-samples/generative-ai-use-cases-jp/blob/main/packages/web/src/components/ExpandableMenu.tsx#L16 ここを継承しました。