### PR TITLE
システムコンテキストを自分の会話履歴から保存できるようにする #439

### DIFF
--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -23,6 +23,7 @@ type Props = BaseProps & {
   hideFeedback?: boolean;
 };
 
+
 const ChatMessage: React.FC<Props> = (props) => {
   const chatContent = useMemo(() => {
     return props.chatContent;

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Markdown from './Markdown';
+import Button from './Button';
 import ButtonCopy from './ButtonCopy';
 import ButtonFeedback from './ButtonFeedback';
 import ZoomUpImage from './ZoomUpImage';
@@ -17,6 +18,8 @@ type Props = BaseProps & {
   idx?: number;
   chatContent?: ShownMessage;
   loading?: boolean;
+  setSaveSystemContext?: any;
+  setShowSystemContextModal?: any;
   hideFeedback?: boolean;
 };
 
@@ -161,7 +164,7 @@ const ChatMessage: React.FC<Props> = (props) => {
         </div>
 
         <div className="flex items-start justify-end lg:-mr-24 print:hidden">
-          {(chatContent?.role === 'user' || chatContent?.role === 'system') && (
+          {(chatContent?.role === 'user') && (
             <div className="lg:w-8"></div>
           )}
           {chatContent?.role === 'assistant' &&
@@ -194,6 +197,20 @@ const ChatMessage: React.FC<Props> = (props) => {
                 )}
               </>
             )}
+          {chatContent?.role === 'system' && (
+            <div className="lg:-mr-24 print:hidden">
+              <Button
+                outlined
+                className=""
+                onClick={() => {
+                  props.setSaveSystemContext(props.chatContent?.content)
+                  props.setShowSystemContextModal(true)
+                }}
+              >
+                保存
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -18,8 +18,8 @@ type Props = BaseProps & {
   idx?: number;
   chatContent?: ShownMessage;
   loading?: boolean;
-  setSaveSystemContext?: any;
-  setShowSystemContextModal?: any;
+  setSaveSystemContext?: (s: string) => void;
+  setShowSystemContextModal?: (value: boolean) => void;
   hideFeedback?: boolean;
 };
 
@@ -203,8 +203,8 @@ const ChatMessage: React.FC<Props> = (props) => {
                 outlined
                 className=""
                 onClick={() => {
-                  props.setSaveSystemContext(props.chatContent?.content)
-                  props.setShowSystemContextModal(true)
+                  props.setSaveSystemContext?.(props.chatContent?.content ?? '');
+                  props.setShowSystemContextModal?.(true);
                 }}
               >
                 保存

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -431,6 +431,8 @@ const ChatPage: React.FC = () => {
               <ChatMessage
                 chatContent={chat}
                 loading={loading && idx === showingMessages.length - 1}
+                setSaveSystemContext={setSaveSystemContext}
+                setShowSystemContextModal={setShowSystemContextModal}
               />
               <div className="w-full border-b border-gray-300"></div>
             </div>
@@ -601,3 +603,4 @@ const ChatPage: React.FC = () => {
 };
 
 export default ChatPage;
+export const _useChatPageState = useChatPageState;

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -603,4 +603,3 @@ const ChatPage: React.FC = () => {
 };
 
 export default ChatPage;
-export const _useChatPageState = useChatPageState;


### PR DESCRIPTION
*Issue #439*

*Description of changes:*
チャット機能にて、"システムコンテキストの表示" トグルを有効化した場合にのみ、システムコンテキストを保存するボタンを実装しました。