### PR TITLE
add jpg as accept file for ChatPage

### DIFF
--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -37,6 +37,7 @@ const fileLimit: FileLimit = {
     '.xls',
     '.xlsx',
     '.gif',
+    '.jpg',
     '.jpeg',
     '.png',
     '.webp',


### PR DESCRIPTION
*Issue #, if available:*

Chatページにおける、以下の問題を解決しました
- jpgファイルをアップロード対象として選択できない
- ドラッグアンドドロップでチャットに追加できない
（jpegファイルは利用できるのにも関わらず）

*Description of changes:*

以下の点を変更しました
- ChatPageのFileLimitのacceptに、jpgを追加した

*動作確認* 

以下のように動作確認しました
- Chatページで、jpgファイルをアップロード対象として選択できた
- ドラッグアンドドロップでチャットに追加できた
- その後、会話を続け、画像に関する会話ができた


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
