### PR TITLE
enforceSSLが未適用のS3バケットについて、enforceSSLを有効化

### DIFF
--- a/packages/cdk/lib/construct/agent.ts
+++ b/packages/cdk/lib/construct/agent.ts
@@ -28,6 +28,7 @@ export class Agent extends Construct {
       encryption: BucketEncryption.S3_MANAGED,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
+      enforceSSL: true,
     });
 
     // schema を s3 に配置

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -119,6 +119,7 @@ export class Api extends Construct {
       encryption: BucketEncryption.S3_MANAGED,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
+      enforceSSL: true,
     });
     fileBucket.addCorsRule({
       allowedOrigins: ['*'],

--- a/packages/cdk/lib/construct/transcribe.ts
+++ b/packages/cdk/lib/construct/transcribe.ts
@@ -27,6 +27,7 @@ export class Transcribe extends Construct {
       encryption: BucketEncryption.S3_MANAGED,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
+      enforceSSL: true,
     });
     audioBucket.addCorsRule({
       allowedOrigins: ['*'],
@@ -40,6 +41,7 @@ export class Transcribe extends Construct {
       encryption: BucketEncryption.S3_MANAGED,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
+      enforceSSL: true,
     });
 
     const getSignedUrlFunction = new NodejsFunction(this, 'GetSignedUrl', {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
enforceSSLがtrueとなっていないS3バケットが4つほどあったため、いずれもenforceSSLをtrueを付与しました。
（trueとなっていない場合、Control Towerが有効な環境においてエラーとなるケースがあるようです）

動作確認
* 変更後、デプロイできること
* デプロイ後、音声認識やチャット（画像添付あり）のユースケースが動作すること

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
