### PR TITLE
Update TranslatePage.tsx

### DIFF
--- a/packages/web/src/pages/TranslatePage.tsx
+++ b/packages/web/src/pages/TranslatePage.tsx
@@ -249,7 +249,7 @@ const TranslatePage: React.FC = () => {
     if (loading) return;
     getTranslation(sentence, language, additionalContext);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sentence, additionalContext, loading, prompter]);
+  }, [sentence, additionalContext, loading, prompter, language]);
 
   // リセット
   const onClickClear = useCallback(() => {


### PR DESCRIPTION
`language` がないため、`getTranslation` 関数が更新されていなかった。

## バグ再現手順
- 翻訳 use case でたまに起こる嫌な挙動の再現方法がわかったので共有です。
- 翻訳したい文章（日本語）を入力
- 日本語にセットして実行
- 想定どおり日本語が日本語に翻訳される
- 英語にセットしなおして実行
- 日本語の翻訳結果がまた出てしまう（会話履歴を見ると日本語に翻訳しろ、というのが残ってしまっている）
