### PR TITLE
ソースコードおよびドキュメントの表記ゆれを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm run cdk:deploy
   - [Agent チャットユースケースの有効化](/docs/DEPLOY_OPTION.md#agent-チャットユースケースの有効化)
     - [Code Interpreter 機能を持つエージェントのデプロイ](/docs/DEPLOY_OPTION.md#Code-Interpreter-エージェントのデプロイ)
     - [検索エージェントのデプロイ](/docs/DEPLOY_OPTION.md#検索エージェントのデプロイ)
-    - [Knowledge base エージェントのデプロイ](/docs/DEPLOY_OPTION.md#knowledge-base-エージェントのデプロイ)
+    - [Agents for Amazon Bedrock のデプロイ](/docs/DEPLOY_OPTION.md#agents-for-amazon-bedrock-のデプロイ)
   - [映像分析ユースケースの有効化](/docs/DEPLOY_OPTION.md#映像分析ユースケースの有効化)
 - [Amazon Bedrock のモデルを変更する](/docs/DEPLOY_OPTION.md#amazon-bedrock-のモデルを変更する)
   - [us-east-1 (バージニア) の Amazon Bedrock のモデルを利用する例](/docs/DEPLOY_OPTION.md#us-east-1-バージニア-の-amazon-bedrock-のモデルを利用する例)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm run cdk:deploy
   - [Agent チャットユースケースの有効化](/docs/DEPLOY_OPTION.md#agent-チャットユースケースの有効化)
     - [Code Interpreter 機能を持つエージェントのデプロイ](/docs/DEPLOY_OPTION.md#Code-Interpreter-エージェントのデプロイ)
     - [検索エージェントのデプロイ](/docs/DEPLOY_OPTION.md#検索エージェントのデプロイ)
-    - [Agents for Amazon Bedrock のデプロイ](/docs/DEPLOY_OPTION.md#agents-for-amazon-bedrock-のデプロイ)
+    - [Knowledge Bases for Amazon Bedrock エージェントのデプロイ](/docs/DEPLOY_OPTION.md#knowledge-bases-for-amazon-bedrock-エージェントのデプロイ)
   - [映像分析ユースケースの有効化](/docs/DEPLOY_OPTION.md#映像分析ユースケースの有効化)
 - [Amazon Bedrock のモデルを変更する](/docs/DEPLOY_OPTION.md#amazon-bedrock-のモデルを変更する)
   - [us-east-1 (バージニア) の Amazon Bedrock のモデルを利用する例](/docs/DEPLOY_OPTION.md#us-east-1-バージニア-の-amazon-bedrock-のモデルを利用する例)

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -231,7 +231,7 @@ context の `agentEnabled` と `searchAgentEnabled` に `true` を指定し(デ�
 > [!NOTE]
 > 検索エージェントの設定を有効後に、再度無効化する場合は、`searchAgentEnabled: false` にして再デプロイすれば検索エージェントは無効化されますが、`WebSearchAgentStack` 自体は残ります。マネージメントコンソールを開き、agentRegion の CloudFormation から `WebSearchAgentStack` というスタックを削除することで完全に消去ができます。
 
-#### Agents for Amazon Bedrock のデプロイ
+#### Knowledge Bases for Amazon Bedrock エージェントのデプロイ
 
 Knowledge Bases for Amazon Bedrock と連携したエージェントを手動で作成し登録することも可能です。
 

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -231,17 +231,17 @@ context の `agentEnabled` と `searchAgentEnabled` に `true` を指定し(デ�
 > [!NOTE]
 > 検索エージェントの設定を有効後に、再度無効化する場合は、`searchAgentEnabled: false` にして再デプロイすれば検索エージェントは無効化されますが、`WebSearchAgentStack` 自体は残ります。マネージメントコンソールを開き、agentRegion の CloudFormation から `WebSearchAgentStack` というスタックを削除することで完全に消去ができます。
 
-#### Knowledge base エージェントのデプロイ
+#### Agents for Amazon Bedrock のデプロイ
 
-Knowledge base for Amazon Bedrock と連携したエージェントを手動で作成し登録することも可能です。
+Knowledge Bases for Amazon Bedrock と連携したエージェントを手動で作成し登録することも可能です。
 
-まず、[Knowledge base の AWS コンソール画面](https://console.aws.amazon.com/bedrock/home?#/knowledge-bases) から[Knowledge base for Amazon Bedrock のドキュメント](https://docs.aws.amazon.com/ja_jp/bedrock/latest/userguide/knowledge-base-create.html)を参考にナレッジベースを作成します。リージョンは後述する `agentRegion` と同じリージョンに作成してください。
+まず、[ナレッジベースの AWS コンソール画面](https://console.aws.amazon.com/bedrock/home?#/knowledge-bases) から[Knowledge Bases for Amazon Bedrock のドキュメント](https://docs.aws.amazon.com/ja_jp/bedrock/latest/userguide/knowledge-base-create.html)を参考にナレッジベースを作成します。リージョンは後述する `agentRegion` と同じリージョンに作成してください。
 
-続いて、 [Agent の AWS コンソール画面](https://console.aws.amazon.com/bedrock/home?#/agents) から手動で Agent を作成します。設定は基本的にデフォルトのままで、Agent のプロンプトは以下の例を参考にプロンプトを入力します。モデルはレスポンスが早いため `anthropic.claude-instant-v1` を推奨します。アクショングループは必要ないため設定せずに進み、ナレッジベースでは前のステップで作成したナレッジベースを登録し、プロンプトは以下の例を参考に入力します。
+続いて、 [エージェントの AWS コンソール画面](https://console.aws.amazon.com/bedrock/home?#/agents) から手動で Agent を作成します。設定は基本的にデフォルトのままで、Agent のプロンプトは以下の例を参考にプロンプトを入力します。モデルはレスポンスが早いため `anthropic.claude-instant-v1` を推奨します。アクショングループは必要ないため設定せずに進み、ナレッジベースでは前のステップで作成したナレッジベースを登録し、プロンプトは以下の例を参考に入力します。
 
 ```
 Agent プロンプト例: あなたは指示に応えるアシスタントです。 指示に応じて情報を検索し、その内容から適切に回答してください。情報に記載のないものについては回答しないでください。複数回検索することが可能です。
-Knowledge base プロンプト例: キーワードで検索し情報を取得します。調査、調べる、Xについて教える、まとめるといったタスクで利用できます。会話から検索キーワードを推測してください。検索結果には関連度の低い内容も含まれているため関連度の高い内容のみを参考に回答してください。複数回実行可能です。
+Knowledge Base プロンプト例: キーワードで検索し情報を取得します。調査、調べる、Xについて教える、まとめるといったタスクで利用できます。会話から検索キーワードを推測してください。検索結果には関連度の低い内容も含まれているため関連度の高い内容のみを参考に回答してください。複数回実行可能です。
 ```
 
 作成された Agent から Alias を作成し、`agentId` と `aliasId` をコピーし以下の形式で context 追加します。`displayName` は UI に表示したい名称を設定してください。また、context の `agentEnabled` を True にし、`agentRegion` は Agent を作成したリージョンを指定します。`npm run cdk:deploy` で再度デプロイして反映させます。
@@ -254,7 +254,7 @@ Knowledge base プロンプト例: キーワードで検索し情報を取得し
     "agentRegion": "us-west-2",
     "agents": [
       {
-        "displayName": "Knowledge base",
+        "displayName": "Knowledge Base",
         "agentId": "XXXXXXXXX",
         "aliasId": "YYYYYYYY"
       }

--- a/packages/web/src/components/DialogConfirmDeleteChat.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteChat.tsx
@@ -23,7 +23,7 @@ const DialogConfirmDeleteChat: React.FC<Props> = (props) => {
 
       <div className="mt-4 flex justify-end gap-2">
         <Button outlined onClick={props.onClose} className="p-2">
-          Cancel
+          キャンセル
         </Button>
         <Button
           onClick={() => {

--- a/packages/web/src/hooks/useRagKnowledgeBase.ts
+++ b/packages/web/src/hooks/useRagKnowledgeBase.ts
@@ -56,7 +56,7 @@ const useRagKnowledgeBase = (id: string) => {
       pushMessage('user', content);
       pushMessage(
         'assistant',
-        'Knowledge base から参考ドキュメントを取得中...'
+        'Knowledge Base から参考ドキュメントを取得中...'
       );
 
       let retrievedItems = null;
@@ -84,8 +84,8 @@ const useRagKnowledgeBase = (id: string) => {
         pushMessage(
           'assistant',
           `参考ドキュメントが見つかりませんでした。次の対応を検討してください。
-- Bedrock Knowledge bases の data source に対象のドキュメントが追加されているか確認する
-- Bedrock Knowledge bases の data source が sync されているか確認する
+- Knowledge Base のデータソースに対象のドキュメントが追加されているか確認する
+- Knowledge Base のデータソースが同期されているか確認する
 - 入力の表現を変更する`
         );
         setLoading(false);

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -529,7 +529,7 @@ const ChatPage: React.FC = () => {
             outlined
             onClick={() => setShowSystemContextModal(false)}
             className="p-2">
-            Cancel
+            キャンセル
           </Button>
           <Button
             onClick={() => {

--- a/packages/web/src/pages/LandingPage.tsx
+++ b/packages/web/src/pages/LandingPage.tsx
@@ -299,7 +299,7 @@ const LandingPage: React.FC = () => {
             label="Agent チャット"
             onClickDemo={demoAgent}
             icon={<PiRobot />}
-            description="Agent チャットユースケースでは Agent for Amazon Bedrock を利用してアクションを実行させたり、Knowledge base for Amazon Bedrock のベクトルデータベースを参照することが可能です。"
+            description="Agent チャットユースケースでは Agents for Amazon Bedrock を利用してアクションを実行させたり、Knowledge Bases for Amazon Bedrock のベクトルデータベースを参照することが可能です。"
           />
         )}
         <CardDemo


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
"Knowledge Base"および"Agents"の表記を統一しました。
AWS公式ドキュメントの表記では「Knowledge bases for Amazon Bedrock」を採用していますが、AWS公式のサービス紹介やAWS Summitの発表資料では「Knowledge Bases」という表記を採用しているため、こちらに統一しました。
併せて、ソースコード内のキャンセルボタンは日本語の表記で統一しました。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.