### PR TITLE
Agent のトレースを表示

### DIFF
--- a/packages/cdk/lambda/agent.ts
+++ b/packages/cdk/lambda/agent.ts
@@ -1,40 +1,8 @@
-type AgentInput = {
-  actionGroup: string;
-  apiPath: string;
-  httpMethod: string;
-  requestBody: {
-    content: {
-      'application/json': {
-        properties: {
-          name: string;
-          type: string;
-          value: string;
-        }[];
-      };
-    };
-  };
-};
-
-type AgentOutput = {
-  messageVersion: string;
-  response: {
-    actionGroup: string;
-    apiPath: string;
-    httpMethod: string;
-    httpStatusCode: number;
-    responseBody: {
-      'application/json': {
-        body: string;
-      };
-    };
-  };
-};
-
-type BraveSearchResult = {
-  title: string;
-  description: string;
-  extra_snippets?: string[];
-};
+import {
+  AgentInput,
+  AgentOutput,
+  BraveSearchResult,
+} from 'generative-ai-use-cases-jp';
 
 export const handler = async (event: AgentInput): Promise<AgentOutput> => {
   try {
@@ -62,6 +30,7 @@ export const handler = async (event: AgentInput): Promise<AgentOutput> => {
       title: result.title,
       description: result.description,
       extra_snippets: result.extra_snippets,
+      url: result.url,
     }));
 
     // Create Response Object

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -217,6 +217,7 @@ export const batchCreateMessages = async (
         messageId: m.messageId,
         role: m.role,
         content: m.content,
+        trace: m.trace,
         extraData: m.extraData,
         userId,
         feedback,

--- a/packages/types/src/agent.d.ts
+++ b/packages/types/src/agent.d.ts
@@ -1,0 +1,38 @@
+export type AgentInput = {
+  actionGroup: string;
+  apiPath: string;
+  httpMethod: string;
+  requestBody: {
+    content: {
+      'application/json': {
+        properties: {
+          name: string;
+          type: string;
+          value: string;
+        }[];
+      };
+    };
+  };
+};
+
+export type AgentOutput = {
+  messageVersion: string;
+  response: {
+    actionGroup: string;
+    apiPath: string;
+    httpMethod: string;
+    httpStatusCode: number;
+    responseBody: {
+      'application/json': {
+        body: string;
+      };
+    };
+  };
+};
+
+export type BraveSearchResult = {
+  title: string;
+  url: string;
+  description: string;
+  extra_snippets?: string[];
+};

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -1,3 +1,4 @@
+export * from './agent';
 export * from './base';
 export * from './message';
 export * from './chat';

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -28,6 +28,7 @@ export type UnrecordedMessage = {
   // テキスト
   content: string;
   // 追加データ（画像など）
+  trace?: string;
   extraData?: ExtraData[];
   llmType?: string;
 };

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -17,6 +17,7 @@ import { MediaFormat } from '@aws-sdk/client-transcribe';
 
 export type StreamingChunk = {
   text: string;
+  trace?: string;
   stopReason?: string;
 };
 

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -102,30 +102,42 @@ const ChatMessage: React.FC<Props> = (props) => {
           )}
 
           <div className="ml-5 grow ">
+            {chatContent?.trace && (
+              <details className="mb-2 rounded border p-2" open>
+                <summary className="text-sm">トレース</summary>
+                <Markdown prefix={`${props.idx}-trace`}>
+                  {chatContent.trace}
+                </Markdown>
+              </details>
+            )}
+            {chatContent?.extraData && (
+              <div className="mb-2 flex flex-wrap gap-2">
+                {chatContent.extraData.map((data, idx) => {
+                  if (data.type === 'image') {
+                    return (
+                      <ZoomUpImage
+                        key={idx}
+                        src={signedUrls[idx]}
+                        size="m"
+                        loading={!signedUrls[idx]}
+                      />
+                    );
+                  } else if (data.type === 'file') {
+                    return (
+                      <FileCard
+                        key={idx}
+                        filename={data.name}
+                        url={signedUrls[idx]}
+                        loading={!signedUrls[idx]}
+                        size="m"
+                      />
+                    );
+                  }
+                })}
+              </div>
+            )}
             {chatContent?.role === 'user' && (
               <div className="break-all">
-                {(chatContent.extraData?.length || 0) > 0 && (
-                  <div className="mb-2 flex flex-wrap gap-2">
-                    {chatContent.extraData?.map((data, idx) =>
-                      data.type === 'image' ? (
-                        <ZoomUpImage
-                          key={idx}
-                          src={signedUrls[idx]}
-                          size="m"
-                          loading={!signedUrls[idx]}
-                        />
-                      ) : (
-                        <FileCard
-                          key={idx}
-                          filename={data.name}
-                          url={signedUrls[idx]}
-                          loading={!signedUrls[idx]}
-                          size="m"
-                        />
-                      )
-                    )}
-                  </div>
-                )}
                 {typingTextOutput.split('\n').map((c, idx) => (
                   <div key={idx}>{c}</div>
                 ))}

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -103,8 +103,15 @@ const ChatMessage: React.FC<Props> = (props) => {
 
           <div className="ml-5 grow ">
             {chatContent?.trace && (
-              <details className="mb-2 rounded border p-2" open>
-                <summary className="text-sm">トレース</summary>
+              <details className="mb-2 cursor-pointer rounded border p-2">
+                <summary className="text-sm">
+                  <div className="inline-flex gap-1">
+                    トレース
+                    {props.loading && !chatContent?.content && (
+                      <div className="border-aws-sky size-5 animate-spin rounded-full border-4 border-t-transparent"></div>
+                    )}
+                  </div>
+                </summary>
                 <Markdown prefix={`${props.idx}-trace`}>
                   {chatContent.trace}
                 </Markdown>

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -418,7 +418,7 @@ const useChatState = create<{
         if (c && c.length > 0) {
           const payload = JSON.parse(c) as StreamingChunk;
 
-          if (payload.text) {
+          if (payload.text.length > 0) {
             tmpChunk += payload.text;
           }
 


### PR DESCRIPTION
*Issue #, if available:*
#607 

*Description of changes:*
- Agent のトレースをトグル内（details, summary）に表示
  - DynamoDB データ型の変更: trace を追加
- カスタムアクション（検索アクション含む）、Knowledge Base、Code Interpreter に対応
- 微修正：Code Interpreter にて同一ファイルが複数回出現するため初出のみ表示するように修正

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
