### PR TITLE
fix: JavaScript heap out of memory error on CodeBuild

### DIFF
--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -178,6 +178,7 @@ export class Web extends Construct {
           props.samlCognitoFederatedIdentityProviderName.toString(),
         VITE_APP_AGENT_NAMES: JSON.stringify(props.agentNames),
         VITE_APP_RECOGNIZE_FILE_ENABLED: props.recognizeFileEnabled.toString(),
+        NODE_OPTIONS: '--max-old-space-size=2048'
       },
     });
 


### PR DESCRIPTION
*Issue #, if available:*

NodejsBuild の処理の中で、JavaScript heap out of memory error が発生していました。
割り当てているコンピューティング環境は現在 "3 GB メモリ、2 vCPU" です。（deploy-time-build の NodejsBuild Construct の Default）

<details>

<summary>CodeBuild Error log</summary>

### CodeBuild Error log

```
[Container] 2024/06/04 00:46:34.288780 Running on CodeBuild On-demand
--
2 | [Container] 2024/06/04 00:46:34.288793 Waiting for agent ping
3 | [Container] 2024/06/04 00:46:34.490210 Waiting for DOWNLOAD_SOURCE
4 | [Container] 2024/06/04 00:46:35.006026 Phase is DOWNLOAD_SOURCE
5 | [Container] 2024/06/04 00:46:35.006928 CODEBUILD_SRC_DIR=/codebuild/output/src856953380/src
6 | [Container] 2024/06/04 00:46:35.006985 YAML location is /codebuild/readonly/buildspec.yml
7 | [Container] 2024/06/04 00:46:35.007228 No commands found for phase name: install
8 | [Container] 2024/06/04 00:46:35.009793 Processing environment variables
9 | [Container] 2024/06/04 00:46:35.255682 Selecting 'nodejs' runtime version '18' based on manual selections...
10 | [Container] 2024/06/04 00:46:37.929261 Moving to directory /codebuild/output/src856953380/src
11 | [Container] 2024/06/04 00:46:37.930971 Unable to initialize cache download: no paths specified to be cached
12 | [Container] 2024/06/04 00:46:38.064507 Configuring ssm agent with target id: codebuild:5f664165-f38d-4aca-b8c7-7d0ce3fc871b
13 | [Container] 2024/06/04 00:46:38.100882 Successfully updated ssm agent configuration
14 | [Container] 2024/06/04 00:46:38.101315 Registering with agent
15 | [Container] 2024/06/04 00:46:38.150686 Phases found in YAML: 3
16 | [Container] 2024/06/04 00:46:38.150707  POST_BUILD: 2 commands
17 | [Container] 2024/06/04 00:46:38.150712  INSTALL: 0 commands
18 | [Container] 2024/06/04 00:46:38.150715  BUILD: 10 commands
19 | [Container] 2024/06/04 00:46:38.151002 Phase complete: DOWNLOAD_SOURCE State: SUCCEEDED
20 | [Container] 2024/06/04 00:46:38.151015 Phase context status code:  Message:
21 | [Container] 2024/06/04 00:46:38.236490 Entering phase INSTALL
22 | [Container] 2024/06/04 00:46:38.238521 Phase complete: INSTALL State: SUCCEEDED
23 | [Container] 2024/06/04 00:46:38.238538 Phase context status code:  Message:
24 | [Container] 2024/06/04 00:46:38.308933 Entering phase PRE_BUILD
25 | [Container] 2024/06/04 00:46:38.310907 Phase complete: PRE_BUILD State: SUCCEEDED
26 | [Container] 2024/06/04 00:46:38.310921 Phase context status code:  Message:
27 | [Container] 2024/06/04 00:46:38.350182 Entering phase BUILD
28 | [Container] 2024/06/04 00:46:38.352251 Running command current_dir=$(pwd)
29 |  
30 | [Container] 2024/06/04 00:46:38.359800 Running command
31 | echo "$input"
32 | for obj in $(echo "$input" \| jq -r '.[] \| @base64'); do
33 | decoded=$(echo "$obj" \| base64 --decode)
34 | assetUrl=$(echo "$decoded" \| jq -r '.assetUrl')
35 | extractPath=$(echo "$decoded" \| jq -r '.extractPath')
36 | commands=$(echo "$decoded" \| jq -r '.commands')
37 |  
38 | # Download the zip file
39 | aws s3 cp "$assetUrl" temp.zip
40 |  
41 | # Extract the zip file to the extractPath directory
42 | mkdir -p "$extractPath"
43 | unzip temp.zip -d "$extractPath"
44 |  
45 | # Remove the zip file
46 | rm temp.zip
47 |  
48 | # Run the specified commands in the extractPath directory
49 | cd "$extractPath"
50 | ls -la
51 | eval "$commands"
52 | cd "$current_dir"
53 | ls -la
54 | done
55 |  
56 | [{"assetUrl":"s3://cdk-hnb659fds-assets-988417841316-ap-northeast-1/b60255202e1c94c95cea3123a17f73a1039891a46a28e753cbe5f42c433af76e.zip","extractPath":"..","commands":""}]
57 | Completed 256.0 KiB/484.7 KiB (1.4 MiB/s) with 1 file(s) remaining
58 | Completed 484.7 KiB/484.7 KiB (2.6 MiB/s) with 1 file(s) remaining
59 | download: s3://cdk-hnb659fds-assets-988417841316-ap-northeast-1/b60255202e1c94c95cea3123a17f73a1039891a46a28e753cbe5f42c433af76e.zip to ./temp.zip
60 | Archive:  temp.zip
61 | inflating: ../package-lock.json
62 | inflating: ../package.json
63 | inflating: ../packages/cdk/.eslintrc.cjs
64 | inflating: ../packages/cdk/.npmignore
65 | inflating: ../packages/cdk/cdk.json
66 | inflating: ../packages/types/package.json
67 | inflating: ../packages/types/src/base.d.ts
68 | inflating: ../packages/types/src/chat.d.ts
69 | inflating: ../packages/types/src/image.d.ts
70 | inflating: ../packages/types/src/index.d.ts
71 | inflating: ../packages/types/src/message.d.ts
72 | inflating: ../packages/types/src/prompt.d.ts
73 | inflating: ../packages/types/src/protocol.d.ts
74 | inflating: ../packages/types/src/share.d.ts
75 | inflating: ../packages/types/src/systemContext.d.ts
76 | inflating: ../packages/types/src/text.d.ts
77 | inflating: ../packages/types/src/utils.d.ts
78 | inflating: ../packages/web/.eslintrc.cjs
79 | inflating: ../packages/web/index.html
80 | inflating: ../packages/web/package.json
81 | inflating: ../packages/web/postcss.config.js
82 | inflating: ../packages/web/public/favicon.png
83 | inflating: ../packages/web/public/favicon.svg
84 | inflating: ../packages/web/public/images/aws_bg_white.svg
85 | inflating: ../packages/web/public/images/aws_icon_180_bg_white.png
86 | inflating: ../packages/web/public/images/aws_icon_180.png
87 | inflating: ../packages/web/public/images/aws_icon_192_maskable.png
88 | inflating: ../packages/web/public/images/aws_icon_192.png
89 | inflating: ../packages/web/public/images/aws_icon_512_maskable.png
90 | inflating: ../packages/web/public/images/aws_icon_512.png
91 | inflating: ../packages/web/public/images/aws_maskable.svg
92 | inflating: ../packages/web/public/images/aws.svg
93 | inflating: ../packages/web/src/@types/common.d.ts
94 | inflating: ../packages/web/src/@types/navigate.d.ts
95 | inflating: ../packages/web/src/App.tsx
96 | inflating: ../packages/web/src/assets/aws.svg
97 | inflating: ../packages/web/src/assets/bedrock.svg
98 | inflating: ../packages/web/src/assets/kendra.svg
99 | inflating: ../packages/web/src/components/Alert.tsx
100 | inflating: ../packages/web/src/components/AuthWithSAML.tsx
101 | inflating: ../packages/web/src/components/AuthWithUserpool.tsx
102 | inflating: ../packages/web/src/components/Base64Image.tsx
103 | inflating: ../packages/web/src/components/Button.tsx
104 | inflating: ../packages/web/src/components/ButtonCopy.tsx
105 | inflating: ../packages/web/src/components/ButtonFeedback.tsx
106 | inflating: ../packages/web/src/components/ButtonIcon.tsx
107 | inflating: ../packages/web/src/components/ButtonSend.tsx
108 | inflating: ../packages/web/src/components/ButtonSendToUseCase.tsx
109 | inflating: ../packages/web/src/components/Card.tsx
110 | inflating: ../packages/web/src/components/CardDemo.tsx
111 | inflating: ../packages/web/src/components/ChatList.tsx
112 | inflating: ../packages/web/src/components/ChatListItem.tsx
113 | inflating: ../packages/web/src/components/ChatMessage.tsx
114 | inflating: ../packages/web/src/components/Checkbox.tsx
115 | inflating: ../packages/web/src/components/DialogConfirmDeleteChat.tsx
116 | inflating: ../packages/web/src/components/Drawer.tsx
117 | inflating: ../packages/web/src/components/ErrorBoundary.tsx
118 | inflating: ../packages/web/src/components/ExpandableField.tsx
119 | inflating: ../packages/web/src/components/ExpandableMenu.tsx
120 | inflating: ../packages/web/src/components/GenerateImageAssistant.tsx
121 | inflating: ../packages/web/src/components/Help.tsx
122 | inflating: ../packages/web/src/components/HighlightText.tsx
123 | inflating: ../packages/web/src/components/IconWithDot.tsx
124 | inflating: ../packages/web/src/components/InputChatContent.tsx
125 | inflating: ../packages/web/src/components/Markdown.tsx
126 | inflating: ../packages/web/src/components/ModalDialog.tsx
127 | inflating: ../packages/web/src/components/PopupInterUseCasesDemo.tsx
128 | inflating: ../packages/web/src/components/PromptList.tsx
129 | inflating: ../packages/web/src/components/RangeSlider.tsx
130 | inflating: ../packages/web/src/components/RowItem.tsx
131 | inflating: ../packages/web/src/components/Select.tsx
132 | inflating: ../packages/web/src/components/SketchPad.tsx
133 | inflating: ../packages/web/src/components/Switch.tsx
134 | inflating: ../packages/web/src/components/Textarea.tsx
135 | inflating: ../packages/web/src/components/TextEditor.tsx
136 | inflating: ../packages/web/src/components/Tooltip.tsx
137 | inflating: ../packages/web/src/components/ZoomUpImage.tsx
138 | inflating: ../packages/web/src/hooks/useChat.ts
139 | inflating: ../packages/web/src/hooks/useChatApi.ts
140 | inflating: ../packages/web/src/hooks/useConversation.ts
141 | inflating: ../packages/web/src/hooks/useDebounce.ts
142 | inflating: ../packages/web/src/hooks/useDrawer.ts
143 | inflating: ../packages/web/src/hooks/useFile.ts
144 | inflating: ../packages/web/src/hooks/useFileApi.ts
145 | inflating: ../packages/web/src/hooks/useFiles.ts
146 | inflating: ../packages/web/src/hooks/useGitHub.ts
147 | inflating: ../packages/web/src/hooks/useHttp.ts
148 | inflating: ../packages/web/src/hooks/useImage.ts
149 | inflating: ../packages/web/src/hooks/useImageApi.ts
150 | inflating: ../packages/web/src/hooks/useInterUseCases.ts
151 | inflating: ../packages/web/src/hooks/useLocalStorage.ts
152 | inflating: ../packages/web/src/hooks/useLocalStorageBoolean.ts
153 | inflating: ../packages/web/src/hooks/useMicrophone.ts
154 | inflating: ../packages/web/src/hooks/useModel.ts
155 | inflating: ../packages/web/src/hooks/useRag.ts
156 | inflating: ../packages/web/src/hooks/useRagApi.ts
157 | inflating: ../packages/web/src/hooks/useRagFile.ts
158 | inflating: ../packages/web/src/hooks/useScroll.ts
159 | inflating: ../packages/web/src/hooks/useSearch.ts
160 | inflating: ../packages/web/src/hooks/useSystemContextApi.ts
161 | inflating: ../packages/web/src/hooks/useTranscribe.ts
162 | inflating: ../packages/web/src/hooks/useTranscribeApi.ts
163 | inflating: ../packages/web/src/hooks/useTyping.ts
164 | inflating: ../packages/web/src/hooks/useVersion.ts
165 | inflating: ../packages/web/src/index.css
166 | inflating: ../packages/web/src/main.tsx
167 | inflating: ../packages/web/src/pages/AgentChatPage.tsx
168 | inflating: ../packages/web/src/pages/ChatPage.tsx
169 | inflating: ../packages/web/src/pages/EditorialPage.tsx
170 | inflating: ../packages/web/src/pages/FileUploadPage.tsx
171 | inflating: ../packages/web/src/pages/GenerateImagePage.tsx
172 | inflating: ../packages/web/src/pages/GenerateTextPage.tsx
173 | inflating: ../packages/web/src/pages/KendraSearchPage.tsx
174 | inflating: ../packages/web/src/pages/LandingPage.tsx
175 | inflating: ../packages/web/src/pages/NotFound.tsx
176 | inflating: ../packages/web/src/pages/RagPage.tsx
177 | inflating: ../packages/web/src/pages/Setting.tsx
178 | inflating: ../packages/web/src/pages/SharedChatPage.tsx
179 | inflating: ../packages/web/src/pages/SummarizePage.tsx
180 | inflating: ../packages/web/src/pages/summit/GenerateSlidePage.tsx
181 | inflating: ../packages/web/src/pages/summit/GenerateSqlPage.tsx
182 | inflating: ../packages/web/src/pages/summit/GenerateUIPage.tsx
183 | inflating: ../packages/web/src/pages/TranscribePage.tsx
184 | inflating: ../packages/web/src/pages/TranslatePage.tsx
185 | inflating: ../packages/web/src/pages/VideoAnalyzerPage.tsx
186 | inflating: ../packages/web/src/pages/WebContent.tsx
187 | inflating: ../packages/web/src/prompts/claude.ts
188 | inflating: ../packages/web/src/prompts/index.ts
189 | inflating: ../packages/web/src/prompts/mistral.ts
190 | inflating: ../packages/web/src/utils/ChatUtils.ts
191 | inflating: ../packages/web/src/vite-env.d.ts
192 | inflating: ../packages/web/tailwind.config.js
193 | inflating: ../packages/web/tsconfig.json
194 | inflating: ../packages/web/tsconfig.node.json
195 | inflating: ../packages/web/vite.config.ts
196 | total 1220
197 | drwxr-xr-x 4 root root      78 Jun  4 00:46 .
198 | drwxr-xr-x 7 root root      99 Jun  4 00:46 ..
199 | -rw-r--r-- 1 root root 1241923 Jan  1  1980 package-lock.json
200 | -rw-r--r-- 1 root root    1435 Jan  1  1980 package.json
201 | drwxr-xr-x 5 root root      41 Jun  4 00:46 packages
202 | drwxr-xr-x 2 root root       6 Jun  4 00:46 src
203 | total 0
204 | drwxr-xr-x 2 root root  6 Jun  4 00:46 .
205 | drwxr-xr-x 4 root root 78 Jun  4 00:46 ..
206 |  
207 | [Container] 2024/06/04 00:46:57.915424 Running command ls -la
208 | total 0
209 | drwxr-xr-x 2 root root  6 Jun  4 00:46 .
210 | drwxr-xr-x 4 root root 78 Jun  4 00:46 ..
211 |  
212 | [Container] 2024/06/04 00:46:57.921530 Running command cd "$workingDirectory"
213 |  
214 | [Container] 2024/06/04 00:46:57.925974 Running command eval "$buildCommands"
215 | npm WARN deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
216 | npm WARN deprecated @babel/plugin-proposal-optional-catch-binding@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
217 | npm WARN deprecated @babel/plugin-proposal-numeric-separator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
218 | npm WARN deprecated querystring@0.2.1: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
219 | npm WARN deprecated @babel/plugin-proposal-logical-assignment-operators@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
220 | npm WARN deprecated rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
221 | npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
222 | npm WARN deprecated @babel/plugin-proposal-nullish-coalescing-operator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
223 | npm WARN deprecated @babel/plugin-proposal-async-generator-functions@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
224 | npm WARN deprecated @babel/plugin-proposal-optional-chaining@7.21.0: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
225 | npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
226 | npm WARN deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
227 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
228 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
229 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
230 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
231 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
232 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
233 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
234 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
235 | npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
236 | npm WARN deprecated workbox-google-analytics@7.0.0: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
237 |  
238 | added 2446 packages, and audited 2450 packages in 1m
239 |  
240 | 296 packages are looking for funding
241 | run `npm fund` for details
242 |  
243 | found 0 vulnerabilities
244 |  
245 | > generative-ai-use-cases-jp@0.0.6 web:build
246 | > VITE_APP_VERSION=${npm_package_version} npm -w packages/web run build
247 |  
248 |  
249 | > build
250 | > tsc && vite build
251 |  
252 | vite v5.2.10 building for production...
253 | transforming...
254 | ✓ 8290 modules transformed.
255 |  
256 | <--- Last few GCs --->
257 |  
258 | [222:0x5cf6870]    74016 ms: Mark-sweep (reduce) 1516.8 (1563.0) -> 1515.9 (1563.2) MB, 1956.9 / 0.0 ms  (average mu = 0.121, current mu = 0.003) allocation failure; scavenge might not succeed
259 | [222:0x5cf6870]    75980 ms: Mark-sweep (reduce) 1517.0 (1563.2) -> 1516.3 (1563.7) MB, 1954.0 / 0.0 ms  (average mu = 0.065, current mu = 0.005) allocation failure; scavenge might not succeed
260 |  
261 |  
262 | <--- JS stacktrace --->
263 |  
264 | FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
265 | 1: 0xb95be0 node::Abort() [node]
266 | 2: 0xa9a7f8  [node]
267 | 3: 0xd6f5b0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [node]
268 | 4: 0xd6f957 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [node]
269 | 5: 0xf4ceb5  [node]
270 | 6: 0xf5f38d v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
271 | 7: 0xf39a7e v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
272 | 8: 0xf3ae47 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
273 | 9: 0xf1c04a v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
274 | 10: 0x12e139f v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
275 | 11: 0x170e079  [node]
276 | Aborted (core dumped)
277 | npm ERR! Lifecycle script `build` failed with error:
278 | npm ERR! Error: command failed
279 | npm ERR!   in workspace: web
280 | npm ERR!   at location: /codebuild/output/src856953380/packages/web
281 |  
282 | [Container] 2024/06/04 00:49:55.993765 Command did not exit successfully eval "$buildCommands" exit status 1
283 | [Container] 2024/06/04 00:49:56.046747 Phase complete: BUILD State: FAILED
284 | [Container] 2024/06/04 00:49:56.046776 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: eval "$buildCommands". Reason: exit status 1
285 | [Container] 2024/06/04 00:49:56.105242 Entering phase POST_BUILD
286 | [Container] 2024/06/04 00:49:56.105849 Running command echo Build completed on `date`
287 | Build completed on Tue Jun 4 00:49:56 UTC 2024
288 |  
289 | [Container] 2024/06/04 00:49:56.114249 Running command
290 | STATUS='SUCCESS'
291 | if [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing
292 | then
293 | STATUS='FAILED'
294 | REASON="NodejsBuild failed. See CloudWatch Log stream for the detailed reason:
295 | https://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\$252Faws\$252Fcodebuild\$252F$projectName/log-events/$CODEBUILD_LOG_PATH"
296 | fi
297 | cat <<EOF > payload.json
298 | {
299 | "StackId": "$stackId",
300 | "RequestId": "$requestId",
301 | "LogicalResourceId":"$logicalResourceId",
302 | "PhysicalResourceId": "$logicalResourceId",
303 | "Status": "$STATUS",
304 | "Reason": "$REASON",
305 | "Data": {
306 | "destinationObjectKey": "$destinationObjectKey"
307 | }
308 | }
309 | EOF
310 | curl -v -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
311 |  
312 | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
313 | Dload  Upload   Total   Spent    Left  Speed
314 |  
315 | 0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 52.219.9.70:443...
316 | * Connected to cloudformation-custom-resource-response-apnortheast1.s3-ap-northeast-1.amazonaws.com (52.219.9.70) port 443 (#0)
317 | * ALPN, offering h2
318 | * ALPN, offering http/1.1
319 | *  CAfile: /etc/ssl/certs/ca-certificates.crt
320 | *  CApath: /etc/ssl/certs
321 | * TLSv1.0 (OUT), TLS header, Certificate Status (22):
322 | } [5 bytes data]
323 | * TLSv1.3 (OUT), TLS handshake, Client hello (1):
324 | } [512 bytes data]
325 | * TLSv1.2 (IN), TLS header, Certificate Status (22):
326 | { [5 bytes data]
327 | * TLSv1.3 (IN), TLS handshake, Server hello (2):
328 | { [122 bytes data]
329 | * TLSv1.2 (IN), TLS header, Finished (20):
330 | { [5 bytes data]
331 | * TLSv1.2 (IN), TLS header, Supplemental data (23):
332 | { [5 bytes data]
333 | * TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
334 | { [25 bytes data]
335 | * TLSv1.2 (IN), TLS header, Supplemental data (23):
336 | { [5 bytes data]
337 | * TLSv1.3 (IN), TLS handshake, Certificate (11):
338 | { [5586 bytes data]
339 | * TLSv1.2 (IN), TLS header, Supplemental data (23):
340 | { [5 bytes data]
341 | * TLSv1.3 (IN), TLS handshake, CERT verify (15):
342 | { [264 bytes data]
343 | * TLSv1.2 (IN), TLS header, Supplemental data (23):
344 | { [5 bytes data]
345 | * TLSv1.3 (IN), TLS handshake, Finished (20):
346 | { [36 bytes data]
347 | * TLSv1.2 (OUT), TLS header, Finished (20):
348 | } [5 bytes data]
349 | * TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
350 | } [1 bytes data]
351 | * TLSv1.2 (OUT), TLS header, Supplemental data (23):
352 | } [5 bytes data]
353 | * TLSv1.3 (OUT), TLS handshake, Finished (20):
354 | } [36 bytes data]
355 | * SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
356 | * ALPN, server accepted to use http/1.1
357 | * Server certificate:
358 | *  subject: CN=*.s3-ap-northeast-1.amazonaws.com
359 | *  start date: Jan 23 00:00:00 2024 GMT
360 | *  expire date: Jan  9 23:59:59 2025 GMT
361 | *  subjectAltName: host "cloudformation-custom-resource-response-apnortheast1.s3-ap-northeast-1.amazonaws.com" matched cert's "*.s3-ap-northeast-1.amazonaws.com"
362 | *  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01
363 | *  SSL certificate verify ok.
364 | * TLSv1.2 (OUT), TLS header, Supplemental data (23):
365 | } [5 bytes data]
366 | > PUT /arn%3Aaws%3Acloudformation%3Aap-northeast-1%3A988417841316%3Astack/GenerativeAiUseCasesStack/ba242770-7920-11ee-883d-0a9f31ffdf53%7CApiBuildWeb746ABF13%7Cbc1fb259-9656-4b23-b936-637d9bdb9da5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240604T004627Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIASU3QWAIZKWE3A45Y%2F20240604%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Signature=ee5e9ca945b0f7f36c725dbcce9577b1bc3918dae161f4d640a94b5c74f77189 HTTP/1.1
367 | > Host: cloudformation-custom-resource-response-apnortheast1.s3-ap-northeast-1.amazonaws.com
368 | > User-Agent: curl/7.81.0
369 | > Accept: */*
370 | > Content-Length: 694
371 | >
372 | } [694 bytes data]
373 | * TLSv1.2 (IN), TLS header, Supplemental data (23):
374 | { [5 bytes data]
375 | * Mark bundle as not supporting multiuse
376 | < HTTP/1.1 200 OK
377 | < x-amz-id-2: 0dnq7eB8KHa96zUwJI3R6NKbfP/9deII7DTb26hWGMgzbHuPkomTq7Xj8ng0hfN9AWOzWBo98eo=
378 | < x-amz-request-id: KV8873TJJ6M1QVJ2
379 | < Date: Tue, 04 Jun 2024 00:49:58 GMT
380 | < x-amz-version-id: EeLOgFfIjXQb8vLSvgQzf3PyR2cKMS8_
381 | < x-amz-server-side-encryption: AES256
382 | < ETag: "4a8af6b1837dc8f8b2fbbaaf9c73e665"
383 | < Server: AmazonS3
384 | < Content-Length: 0
385 | <
386 |  
387 | 100   694    0     0  100   694      0   6117 --:--:-- --:--:-- --:--:--  6141
388 | * Connection #0 to host cloudformation-custom-resource-response-apnortheast1.s3-ap-northeast-1.amazonaws.com left intact
389 | HTTP/1.1 200 OK
390 | x-amz-id-2: 0dnq7eB8KHa96zUwJI3R6NKbfP/9deII7DTb26hWGMgzbHuPkomTq7Xj8ng0hfN9AWOzWBo98eo=
391 | x-amz-request-id: KV8873TJJ6M1QVJ2
392 | Date: Tue, 04 Jun 2024 00:49:58 GMT
393 | x-amz-version-id: EeLOgFfIjXQb8vLSvgQzf3PyR2cKMS8_
394 | x-amz-server-side-encryption: AES256
395 | ETag: "4a8af6b1837dc8f8b2fbbaaf9c73e665"
396 | Server: AmazonS3
397 | Content-Length: 0
398 |  
399 |  
400 | [Container] 2024/06/04 00:49:57.742647 Phase complete: POST_BUILD State: SUCCEEDED
401 | [Container] 2024/06/04 00:49:57.742670 Phase context status code:  Message:
402 | [Container] 2024/06/04 00:49:57.799675 Set report auto-discover timeout to 5 seconds
403 | [Container] 2024/06/04 00:49:57.801431 Expanding base directory path:  .
404 | [Container] 2024/06/04 00:49:57.803144 Assembling file list
405 | [Container] 2024/06/04 00:49:57.803157 Expanding .
406 | [Container] 2024/06/04 00:49:57.804898 Expanding file paths for base directory .
407 | [Container] 2024/06/04 00:49:57.804912 Assembling file list
408 | [Container] 2024/06/04 00:49:57.804953 Expanding **/*
409 | [Container] 2024/06/04 00:49:57.809268 No matching auto-discover report paths found
410 | [Container] 2024/06/04 00:49:57.809354 Report auto-discover file discovery took 0.009680 seconds
411 | [Container] 2024/06/04 00:49:57.809432 Phase complete: UPLOAD_ARTIFACTS State: SUCCEEDED
412 | [Container] 2024/06/04 00:49:57.809442 Phase context status code:  Message:
```

</details>



*Description of changes:*
環境変数で Node.js の割り当てメモリサイズを 1024MB から 2048MB に増やして対応しています。


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
