### PR TITLE
マネジメントコンソールの Knowledge bases のページで、S3 へのリンクが正常に動作していない問題の修正

### DIFF
--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -287,7 +287,7 @@ export class RagKnowledgeBaseStack extends Stack {
       dataSourceConfiguration: {
         s3Configuration: {
           bucketArn: `arn:aws:s3:::${dataSourceBucket.bucketName}`,
-          inclusionPrefixes: ['docs'],
+          inclusionPrefixes: ['docs/'],
         },
         type: 'S3',
       },


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
AWS マネジメントコンソール上の挙動の修正です。
Data source の Source Link をクリックしても、S3 のページが開かれません。
理由としては、末尾のスラッシュが無いことにより、マネジメントコンソール上でうまく扱うことができないエラーです。

・Before
docs

・after
docs/

![image](https://github.com/user-attachments/assets/9a91cdc5-0de8-44d5-91a0-4cee037dda64)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
