### PR TITLE
画像生成ユーズケースの改善（解像度, 類似画像生成改善)

### DIFF
--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -383,8 +383,11 @@ const createBodyImageStableDiffusion = (params: GenerateImageParams) => {
     style_preset: params.stylePreset,
     seed: params.seed,
     steps: params.step,
-    init_image: params.initImage,
     image_strength: params.imageStrength,
+    height: params.height,
+    width: params.width,
+    // Image to Image
+    init_image: params.initImage,
   };
   return JSON.stringify(body);
 };
@@ -394,8 +397,8 @@ const createBodyImageTitanImage = (params: GenerateImageParams) => {
   const imageGenerationConfig = {
     numberOfImages: 1,
     quality: 'standard',
-    height: 512,
-    width: 512,
+    height: params.height,
+    width: params.width,
     cfgScale: params.cfgScale,
     seed: params.seed % 214783648, // max for titan image
   };
@@ -410,6 +413,7 @@ const createBodyImageTitanImage = (params: GenerateImageParams) => {
           params.stylePreset,
         negativeText: params.textPrompt.find((x) => x.weight < 0)?.text,
         images: [params.initImage],
+        similarityStrength: Math.max(params.imageStrength || 0.2, 0.2), // Min 0.2
       },
       imageGenerationConfig: imageGenerationConfig,
     };

--- a/packages/types/src/image.d.ts
+++ b/packages/types/src/image.d.ts
@@ -8,8 +8,15 @@ export type GenerateImageParams = {
   seed: number;
   step: number;
   stylePreset?: string;
-  initImage?: string;
   imageStrength?: number;
+  height: number;
+  width: number;
+  // Image to Image
+  initImage?: string;
+  // Inpaint / Outpaint
+  maskImage?: string;
+  maskPrompt?: string;
+  maskMode?: 'INPAINTING' | 'OUTPAINTING';
 };
 
 // Stable Diffusion
@@ -19,8 +26,8 @@ export type StableDiffusionParams = {
     text: string;
     weight: number;
   }[];
-  height?: string;
-  width?: string;
+  height?: number;
+  width?: number;
   cfg_scale?: number;
   clip_guidance_preset?: string;
   sampler?: string;
@@ -32,6 +39,9 @@ export type StableDiffusionParams = {
   init_image?: string;
   init_image_mode?: string;
   image_strength?: number;
+  // Image to Image (Masking)
+  mask_source?: string;
+  mask_image?: string;
 };
 
 // Titan Image
@@ -61,6 +71,7 @@ export type TitanImageParams = {
     text?: string;
     negativeText?: string;
     images: string[];
+    similarityStrength?: number;
   };
   imageGenerationConfig: {
     numberOfImages: number;
@@ -68,7 +79,7 @@ export type TitanImageParams = {
     height: number;
     width: number;
     cfgScale: number;
-    seed: number;
+    seed?: number;
   };
 };
 

