### PR TITLE
Remove llama2

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -309,8 +309,6 @@ Knowledge base プロンプト例: キーワードで検索し情報を取得し
 "anthropic.claude-v2:1",
 "anthropic.claude-v2",
 "anthropic.claude-instant-v1",
-"meta.llama2-70b-chat-v1",
-"meta.llama2-13b-chat-v1",
 "mistral.mixtral-8x7b-instruct-v0:1",
 "mistral.mistral-7b-instruct-v0:2"
 ```

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -559,22 +559,6 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseOutputText: extractConverseOutputText,
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
-  'meta.llama2-13b-chat-v1': {
-    defaultParams: LLAMA_DEFAULT_PARAMS,
-    usecaseParams: USECASE_DEFAULT_PARAMS,
-    createConverseCommandInput: createConverseCommandInput,
-    createConverseStreamCommandInput: createConverseStreamCommandInput,
-    extractConverseOutputText: extractConverseOutputText,
-    extractConverseStreamOutputText: extractConverseStreamOutputText,
-  },
-  'meta.llama2-70b-chat-v1': {
-    defaultParams: LLAMA_DEFAULT_PARAMS,
-    usecaseParams: USECASE_DEFAULT_PARAMS,
-    createConverseCommandInput: createConverseCommandInput,
-    createConverseStreamCommandInput: createConverseStreamCommandInput,
-    extractConverseOutputText: extractConverseOutputText,
-    extractConverseStreamOutputText: extractConverseStreamOutputText,
-  },
   'mistral.mistral-7b-instruct-v0:2': {
     defaultParams: MISTRAL_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -86,8 +86,6 @@ export class Api extends Construct {
       'meta.llama3-1-8b-instruct-v1:0',
       'meta.llama3-1-70b-instruct-v1:0',
       'meta.llama3-1-405b-instruct-v1:0',
-      'meta.llama2-13b-chat-v1',
-      'meta.llama2-70b-chat-v1',
       'mistral.mistral-7b-instruct-v0:2',
       'mistral.mixtral-8x7b-instruct-v0:1',
       'mistral.mistral-small-2402-v1:0',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove llama2 from supported models due to deprecation of the legacy models after 12-Aug, 2024

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
