### PR TITLE
RAGチャットのリンクを修正

### DIFF
--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -137,8 +137,12 @@ const useRag = (id: string) => {
                     _excerpt_page_number
                       ? `(${_excerpt_page_number} ページ)`
                       : ''
-                  }](${item.DocumentURI}${
-                    _excerpt_page_number ? `#page=${_excerpt_page_number}` : ''
+                  }](
+                  ${item.DocumentURI
+                    ? encodeURI(item.DocumentURI).replace(/\(/g, '\\(').replace(/\)/g, '\\)')
+                    : ''
+                  }${
+                  _excerpt_page_number ? `#page=${_excerpt_page_number}` : ''
                   })`
                 : '';
             })


### PR DESCRIPTION
*Issue #, if available:*
RAGチャットを利用したとき、リンク先のURLに以下が含まれていると、リンクが崩れる
- 半角スペース
  - #411 でも言及されている内容
- 半角カッコ "(" ")"

*Description of changes:*
変更点
- item.DocumentURIにencodeURIを適用し、半角カッコをエスケープするようにした

動作確認
- S3に半角スペース・半角カッコが含まれるファイルをアップロードした
- RAGチャットを使用してリンクをクリックしたとき、ファイルが表示された

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
