### PR TITLE
保存したシステムコンテキストのタイトル変更

### DIFF
--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -311,6 +311,30 @@ export const deleteChat = async (
   );
 };
 
+export const updateSystemContextTitle = async (
+  _userId: string,
+  _systemContextId: string,
+  title: string
+): Promise<SystemContext> => {
+  const systemContext = await findSystemContextById(_userId, _systemContextId);
+  const res = await dynamoDbDocument.send(
+    new UpdateCommand({
+      TableName: TABLE_NAME,
+      Key: {
+        id: systemContext?.id,
+        createdDate: systemContext?.createdDate,
+      },
+      UpdateExpression: 'set systemContextTitle = :systemContextTitle',
+      ExpressionAttributeValues: {
+        ':systemContextTitle': title,
+      },
+      ReturnValues: 'ALL_NEW',
+    })
+  );
+
+  return res.Attributes as SystemContext;
+};
+
 export const deleteSystemContext = async (
   _userId: string,
   _systemContextId: string

--- a/packages/cdk/lambda/updateSystemContextTitle.ts
+++ b/packages/cdk/lambda/updateSystemContextTitle.ts
@@ -1,0 +1,38 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { UpdateSystemContextTitleRequest } from 'generative-ai-use-cases-jp';
+import { updateSystemContextTitle } from './repository';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
+    const systemContextId = event.pathParameters!.systemContextId!;
+    const req: UpdateSystemContextTitleRequest = JSON.parse(event.body!);
+    const systemContext = await updateSystemContextTitle(
+      userId,
+      systemContextId,
+      req.title
+    );
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ systemContext }),
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    };
+  }
+};

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -397,6 +397,20 @@ export class Api extends Construct {
     );
     table.grantWriteData(createSystemContextFunction);
 
+    const updateSystemContextTitleFunction = new NodejsFunction(
+      this,
+      'UpdateSystemContextTitle',
+      {
+        runtime: Runtime.NODEJS_18_X,
+        entry: './lambda/updateSystemContextTitle.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          TABLE_NAME: table.tableName,
+        },
+      }
+    );
+    table.grantReadWriteData(updateSystemContextTitleFunction);
+
     const deleteSystemContextFunction = new NodejsFunction(
       this,
       'DeleteSystemContexts',
@@ -543,6 +557,16 @@ export class Api extends Construct {
     systemContextResource.addMethod(
       'DELETE',
       new LambdaIntegration(deleteSystemContextFunction),
+      commonAuthorizerProps
+    );
+
+    const systemContextTitleResource =
+      systemContextResource.addResource('title');
+
+    // PUT: /systemcontexts/{systemContextId}/title
+    systemContextTitleResource.addMethod(
+      'PUT',
+      new LambdaIntegration(updateSystemContextTitleFunction),
       commonAuthorizerProps
     );
 

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -42,6 +42,14 @@ export type CreateSystemContextRequest = {
   systemContext: SystemContext;
 };
 
+export type UpdateSystemContextTitleRequest = {
+  title: string;
+};
+
+export type UpdateSystemContextTitleResponse = {
+  systemContext: SystemContext;
+};
+
 export type UpdateFeedbackRequest = {
   createdDate: string;
   feedback: string;

--- a/packages/web/src/hooks/useSystemContextApi.ts
+++ b/packages/web/src/hooks/useSystemContextApi.ts
@@ -1,6 +1,7 @@
 import {
   CreateSystemContextRequest,
   SystemContext,
+  UpdateSystemContextTitleResponse,
 } from 'generative-ai-use-cases-jp';
 
 import useHttp from './useHttp';
@@ -23,6 +24,16 @@ const useSystemContextApi = () => {
     deleteSystemContext: async (_systemContextId: string) => {
       const systemContextId = decomposeId(_systemContextId);
       return http.delete<void>(`/systemcontexts/${systemContextId}`);
+    },
+    updateSystemContextTitle: async (
+      _systemContextId: string,
+      title: string
+    ): Promise<UpdateSystemContextTitleResponse> => {
+      const systemContextId = decomposeId(_systemContextId);
+      const res = await http.put(`systemcontexts/${systemContextId}/title`, {
+        title,
+      });
+      return res.data;
     },
     listSystemContexts: () => {
       const res = http.get<SystemContext[]>('/systemcontexts');

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -80,7 +80,8 @@ const ChatPage: React.FC = () => {
   const { pathname, search } = useLocation();
   const { chatId } = useParams();
 
-  const { listSystemContexts, deleteSystemContext } = useSystemContextApi();
+  const { listSystemContexts, deleteSystemContext, updateSystemContextTitle } =
+    useSystemContextApi();
   const [systemContextList, setSystemContextList] = useState<SystemContext[]>(
     []
   );
@@ -288,6 +289,31 @@ const ChatPage: React.FC = () => {
     }
   };
 
+  const onClickUpdateSystemContext = async (
+    systemContextId: string,
+    title: string
+  ) => {
+    try {
+      const idx = systemContextList.findIndex(
+        (item) => item.systemContextId === systemContextId
+      );
+      if (idx >= 0) {
+        setSystemContextList(
+          systemContextList.map((item, i) => {
+            if (i === idx) {
+              return { ...item, systemContextTitle: title };
+            }
+            return item;
+          })
+        );
+      }
+      await updateSystemContextTitle(systemContextId, title);
+      mutate();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   const handleDragOver = (event: React.DragEvent) => {
     // ファイルドラッグ時にオーバーレイを表示
     event.preventDefault();
@@ -450,6 +476,7 @@ const ChatPage: React.FC = () => {
           onClick={onClickSamplePrompt}
           systemContextList={systemContextList as SystemContext[]}
           onClickDeleteSystemContext={onClickDeleteSystemContext}
+          onClickUpdateSystemContext={onClickUpdateSystemContext}
         />
       )}
 


### PR DESCRIPTION
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/432
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/489

- #489 で出た UI 実装案とは若干異なるもの (常時編集ボタンが表示されているか、編集ボタンの表示非表示を切り替えられるかの違いという認識) ですが、常時表示でも (個人的に) 邪魔にならず、かつ `「保存したシステムコンテキスト」を選択したときに、「プロンプト例」を選択したときと同様にチャット画面に遷移したい` の要件は満たすためそのように実装しています。