--- a/packages/web/src/components/Button.tsx
+++ b/packages/web/src/components/Button.tsx
@@ -3,6 +3,7 @@ import { BaseProps } from '../@types/common';
 import { PiSpinnerGap } from 'react-icons/pi';
 
 type Props = BaseProps & {
+  title?: string;
   disabled?: boolean;
   loading?: boolean;
   outlined?: boolean;
@@ -21,6 +22,7 @@ const Button: React.FC<Props> = (props) => {
       flex items-center justify-center rounded-lg p-1 px-3 ${
         props.disabled || props.loading ? 'opacity-30' : 'hover:brightness-75'
       }`}
+      title={props.title}
       onClick={props.onClick}
       disabled={props.disabled || props.loading}>
       {props.loading && <PiSpinnerGap className="mr-2 animate-spin" />}

--- a/packages/web/src/components/ExpandableField.tsx
+++ b/packages/web/src/components/ExpandableField.tsx
@@ -1,31 +1,38 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import RowItem, { RowItemProps } from './RowItem';
 import { PiCaretRightFill } from 'react-icons/pi';
 
 type Props = RowItemProps & {
   label: string;
   defaultOpened?: boolean;
-  expanded?: number;
   optional?: boolean;
   children: React.ReactNode;
+  // トグル状態を親コンポーネントから制御したい場合のプロパティ
+  overrideExpanded?: boolean;
+  setOverrideExpanded?: (overrideExpanded: boolean) => void;
 };
 
 const ExpandableField: React.FC<Props> = (props) => {
   const [expanded, setExpanded] = useState(props.defaultOpened ?? false);
 
-  useEffect(() => {
-    setExpanded(props.expanded !== undefined && props.expanded > 0);
-  }, [props.expanded]);
+  // トグル状態の上書きに対応するために expanded と overrideExpanded の or をとる
+  const expandState = useMemo(
+    () => expanded || props.overrideExpanded,
+    [expanded, props.overrideExpanded]
+  );
 
   return (
     <RowItem notItem={props.notItem} className={props.className}>
       <div
         className="mb-1 flex cursor-pointer items-center text-sm font-semibold"
         onClick={() => {
-          setExpanded(!expanded);
+          setExpanded(!expandState);
+          if (props.setOverrideExpanded) {
+            props.setOverrideExpanded(!expandState);
+          }
         }}>
         <PiCaretRightFill
-          className={`mr-1 ${expanded && 'rotate-90'} transition`}
+          className={`mr-1 ${expandState && 'rotate-90'} transition`}
         />
         {props.label}
         {props.optional && (
@@ -36,7 +43,7 @@ const ExpandableField: React.FC<Props> = (props) => {
         )}
       </div>
 
-      {expanded && <>{props.children}</>}
+      {expandState && <>{props.children}</>}
     </RowItem>
   );
 };

--- a/packages/web/src/components/ExpandableField.tsx
+++ b/packages/web/src/components/ExpandableField.tsx
@@ -1,16 +1,21 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import RowItem, { RowItemProps } from './RowItem';
 import { PiCaretRightFill } from 'react-icons/pi';
 
 type Props = RowItemProps & {
   label: string;
   defaultOpened?: boolean;
+  expanded?: number;
   optional?: boolean;
   children: React.ReactNode;
 };
 
 const ExpandableField: React.FC<Props> = (props) => {
   const [expanded, setExpanded] = useState(props.defaultOpened ?? false);
+
+  useEffect(() => {
+    setExpanded(props.expanded !== undefined && props.expanded > 0);
+  }, [props.expanded]);
 
   return (
     <RowItem notItem={props.notItem} className={props.className}>

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -7,7 +7,7 @@ import RangeSlider from '../components/RangeSlider';
 import Select from '../components/Select';
 import ExpandableField from '../components/ExpandableField';
 import ButtonIcon from '../components/ButtonIcon';
-import { PiFileArrowUp, PiDiceFive, PiShuffle } from 'react-icons/pi';
+import { PiFileArrowUp, PiDiceFive, PiNotePencil } from 'react-icons/pi';
 import useImage from '../hooks/useImage';
 import GenerateImageAssistant from '../components/GenerateImageAssistant';
 import SketchPad from '../components/SketchPad';
@@ -278,6 +278,7 @@ const GenerateImagePage: React.FC = () => {
   const [generating, setGenerating] = useState(false);
   const [isOpenSketch, setIsOpenSketch] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const [detailExpanded, setDetailExpanded] = useState(0);
   const { modelIds, imageGenModelIds, imageGenModels } = MODELS;
   const modelId = getModelId();
   const prompter = useMemo(() => {
@@ -361,7 +362,7 @@ const GenerateImagePage: React.FC = () => {
           stylePreset: _stylePreset ?? stylePreset,
         };
 
-        if (generationMode === "IMAGE_VARIATION") {
+        if (generationMode === 'IMAGE_VARIATION') {
           params = {
             ...params,
             initImage: initImageBase64,
@@ -397,6 +398,7 @@ const GenerateImagePage: React.FC = () => {
       height,
       imageSample,
       imageStrength,
+      generationMode,
       initImageBase64,
       seed,
       setImage,
@@ -435,8 +437,15 @@ const GenerateImagePage: React.FC = () => {
       setInitImageBase64(
         `data:image/png;base64,${image[selectedImageIndex].base64}`
       );
+      setDetailExpanded(performance.now());
     }
-  }, [image, selectedImageIndex, setGenerationMode, setInitImageBase64]);
+  }, [
+    image,
+    selectedImageIndex,
+    setGenerationMode,
+    setInitImageBase64,
+    setDetailExpanded,
+  ]);
 
   const clearAll = useCallback(() => {
     setSelectedImageIndex(0);
@@ -524,10 +533,11 @@ const GenerateImagePage: React.FC = () => {
               </React.Fragment>
             ))}
             <Button
+              title="Generate Variant"
               outlined
               className="mt-3 size-10"
               onClick={generateImageVariant}>
-              <PiShuffle></PiShuffle>
+              <PiNotePencil></PiNotePencil>
             </Button>
           </div>
 
@@ -597,7 +607,7 @@ const GenerateImagePage: React.FC = () => {
             />
           </div>
 
-          <ExpandableField label="詳細なパラメータ">
+          <ExpandableField label="詳細なパラメータ" expanded={detailExpanded}>
             <div className="grid grid-cols-2 gap-2 pt-4">
               <div className="col-span-2 flex flex-col items-stretch justify-start lg:col-span-1">
                 <Select

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -342,7 +342,7 @@ const GenerateImagePage: React.FC = () => {
           _seed = rand;
         }
 
-        const params: GenerateImageParams = {
+        let params: GenerateImageParams = {
           textPrompt: [
             {
               text: _prompt,
@@ -359,9 +359,15 @@ const GenerateImagePage: React.FC = () => {
           seed: _seed,
           step,
           stylePreset: _stylePreset ?? stylePreset,
-          initImage: initImageBase64,
-          imageStrength: imageStrength,
         };
+
+        if (generationMode === "IMAGE_VARIATION") {
+          params = {
+            ...params,
+            initImage: initImageBase64,
+            imageStrength,
+          };
+        }
 
         return generate(
           params,

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -278,7 +278,7 @@ const GenerateImagePage: React.FC = () => {
   const [generating, setGenerating] = useState(false);
   const [isOpenSketch, setIsOpenSketch] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
-  const [detailExpanded, setDetailExpanded] = useState(0);
+  const [detailExpanded, setDetailExpanded] = useState(false);
   const { modelIds, imageGenModelIds, imageGenModels } = MODELS;
   const modelId = getModelId();
   const prompter = useMemo(() => {
@@ -437,7 +437,7 @@ const GenerateImagePage: React.FC = () => {
       setInitImageBase64(
         `data:image/png;base64,${image[selectedImageIndex].base64}`
       );
-      setDetailExpanded(performance.now());
+      setDetailExpanded(true);
     }
   }, [
     image,
@@ -536,6 +536,7 @@ const GenerateImagePage: React.FC = () => {
               title="Generate Variant"
               outlined
               className="mt-3 size-10"
+              disabled={!image[selectedImageIndex].base64}
               onClick={generateImageVariant}>
               <PiNotePencil></PiNotePencil>
             </Button>
@@ -607,7 +608,10 @@ const GenerateImagePage: React.FC = () => {
             />
           </div>
 
-          <ExpandableField label="詳細なパラメータ" expanded={detailExpanded}>
+          <ExpandableField
+            label="詳細なパラメータ"
+            overrideExpanded={detailExpanded}
+            setOverrideExpanded={setDetailExpanded}>
             <div className="grid grid-cols-2 gap-2 pt-4">
               <div className="col-span-2 flex flex-col items-stretch justify-start lg:col-span-1">
                 <Select

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -7,7 +7,7 @@ import RangeSlider from '../components/RangeSlider';
 import Select from '../components/Select';
 import ExpandableField from '../components/ExpandableField';
 import ButtonIcon from '../components/ButtonIcon';
-import { PiFileArrowUp, PiDiceFive } from 'react-icons/pi';
+import { PiFileArrowUp, PiDiceFive, PiShuffle } from 'react-icons/pi';
 import useImage from '../hooks/useImage';
 import GenerateImageAssistant from '../components/GenerateImageAssistant';
 import SketchPad from '../components/SketchPad';
@@ -22,8 +22,25 @@ import { GenerateImagePageQueryParams } from '../@types/navigate';
 import { MODELS } from '../hooks/useModel';
 import { getPrompter } from '../prompts';
 import queryString from 'query-string';
+import { GenerateImageParams } from 'generative-ai-use-cases-jp';
 
 const MAX_SAMPLE = 7;
+
+type GenerationMode = 'TEXT_IMAGE' | 'IMAGE_VARIATION';
+const modeOptions = ['TEXT_IMAGE', 'IMAGE_VARIATION'].map((s) => ({
+  value: s as GenerationMode,
+  label: s as GenerationMode,
+}));
+
+const resolutionPresets = [
+  '512 x 512',
+  '1024 x 1024',
+  '1280 x 768',
+  '768 x 1280',
+].map((s) => ({
+  value: s,
+  label: s,
+}));
 
 type StateType = {
   imageGenModelId: string;
@@ -32,6 +49,8 @@ type StateType = {
   setPrompt: (s: string) => void;
   negativePrompt: string;
   setNegativePrompt: (s: string) => void;
+  resolution: string;
+  setResolution: (s: string) => void;
   stylePreset: string;
   setStylePreset: (s: string) => void;
   seed: number[];
@@ -42,6 +61,8 @@ type StateType = {
   setCfgScale: (n: number) => void;
   imageStrength: number;
   setImageStrength: (n: number) => void;
+  generationMode: GenerationMode;
+  setGenerationMode: (s: GenerationMode) => void;
   initImageBase64: string;
   setInitImageBase64: (s: string) => void;
   imageSample: number;
@@ -64,11 +85,13 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
     imageGenModelId: '',
     prompt: '',
     negativePrompt: '',
+    resolution: resolutionPresets[0].value,
     stylePreset: '',
     seed: [0, ...new Array(MAX_SAMPLE - 1).fill(-1)],
     step: 50,
     cfgScale: 7,
     imageStrength: 0.35,
+    generationMode: modeOptions[0]['value'],
     initImageBase64: '',
     imageSample: 3,
     image: new Array(MAX_SAMPLE).fill({
@@ -93,6 +116,11 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
     setNegativePrompt: (s) => {
       set(() => ({
         negativePrompt: s,
+      }));
+    },
+    setResolution: (s) => {
+      set(() => ({
+        resolution: s,
       }));
     },
     setStylePreset: (s) => {
@@ -120,6 +148,11 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
     setImageStrength: (n) => {
       set(() => ({
         imageStrength: n,
+      }));
+    },
+    setGenerationMode: (s) => {
+      set(() => ({
+        generationMode: s,
       }));
     },
     setInitImageBase64: (s) => {
@@ -205,6 +238,8 @@ const GenerateImagePage: React.FC = () => {
     setPrompt,
     negativePrompt,
     setNegativePrompt,
+    resolution,
+    setResolution,
     stylePreset,
     setStylePreset,
     seed,
@@ -213,6 +248,8 @@ const GenerateImagePage: React.FC = () => {
     setStep,
     cfgScale,
     setCfgScale,
+    generationMode,
+    setGenerationMode,
     initImageBase64,
     setInitImageBase64,
     image,
@@ -246,6 +283,9 @@ const GenerateImagePage: React.FC = () => {
   const prompter = useMemo(() => {
     return getPrompter(modelId);
   }, [modelId]);
+  const [width, height] = useMemo(() => {
+    return resolution.split('x').map((v) => Number(v));
+  }, [resolution]);
 
   useEffect(() => {
     updateSystemContextByModel();
@@ -302,25 +342,29 @@ const GenerateImagePage: React.FC = () => {
           _seed = rand;
         }
 
+        const params: GenerateImageParams = {
+          textPrompt: [
+            {
+              text: _prompt,
+              weight: 1,
+            },
+            {
+              text: _negativePrompt,
+              weight: -1,
+            },
+          ],
+          width: width,
+          height: height,
+          cfgScale,
+          seed: _seed,
+          step,
+          stylePreset: _stylePreset ?? stylePreset,
+          initImage: initImageBase64,
+          imageStrength: imageStrength,
+        };
+
         return generate(
-          {
-            textPrompt: [
-              {
-                text: _prompt,
-                weight: 1,
-              },
-              {
-                text: _negativePrompt,
-                weight: -1,
-              },
-            ],
-            cfgScale,
-            seed: _seed,
-            step,
-            stylePreset: _stylePreset ?? stylePreset,
-            initImage: initImageBase64,
-            imageStrength: imageStrength,
-          },
+          params,
           imageGenModels.find((m) => m.modelId === imageGenModelId)
         )
           .then((res) => {
@@ -343,6 +387,8 @@ const GenerateImagePage: React.FC = () => {
       clearImage,
       generate,
       generateRandomSeed,
+      width,
+      height,
       imageSample,
       imageStrength,
       initImageBase64,
@@ -377,6 +423,15 @@ const GenerateImagePage: React.FC = () => {
     [generateRandomSeed, seed, setSeed]
   );
 
+  const generateImageVariant = useCallback(() => {
+    if (image[selectedImageIndex].base64) {
+      setGenerationMode('IMAGE_VARIATION');
+      setInitImageBase64(
+        `data:image/png;base64,${image[selectedImageIndex].base64}`
+      );
+    }
+  }, [image, selectedImageIndex, setGenerationMode, setInitImageBase64]);
+
   const clearAll = useCallback(() => {
     setSelectedImageIndex(0);
     clear();
@@ -394,6 +449,8 @@ const GenerateImagePage: React.FC = () => {
           setIsOpenSketch(false);
         }}>
         <SketchPad
+          width={width}
+          height={height}
           imageBase64={initImageBase64}
           onChange={onChangeInitImageBase64}
           onCancel={() => {
@@ -433,7 +490,7 @@ const GenerateImagePage: React.FC = () => {
         <Card className="lg:min-h-[calc(100vh-2rem)]">
           <div className="flex items-center justify-center">
             <Base64Image
-              className="size-60"
+              className="min-h-60 min-w-60 max-w-lg"
               imageBase64={image[selectedImageIndex].base64}
               loading={generating}
               error={image[selectedImageIndex].error}
@@ -460,6 +517,12 @@ const GenerateImagePage: React.FC = () => {
                 )}
               </React.Fragment>
             ))}
+            <Button
+              outlined
+              className="mt-3 size-10"
+              onClick={generateImageVariant}>
+              <PiShuffle></PiShuffle>
+            </Button>
           </div>
 
           <Textarea
@@ -480,13 +543,22 @@ const GenerateImagePage: React.FC = () => {
             rows={2}
           />
 
-          <Select
-            value={imageGenModelId}
-            onChange={setImageGenModelId}
-            options={imageGenModelIds.map((m) => {
-              return { value: m, label: m };
-            })}
-          />
+          <div className="grid w-full grid-cols-2 gap-2">
+            <Select
+              label="モデル"
+              value={imageGenModelId}
+              onChange={setImageGenModelId}
+              options={imageGenModelIds.map((m) => {
+                return { value: m, label: m };
+              })}
+            />
+            <Select
+              label="サイズ"
+              value={resolution}
+              onChange={setResolution}
+              options={resolutionPresets}
+            />
+          </div>
 
           <div className="grid w-full grid-cols-2 gap-2 pt-4">
             <div className="relative col-span-2 flex flex-row items-center lg:col-span-1">
@@ -520,31 +592,44 @@ const GenerateImagePage: React.FC = () => {
           </div>
 
           <ExpandableField label="詳細なパラメータ">
-            <div className="grid grid-cols-2 pt-4">
-              <div className="col-span-2 flex flex-col items-center justify-center lg:col-span-1">
-                <div className="mb-1 flex items-center text-sm font-bold">
-                  初期画像
-                  <Help
-                    className="ml-1"
-                    position="center"
-                    message="画像生成の初期状態となる画像を設定できます。初期画像を設定することで、初期画像に近い画像を生成するように誘導できます。"
-                  />
-                </div>
-                <Base64Image
-                  className="size-32"
-                  imageBase64={initImageBase64}
+            <div className="grid grid-cols-2 gap-2 pt-4">
+              <div className="col-span-2 flex flex-col items-stretch justify-start lg:col-span-1">
+                <Select
+                  label="GenerationMode"
+                  options={modeOptions}
+                  value={generationMode}
+                  onChange={(v) => setGenerationMode(v as GenerationMode)}
+                  fullWidth
                 />
-                <Button
-                  className="m-auto mt-2 text-sm"
-                  onClick={() => {
-                    setIsOpenSketch(true);
-                  }}>
-                  <PiFileArrowUp className="mr-2" />
-                  設定
-                </Button>
+                <div className="mb-2 flex flex-row justify-center gap-2 lg:flex-col xl:flex-row">
+                  {generationMode !== 'TEXT_IMAGE' && (
+                    <div className="flex flex-col items-center">
+                      <div className="mb-1 flex items-center text-sm font-bold">
+                        初期画像
+                        <Help
+                          className="ml-1"
+                          position="center"
+                          message="画像生成の初期状態となる画像を設定できます。初期画像を設定することで、初期画像に近い画像を生成するように誘導できます。"
+                        />
+                      </div>
+                      <Base64Image
+                        className="size-32"
+                        imageBase64={initImageBase64}
+                      />
+                      <Button
+                        className="m-auto mt-2 text-sm"
+                        onClick={() => {
+                          setIsOpenSketch(true);
+                        }}>
+                        <PiFileArrowUp className="mr-2" />
+                        設定
+                      </Button>
+                    </div>
+                  )}
+                </div>
               </div>
 
-              <div className="col-span-2 flex flex-col items-center justify-center lg:col-span-1">
+              <div className="col-span-2 flex flex-col items-center justify-start lg:col-span-1">
                 <div className="mb-2 w-full">
                   <Select
                     label="StylePreset"
@@ -570,22 +655,24 @@ const GenerateImagePage: React.FC = () => {
                   className="w-full"
                   label="Step"
                   min={10}
-                  max={150}
+                  max={50}
                   value={step}
                   onChange={setStep}
                   help="画像生成の反復回数です。Step 数が多いほど画像が洗練されますが、生成に時間がかかります。"
                 />
 
-                <RangeSlider
-                  className="w-full"
-                  label="ImageStrength"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={imageStrength}
-                  onChange={setImageStrength}
-                  help="1に近いほど「初期画像」に近い画像が生成され、0に近いほど「初期画像」とは異なる画像が生成されます。"
-                />
+                {generationMode === 'IMAGE_VARIATION' && (
+                  <RangeSlider
+                    className="w-full"
+                    label="ImageStrength"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={imageStrength}
+                    onChange={setImageStrength}
+                    help="1に近いほど「初期画像」に近い画像が生成され、0に近いほど「初期画像」とは異なる画像が生成されます。"
+                  />
+                )}
               </div>
             </div>
           </ExpandableField>


### PR DESCRIPTION
*Issue #, if available:*
- #162, #404
- #507 
- #332 

*Description of changes:*
- 類似画像生成をワンクリックでできるボタンの追加
- Titan Image の similarityStrength パラメータの対応
- 解像度が 512 x 512 固定だったのを変更できるように対応
- リファクタリング

別 PR で Inpaint / Outpaint を実装するため事前のコード整理も行っています。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
