### PR TITLE
OpenSearch Serverless の Description がないと特定の条件下で Description cannot be empty エラーがでる

### DIFF
--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -113,6 +113,7 @@ export class RagKnowledgeBaseStack extends Stack {
 
     const collection = new oss.CfnCollection(this, 'Collection', {
       name: collectionName,
+      description: 'GenU Collection',
       type: 'VECTORSEARCH',
       standbyReplicas: standbyReplicas ? 'ENABLED' : 'DISABLED',
     });


### PR DESCRIPTION
- OSS Collection にアップデートが入ったさいに description がないと表題のエラーになる。
- Description があるとエラーが出なかったので、追加した。
- 詳細は https://github.com/aws-samples/generative-ai-use-cases-jp/issues/559
