### PR TITLE
Agent のレスポンスに Attribution を追加

### DIFF
--- a/packages/cdk/lambda/utils/bedrockAgentApi.ts
+++ b/packages/cdk/lambda/utils/bedrockAgentApi.ts
@@ -38,17 +38,21 @@ const bedrockAgentApi: Partial<ApiInterface> = {
         for (const citation of streamChunk.chunk?.attribution?.citations ||
           []) {
           for (const ref of citation.retrievedReferences || []) {
+            // S3 URI を取得し URL に変換
             const s3Uri = ref?.location?.s3Location?.uri || '';
+            if (!s3Uri) continue;
             const [bucket, ...objectPath] = s3Uri.slice(5).split('/');
             const objectName = objectPath.join('/');
             const url = `https://${bucket}.s3.amazonaws.com/${objectName})`;
 
+            // データソースがユニークであれば文末に Reference 追加
             if (sources[url] === undefined) {
               sources[url] = Object.keys(sources).length;
               body += `\n[^${sources[url]}]: ${url}`;
             }
             const referenceId = sources[url];
 
+            // 文中に Reference 追加
             const position =
               (citation.generatedResponsePart?.textResponsePart?.span?.end ||
                 0) +

--- a/packages/cdk/lambda/utils/bedrockAgentApi.ts
+++ b/packages/cdk/lambda/utils/bedrockAgentApi.ts
@@ -27,15 +27,42 @@ const bedrockAgentApi: Partial<ApiInterface> = {
       }
 
       for await (const streamChunk of res.completion) {
-        if (!streamChunk.chunk?.bytes) {
+        if (!streamChunk.chunk?.bytes && !streamChunk.chunk?.attribution) {
           break;
         }
-        const body = new TextDecoder('utf-8').decode(streamChunk.chunk?.bytes);
+        let body = new TextDecoder('utf-8').decode(streamChunk.chunk?.bytes);
+
+        // Attribution の追加
+        const sources: { [key: string]: number } = {};
+        let offset = 0;
+        for (const citation of streamChunk.chunk?.attribution?.citations ||
+          []) {
+          for (const ref of citation.retrievedReferences || []) {
+            const s3Uri = ref?.location?.s3Location?.uri || '';
+            const [bucket, ...objectPath] = s3Uri.slice(5).split('/');
+            const objectName = objectPath.join('/');
+            const url = `https://${bucket}.s3.amazonaws.com/${objectName})`;
+
+            if (sources[url] === undefined) {
+              sources[url] = Object.keys(sources).length;
+              body += `\n[^${sources[url]}]: ${url}`;
+            }
+            const referenceId = sources[url];
+
+            const position =
+              (citation.generatedResponsePart?.textResponsePart?.span?.end ||
+                0) +
+              offset +
+              1;
+            const referenceText = `[^${referenceId}]`;
+            offset += referenceText.length;
+            body =
+              body.slice(0, position) + referenceText + body.slice(position);
+          }
+        }
+
         if (body) {
           yield body;
-        }
-        if (body) {
-          break;
         }
       }
     } catch (e) {

--- a/packages/web/src/components/Markdown.tsx
+++ b/packages/web/src/components/Markdown.tsx
@@ -62,6 +62,9 @@ const Markdown: React.FC<Props> = ({ className, prefix, children }) => {
       remarkRehypeOptions={{ clobberPrefix: prefix }}
       components={{
         a: LinkRenderer,
+        sup: ({ children }) => (
+          <sup className="m-0.5 rounded-full bg-gray-200 px-1">{children}</sup>
+        ),
         code({ className, children }) {
           const language = /language-(\w+)/.exec(className || '')?.[1];
           const isCodeBlock = !!language;

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -151,6 +151,7 @@ const AgentChatPage: React.FC = () => {
                 <div className="w-full border-b border-gray-300"></div>
               )}
               <ChatMessage
+                idx={idx}
                 chatContent={chat}
                 loading={loading && idx === showingMessages.length - 1}
               />

--- a/packages/web/src/pages/AgentChatPage.tsx
+++ b/packages/web/src/pages/AgentChatPage.tsx
@@ -39,7 +39,7 @@ const useChatPageState = create<StateType>((set) => {
 });
 
 const AgentChatPage: React.FC = () => {
-  const { sessionId, content, setContent } = useChatPageState();
+  const { sessionId, content, setContent, setSessionId } = useChatPageState();
   const { pathname, search } = useLocation();
   const { chatId } = useParams();
 
@@ -100,6 +100,7 @@ const AgentChatPage: React.FC = () => {
   const onReset = useCallback(() => {
     clear();
     setContent('');
+    setSessionId(uuidv4());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clear]);
 


### PR DESCRIPTION
*Issue #, if available:*
#524 

*Description of changes:*
- Agent のレスポンスに Attribution が含まれる際、レスポンスを含めるように変更。
- 微修正：複数の参考文献を表示する際 `sup` タグの隙間がないため UI を微修正。
- 微修正：Agent のセッション情報がリセット時に新規セッションに変更されない問題を修正。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
