### PR TITLE
Transcribe の複数話者対応

### DIFF
--- a/packages/cdk/lambda/startTranscription.ts
+++ b/packages/cdk/lambda/startTranscription.ts
@@ -14,7 +14,7 @@ export const handler = async (
     const req: StartTranscriptionRequest = JSON.parse(event.body!);
     const userId = event.requestContext.authorizer!.claims.sub;
 
-    const { audioUrl } = req;
+    const { audioUrl, speakerLabel, maxSpeakers } = req;
 
     const uuid = uuidv4();
 
@@ -23,6 +23,10 @@ export const handler = async (
       LanguageOptions: ['ja-JP', 'en-US'],
       Media: { MediaFileUri: audioUrl },
       TranscriptionJobName: uuid,
+      Settings: {
+        ShowSpeakerLabels: speakerLabel,
+        MaxSpeakerLabels: speakerLabel ? maxSpeakers : undefined,
+      },
       OutputBucketName: process.env.TRANSCRIPT_BUCKET_NAME,
       Tags: [
         {

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -131,15 +131,23 @@ export type DeleteFileResponse = null;
 
 export type StartTranscriptionRequest = {
   audioUrl: string;
+  speakerLabel: boolean;
+  maxSpeakers: number;
 };
 
 export type StartTranscriptionResponse = {
   jobName: string;
 };
 
+export type Transcript = {
+  speakerLabel?: string;
+  transcript: string;
+};
+
 export type GetTranscriptionResponse = {
   status: string;
-  transcript?: string;
+  languageCode: string;
+  transcripts?: Transcript[];
 };
 
 export type UploadAudioRequest = {

--- a/packages/web/src/hooks/useMicrophone.ts
+++ b/packages/web/src/hooks/useMicrophone.ts
@@ -1,14 +1,17 @@
 import {
+  Item,
   StartStreamTranscriptionCommand,
   TranscribeStreamingClient,
+  LanguageCode,
 } from '@aws-sdk/client-transcribe-streaming';
 import MicrophoneStream from 'microphone-stream';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import update from 'immutability-helper';
 import { Buffer } from 'buffer';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { fetchAuthSession } from 'aws-amplify/auth';
+import { Transcript } from 'generative-ai-use-cases-jp';
 
 const pcmEncodeChunk = (chunk: Buffer) => {
   const input = MicrophoneStream.toRaw(chunk);
@@ -31,14 +34,44 @@ const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 const useMicrophone = () => {
   const [micStream, setMicStream] = useState<MicrophoneStream | undefined>();
   const [recording, setRecording] = useState(false);
-  const [transcriptMic, setTranscripts] = useState<
+  const [rawTranscripts, setRawTranscripts] = useState<
     {
       isPartial: boolean;
-      transcript: string;
+      transcripts: Transcript[];
     }[]
   >([]);
+  const [language, setLanguage] = useState<string>('ja-JP');
   const [transcribeClient, setTranscribeClient] =
     useState<TranscribeStreamingClient>();
+
+  const transcriptMic = useMemo(() => {
+    const transcripts: Transcript[] = rawTranscripts.flatMap(
+      (t) => t.transcripts
+    );
+    // 話者が連続する場合はマージ
+    const mergedTranscripts = transcripts.reduce((prev, item) => {
+      if (
+        prev.length === 0 ||
+        item.speakerLabel !== prev[prev.length - 1].speakerLabel
+      ) {
+        prev.push({
+          speakerLabel: item.speakerLabel,
+          transcript: item.transcript,
+        });
+      } else {
+        prev[prev.length - 1].transcript += ' ' + item.transcript;
+      }
+      return prev;
+    }, [] as Transcript[]);
+    // 日本語の場合はスペースを除去
+    if (language === 'ja-JP') {
+      return mergedTranscripts.map((item) => ({
+        ...item,
+        transcript: item.transcript.replace(/ /g, ''),
+      }));
+    }
+    return mergedTranscripts;
+  }, [rawTranscripts, language]);
 
   useEffect(() => {
     // break if already set
@@ -65,8 +98,17 @@ const useMicrophone = () => {
     });
   }, [transcribeClient]);
 
-  const startStream = async (mic: MicrophoneStream) => {
+  const startStream = async (
+    mic: MicrophoneStream,
+    languageCode?: LanguageCode,
+    speakerLabel: boolean = false
+  ) => {
     if (!transcribeClient) return;
+
+    // Update Language
+    if (languageCode) {
+      setLanguage(languageCode);
+    }
 
     const audioStream = async function* () {
       for await (const chunk of mic as unknown as Buffer[]) {
@@ -78,13 +120,17 @@ const useMicrophone = () => {
       }
     };
 
+    // Best Practice: https://docs.aws.amazon.com/transcribe/latest/dg/streaming.html
     const command = new StartStreamTranscriptionCommand({
-      // LanguageCode: languageCode,
-      IdentifyLanguage: true,
-      LanguageOptions: 'en-US,ja-JP',
+      LanguageCode: languageCode,
+      IdentifyLanguage: languageCode ? false : true,
+      LanguageOptions: languageCode ? undefined : 'en-US,ja-JP',
       MediaEncoding: 'pcm',
-      MediaSampleRateHertz: 48000,
+      MediaSampleRateHertz: 16000,
       AudioStream: audioStream(),
+      ShowSpeakerLabel: speakerLabel,
+      // EnablePartialResultsStabilization: true,
+      // PartialResultsStability: 'high',
     });
 
     try {
@@ -100,23 +146,45 @@ const useMicrophone = () => {
             // Get multiple possible results, but this code only processes a single result
             const result = event.TranscriptEvent.Transcript?.Results[0];
 
-            setTranscripts((prev) => {
-              // transcript from array to string
-              const transcript = (
-                result.Alternatives?.map(
-                  (alternative) => alternative.Transcript ?? ''
-                ) ?? []
-              ).join('');
+            // Update Language
+            if (result.LanguageCode) {
+              setLanguage(result.LanguageCode);
+            }
 
-              const index = prev.length - 1;
+            // Process Multiple Speaker
+            const transcriptItems =
+              result.Alternatives?.flatMap(
+                (alternative) => alternative.Items ?? []
+              ) ?? [];
+            // Merge consecutive transcript with same Speaker
+            const mergedTranscripts = transcriptItems.reduce((acc, curr) => {
+              if (acc.length > 0 && curr.Type === 'punctuation') {
+                acc[acc.length - 1].Content += curr.Content || '';
+              } else if (
+                acc.length > 0 &&
+                acc[acc.length - 1].Speaker === curr.Speaker
+              ) {
+                acc[acc.length - 1].Content += ' ' + (curr.Content || '');
+              } else {
+                acc.push(curr);
+              }
+              return acc;
+            }, [] as Item[]);
+            const transcripts: Transcript[] = mergedTranscripts?.map(
+              (item) => ({
+                speakerLabel: item.Speaker ? 'spk_' + item.Speaker : undefined,
+                transcript: item.Content || '',
+              })
+            );
 
+            setRawTranscripts((prev) => {
               if (prev.length === 0 || !prev[prev.length - 1].isPartial) {
                 // segment is complete
                 const tmp = update(prev, {
                   $push: [
                     {
                       isPartial: result.IsPartial ?? false,
-                      transcript,
+                      transcripts,
                     },
                   ],
                 });
@@ -126,11 +194,11 @@ const useMicrophone = () => {
                 const tmp = update(prev, {
                   $splice: [
                     [
-                      index,
+                      prev.length - 1,
                       1,
                       {
                         isPartial: result.IsPartial ?? false,
-                        transcript,
+                        transcripts,
                       },
                     ],
                   ],
@@ -150,8 +218,16 @@ const useMicrophone = () => {
     }
   };
 
-  const startTranscription = async () => {
-    const mic = new MicrophoneStream();
+  const startTranscription = async (
+    languageCode?: LanguageCode,
+    speakerLabel?: boolean
+  ) => {
+    const audioContext = new AudioContext({ sampleRate: 16000 });
+    const mic = new MicrophoneStream({
+      objectMode: false,
+      context: audioContext,
+    });
+    // const mic = new MicrophoneStream();
     try {
       setMicStream(mic);
       mic.setStream(
@@ -162,7 +238,7 @@ const useMicrophone = () => {
       );
 
       setRecording(true);
-      await startStream(mic);
+      await startStream(mic, languageCode, speakerLabel);
     } catch (e) {
       console.log(e);
     } finally {
@@ -181,7 +257,7 @@ const useMicrophone = () => {
   };
 
   const clearTranscripts = () => {
-    setTranscripts([]);
+    setRawTranscripts([]);
   };
 
   return {

--- a/packages/web/src/hooks/useMicrophone.ts
+++ b/packages/web/src/hooks/useMicrophone.ts
@@ -126,11 +126,9 @@ const useMicrophone = () => {
       IdentifyLanguage: languageCode ? false : true,
       LanguageOptions: languageCode ? undefined : 'en-US,ja-JP',
       MediaEncoding: 'pcm',
-      MediaSampleRateHertz: 16000,
+      MediaSampleRateHertz: 48000,
       AudioStream: audioStream(),
       ShowSpeakerLabel: speakerLabel,
-      // EnablePartialResultsStabilization: true,
-      // PartialResultsStability: 'high',
     });
 
     try {
@@ -222,12 +220,7 @@ const useMicrophone = () => {
     languageCode?: LanguageCode,
     speakerLabel?: boolean
   ) => {
-    const audioContext = new AudioContext({ sampleRate: 16000 });
-    const mic = new MicrophoneStream({
-      objectMode: false,
-      context: audioContext,
-    });
-    // const mic = new MicrophoneStream();
+    const mic = new MicrophoneStream();
     try {
       setMicStream(mic);
       mic.setStream(

--- a/packages/web/src/hooks/useTranscribe.ts
+++ b/packages/web/src/hooks/useTranscribe.ts
@@ -6,7 +6,7 @@ const useTranscribeState = create<{
   loading: boolean;
   file: File | null;
   setFile: (file: File) => void;
-  transcribe: () => Promise<void>;
+  transcribe: (speakerLabel?: boolean, maxSpakers?: number) => Promise<void>;
   jobName: string | null;
   status: string;
   setStatus: (status: string) => void;
@@ -35,7 +35,7 @@ const useTranscribeState = create<{
     }));
   };
 
-  const transcribe = async () => {
+  const transcribe = async (speakerLabel = false, maxSpeakers = 1) => {
     set(() => ({
       loading: true,
     }));
@@ -55,6 +55,8 @@ const useTranscribeState = create<{
     // 音声認識
     const startTranscriptionRes = await api.startTranscription({
       audioUrl: audioUrl,
+      speakerLabel: speakerLabel,
+      maxSpeakers: maxSpeakers,
     });
 
     set(() => ({

--- a/packages/web/src/pages/TranscribePage.tsx
+++ b/packages/web/src/pages/TranscribePage.tsx
@@ -12,19 +12,10 @@ import RangeSlider from '../components/RangeSlider';
 import ExpandableField from '../components/ExpandableField';
 import { Transcript } from 'generative-ai-use-cases-jp';
 import Textarea from '../components/Textarea';
-import { LanguageCode } from '@aws-sdk/client-transcribe-streaming';
-import Select from '../components/Select';
-
-const languageOptions = [
-  { value: 'ja-JP', label: '日本語' },
-  { value: 'en-US', label: 'English' },
-];
 
 type StateType = {
   content: Transcript[];
   setContent: (c: Transcript[]) => void;
-  language: LanguageCode;
-  setLanguage: (s: LanguageCode) => void;
   speakerLabel: boolean;
   setSpeakerLabel: (b: boolean) => void;
   maxSpeakers: number;
@@ -36,18 +27,12 @@ type StateType = {
 const useTranscribeState = create<StateType>((set) => {
   return {
     content: [],
-    language: 'ja-JP',
     speakerLabel: false,
     maxSpeakers: 2,
     speakers: '',
     setContent: (s: Transcript[]) => {
       set(() => ({
         content: s,
-      }));
-    },
-    setLanguage: (s: LanguageCode) => {
-      set(() => ({
-        language: s,
       }));
     },
     setSpeakerLabel: (b: boolean) => {
@@ -81,8 +66,6 @@ const TranscribePage: React.FC = () => {
   const {
     content,
     setContent,
-    language,
-    setLanguage,
     speakerLabel,
     setSpeakerLabel,
     maxSpeakers,
@@ -172,15 +155,8 @@ const TranscribePage: React.FC = () => {
     setContent([]);
     clear();
     clearTranscripts();
-    startTranscription(language, speakerLabel);
-  }, [
-    language,
-    speakerLabel,
-    clear,
-    clearTranscripts,
-    setContent,
-    startTranscription,
-  ]);
+    startTranscription(undefined, speakerLabel);
+  }, [speakerLabel, clear, clearTranscripts, setContent, startTranscription]);
 
   return (
     <div className="grid grid-cols-12">
@@ -205,16 +181,6 @@ const TranscribePage: React.FC = () => {
             mp3, mp4, wav, flac, ogg, amr, webm, m4a ファイルが利用可能です
           </p>
           <ExpandableField label="詳細なパラメータ">
-            <div className="grid grid-cols-2 gap-2 pt-4">
-              {!file && (
-                <Select
-                  label="Language"
-                  options={languageOptions}
-                  value={language}
-                  onChange={(v) => setLanguage(v as LanguageCode)}
-                />
-              )}
-            </div>
             <div className="grid grid-cols-2 gap-2 pt-4">
               <Switch
                 label="話者認識"

--- a/packages/web/src/pages/TranscribePage.tsx
+++ b/packages/web/src/pages/TranscribePage.tsx
@@ -6,20 +6,63 @@ import ButtonCopy from '../components/ButtonCopy';
 import ButtonSendToUseCase from '../components/ButtonSendToUseCase';
 import useTranscribe from '../hooks/useTranscribe';
 import useMicrophone from '../hooks/useMicrophone';
-import Markdown from '../components/Markdown';
 import { PiMicrophone, PiMicrophoneSlash } from 'react-icons/pi';
+import Switch from '../components/Switch';
+import RangeSlider from '../components/RangeSlider';
+import ExpandableField from '../components/ExpandableField';
+import { Transcript } from 'generative-ai-use-cases-jp';
+import Textarea from '../components/Textarea';
+import { LanguageCode } from '@aws-sdk/client-transcribe-streaming';
+import Select from '../components/Select';
+
+const languageOptions = [
+  { value: 'ja-JP', label: '日本語' },
+  { value: 'en-US', label: 'English' },
+];
 
 type StateType = {
-  content: string;
-  setContent: (c: string) => void;
+  content: Transcript[];
+  setContent: (c: Transcript[]) => void;
+  language: LanguageCode;
+  setLanguage: (s: LanguageCode) => void;
+  speakerLabel: boolean;
+  setSpeakerLabel: (b: boolean) => void;
+  maxSpeakers: number;
+  setMaxSpeakers: (n: number) => void;
+  speakers: string;
+  setSpeakers: (s: string) => void;
 };
 
 const useTranscribeState = create<StateType>((set) => {
   return {
-    content: '',
-    setContent: (s: string) => {
+    content: [],
+    language: 'ja-JP',
+    speakerLabel: false,
+    maxSpeakers: 2,
+    speakers: '',
+    setContent: (s: Transcript[]) => {
       set(() => ({
         content: s,
+      }));
+    },
+    setLanguage: (s: LanguageCode) => {
+      set(() => ({
+        language: s,
+      }));
+    },
+    setSpeakerLabel: (b: boolean) => {
+      set(() => ({
+        speakerLabel: b,
+      }));
+    },
+    setMaxSpeakers: (n: number) => {
+      set(() => ({
+        maxSpeakers: n,
+      }));
+    },
+    setSpeakers: (s: string) => {
+      set(() => ({
+        speakers: s,
       }));
     },
   };
@@ -35,8 +78,35 @@ const TranscribePage: React.FC = () => {
     recording,
     clearTranscripts,
   } = useMicrophone();
-  const { content, setContent } = useTranscribeState();
+  const {
+    content,
+    setContent,
+    language,
+    setLanguage,
+    speakerLabel,
+    setSpeakerLabel,
+    maxSpeakers,
+    setMaxSpeakers,
+    speakers,
+    setSpeakers,
+  } = useTranscribeState();
   const ref = useRef<HTMLInputElement>(null);
+
+  const speakerMapping = useMemo(() => {
+    return Object.fromEntries(
+      speakers.split(',').map((speaker, idx) => [`spk_${idx}`, speaker.trim()])
+    );
+  }, [speakers]);
+
+  const formattedOutput: string = useMemo(() => {
+    return content
+      .map((item) =>
+        item.speakerLabel
+          ? `${speakerMapping[item.speakerLabel] || item.speakerLabel}: ${item.transcript}`
+          : item.transcript
+      )
+      .join('\n');
+  }, [content, speakerMapping]);
 
   const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -46,15 +116,14 @@ const TranscribePage: React.FC = () => {
   };
 
   useEffect(() => {
-    if (transcriptData && transcriptData.transcript) {
-      setContent(transcriptData.transcript);
+    if (transcriptData && transcriptData.transcripts) {
+      setContent(transcriptData.transcripts);
     }
   }, [setContent, transcriptData]);
 
   useEffect(() => {
     if (transcriptMic && transcriptMic.length > 0) {
-      const _content: string = transcriptMic.map((t) => t.transcript).join(' ');
-      setContent(_content);
+      setContent(transcriptMic);
     }
   }, [setContent, transcriptMic]);
 
@@ -63,7 +132,7 @@ const TranscribePage: React.FC = () => {
   }, [file, loading, recording]);
 
   const disableClearExec = useMemo(() => {
-    return (!file && content == '') || loading || recording;
+    return (!file && content.length === 0) || loading || recording;
   }, [content, file, loading, recording]);
 
   const disabledMicExec = useMemo(() => {
@@ -72,17 +141,25 @@ const TranscribePage: React.FC = () => {
 
   const onClickExec = useCallback(() => {
     if (loading) return;
-    setContent('');
+    setContent([]);
     stopTranscription();
     clearTranscripts();
-    transcribe();
-  }, [loading, setContent, stopTranscription, clearTranscripts, transcribe]);
+    transcribe(speakerLabel, maxSpeakers);
+  }, [
+    loading,
+    speakerLabel,
+    maxSpeakers,
+    setContent,
+    stopTranscription,
+    clearTranscripts,
+    transcribe,
+  ]);
 
   const onClickClear = useCallback(() => {
     if (ref.current) {
       ref.current.value = '';
     }
-    setContent('');
+    setContent([]);
     stopTranscription();
     clear();
     clearTranscripts();
@@ -92,11 +169,18 @@ const TranscribePage: React.FC = () => {
     if (ref.current) {
       ref.current.value = '';
     }
-    setContent('');
+    setContent([]);
     clear();
     clearTranscripts();
-    startTranscription();
-  }, [clear, clearTranscripts, setContent, startTranscription]);
+    startTranscription(language, speakerLabel);
+  }, [
+    language,
+    speakerLabel,
+    clear,
+    clearTranscripts,
+    setContent,
+    startTranscription,
+  ]);
 
   return (
     <div className="grid grid-cols-12">
@@ -115,9 +199,41 @@ const TranscribePage: React.FC = () => {
             type="file"
             accept=".mp3, .mp4, .wav, .flac, .ogg, .amr, .webm, .m4a"
             ref={ref}></input>
-          <p className="ml-0.5 mt-1 text-sm text-gray-500" id="file_input_help">
+          <p
+            className="mb-2 ml-0.5 mt-1 text-sm text-gray-500"
+            id="file_input_help">
             mp3, mp4, wav, flac, ogg, amr, webm, m4a ファイルが利用可能です
           </p>
+          <ExpandableField label="詳細なパラメータ">
+            <div className="grid grid-cols-2 gap-2 pt-4">
+              {!file && (
+                <Select
+                  label="Language"
+                  options={languageOptions}
+                  value={language}
+                  onChange={(v) => setLanguage(v as LanguageCode)}
+                />
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-2 pt-4">
+              <Switch
+                label="話者認識"
+                checked={speakerLabel}
+                onSwitch={setSpeakerLabel}
+              />
+              {speakerLabel && (
+                <RangeSlider
+                  className=""
+                  label="Max Speakers"
+                  min={2}
+                  max={10}
+                  value={maxSpeakers}
+                  onChange={setMaxSpeakers}
+                  help="認識する話者の最大数"
+                />
+              )}
+            </div>
+          </ExpandableField>
           <div className="flex justify-end gap-3">
             <Button outlined disabled={disableClearExec} onClick={onClickClear}>
               クリア
@@ -138,9 +254,33 @@ const TranscribePage: React.FC = () => {
               </Button>
             )}
           </div>
+          {speakerLabel && (
+            <div className="mt-5">
+              <Textarea
+                placeholder="話し手の名前（カンマ区切り）"
+                value={speakers}
+                onChange={setSpeakers}
+              />
+            </div>
+          )}
           <div className="mt-5 rounded border border-black/30 p-1.5">
-            {content != '' && <Markdown>{content}</Markdown>}
-            {!loading && content == '' && (
+            {content.length > 0 && (
+              <div>
+                {content.map((transcript, idx) => (
+                  <div key={idx} className="flex">
+                    {transcript.speakerLabel && (
+                      <div className="min-w-20">
+                        {speakerMapping[transcript.speakerLabel] ||
+                          transcript.speakerLabel}
+                        :
+                      </div>
+                    )}
+                    <div className="grow">{transcript.transcript}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {!loading && formattedOutput == '' && (
               <div className="text-gray-500">
                 音声認識結果がここに表示されます
               </div>
@@ -150,12 +290,12 @@ const TranscribePage: React.FC = () => {
             )}
 
             <div className="flex w-full justify-end">
-              {content && content && (
+              {content && (
                 <>
                   <ButtonCopy
-                    text={content}
+                    text={formattedOutput}
                     interUseCasesKey="transcript"></ButtonCopy>
-                  <ButtonSendToUseCase text={content} />
+                  <ButtonSendToUseCase text={formattedOutput} />
                 </>
               )}
             </div>

--- a/packages/web/src/pages/TranslatePage.tsx
+++ b/packages/web/src/pages/TranslatePage.tsx
@@ -214,36 +214,22 @@ const TranslatePage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages]);
 
-  // 音声入力フラグの切り替え
-  // audioのトグルボタンがOnになったら、startTranscriptionを実行する
-  useEffect(() => {
-    if (audio) {
-      startTranscription();
-    } else {
-      stopTranscription();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [audio]);
-
   // 録音機能がエラー終了した時にトグルスイッチをOFFにする
   useEffect(() => {
     if (!recording) {
       setAudioInput(false);
     }
   }, [recording]);
+
   // transcribeの要素が追加された時の処理. 左のボックスに自動入力する
   useEffect(() => {
-    // transcriptMic[*].transcriptが重複していたら削除する
-    const combinedTranscript = Array.from(
-      new Set(transcriptMic.map((t) => t.transcript))
-    ).join('');
-
+    const combinedTranscript = transcriptMic
+      .map((item) => item.transcript)
+      .join('\n');
     if (combinedTranscript.length > 0) {
       setSentence(combinedTranscript);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [transcriptMic]);
+  }, [transcriptMic, setSentence]);
 
   // LLM にリクエスト送信
   const getTranslation = (


### PR DESCRIPTION
*Issue #, if available:*
#201 #419 #538

*Description of changes:*
- Transcribe の複数話者の話者特定に対応
  - 話者登録: 複数話者の際、名前をカンマ区切りで入れることで話者 ID  spk_{i} を置き換え可能
  - テストケース: ファイル/リアルタイム、日本語/英語、複数話者 ON/OFF の8ケースで検証。
- 微修正: Translate の音声入力で onClick と useEffect で二重に startTranscription が実行され出力が二重になる問題の修正

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
