### PR TITLE
RAG で Knowledge Bases を利用するときに、コストを削減するために OpenSearch Serverless の冗長性を無効化できる機能を追加

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -80,10 +80,15 @@ context の `ragKnowledgeBaseEnabled` に `true` を指定します。(デフォ
 {
   "context": {
     "ragKnowledgeBaseEnabled": true,
+    "ragKnowledgeBaseStandbyReplicas": false,
     "embeddingModelId": "amazon.titan-embed-text-v2:0",
   }
 }
 ```
+
+`ragKnowledgeBaseStandbyReplicas` は自動作成される OpenSearch Serverless の冗長化に関する値です。
+- `false` : 開発およびテスト目的に適した指定。シングル AZ で稼働し、OCU のコストを半分にできる。
+- `true` : 本番環境に適した設定。複数の AZ で稼働し、高可用性な構成が実現できる。
 
 `embeddingModelId` は embedding に利用するモデルです。現状、以下モデルをサポートしています。
 

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -21,6 +21,7 @@
     "kendraIndexArn": null,
     "kendraDataSourceBucketName": null,
     "ragKnowledgeBaseEnabled": false,
+    "ragKnowledgeBaseStandbyReplicas": false,
     "embeddingModelId": "amazon.titan-embed-text-v2:0",
     "selfSignUpEnabled": true,
     "allowedSignUpEmailDomains": null,

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -109,9 +109,12 @@ export class RagKnowledgeBaseStack extends Stack {
       assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
     });
 
+    const standbyReplicas = this.node.tryGetContext('ragKnowledgeBaseStandbyReplicas');
+
     const collection = new oss.CfnCollection(this, 'Collection', {
       name: collectionName,
       type: 'VECTORSEARCH',
+      standbyReplicas: standbyReplicas ? 'ENABLED' : 'DISABLED',
     });
 
     const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {


### PR DESCRIPTION
*Issue #, if available:*
#548 

*Description of changes:*
Knowledge Bases を有効化すると、OpenSearch Serverless が自動的に作成される。
その際に、2 OCU が利用されるが、PoC などの場面でコストを削減するために、redundancy を無効化することで 1 OCU に削減ができ、料金が約半額になる。そのための機能を追加する。

デフォルトのパラメーターは 「冗長化なし (false)」としている。理由としては、以下の 2 点
- GenU を初めて使い始めるお客様を想定し、PoC で検証を始められる場合のコストを最小化
- Kendra を利用した RAG の場合は、デフォルトでは Developer Edition で作成され、シングル AZ で構成される。これと似た意味を持つように OpenSearch Serverless でも利用する。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
