### PR TITLE
Kendra RAG / ユーザーコンテキストを考慮したクエリ生成

### DIFF
--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -67,6 +67,7 @@ const useRag = (id: string) => {
         console.error(`model not found for ${modelId}`);
         return;
       }
+      const prevQueries = messages.filter((m) => m.role == 'user').map((m) => m.content);
 
       // Kendra から Retrieve する際に、ローディング表示する
       setLoading(true);
@@ -80,7 +81,7 @@ const useRag = (id: string) => {
             role: 'user',
             content: prompter.ragPrompt({
               promptType: 'RETRIEVE',
-              retrieveQueries: [content],
+              retrieveQueries: [...prevQueries, content],
             }),
           },
         ],

--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -67,7 +67,7 @@ const useRag = (id: string) => {
         console.error(`model not found for ${modelId}`);
         return;
       }
-      const prevQueries = messages.filter((m) => m.role == 'user').map((m) => m.content);
+      const prevQueries = messages.filter((m) => m.role === 'user').map((m) => m.content);
 
       // Kendra から Retrieve する際に、ローディング表示する
       setLoading(true);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
現状のKendra RAGでは、Retrieve時に過去クエリの履歴を考慮しておらず、複数回クエリを行う場合に文脈が考慮されないケースがあったため、クエリ生成時に過去のユーザー入力を考慮したクエリを生成するように変更。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
