### PR TITLE
Knowledge Bases for Amazon Bedrockのデータソース対応と脚注付与方法の改善

### DIFF
--- a/packages/web/src/hooks/useRagKnowledgeBase.ts
+++ b/packages/web/src/hooks/useRagKnowledgeBase.ts
@@ -152,14 +152,14 @@ const useRagKnowledgeBase = (id: string) => {
           });
 
           // 本文中の脚注番号に合わせてフッター部分を作成
-          const footnoteText = Array.from(uriToFootnote)
+          const footnote = Array.from(uriToFootnote)
             .map(
               ([uri, { updatedIndex, title }]) =>
                 `[^${updatedIndex}]: [${title}](${encodeURI(uri).replace(/\(/g, '%28').replace(/\)/g, '%29')})`
             )
             .join('\n');
 
-          return `${updatedMessage}\n${footnoteText}`;
+          return `${updatedMessage}\n\n${footnote}`;
         }
       );
     },


### PR DESCRIPTION
*Description of changes:*

本プルリクエストでは、RAG チャット (Knowledge Base) 機能に以下の2点の変更を行いました。

1. **Knowledge Bases for Amazon Bedrock の追加データソースへの対応**
2. **後処理の脚注付与方法の改良**

**変更の概要**

#### 1. Knowledge Bases for Amazon Bedrock の追加データソースへの対応

- **目的**: Knowledge Bases for Amazon Bedrock が Web クローラー等の新たなデータソースに対応したため、S3 以外のデータソースをデプロイ済みの Knowledge Base に追加した際に RAG チャットで利用できるようにするための変更です
- **変更点**:
  - `convertS3UriToUrl` 関数を修正し、変換に失敗した場合は元の URI をそのまま返すよう変更しました。

    変更によって、S3 以外のデータソース利用時に脚注の URI が空になる問題に対応しました。
  - `retrievedItemsKendraFormat` の生成方法を変更し、`location?.s3Location?.uri` の代わりに各種データソースで共通して URI を取得できる `metadata?.['x-amz-bedrock-kb-source-uri']` を使用するよう変更しました。
  
    `location` キーを用いる場合はデータソースごとに異なる名称が返却されるため、参照先を変更しています。変更にあたって、 [Retrieve - Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_Retrieve.html)  を参照しました。

#### 2. 後処理の脚注付与方法の改良

- **目的**: データソースに長大な 1 ファイルを読み込ませた際に、同じ URI に別の脚注番号が割り当てられることを防ぐための変更です。
- **変更点**:
  - 本文中の脚注番号に紐づく URI を取得し、重複する場合は脚注番号を置き換える処理を追加しました。
  - 脚注番号の重複排除と併せて、本文中の脚注番号を 1 番から始まる連番に振りなおす処理を追加しました。
  
    現行は順不同で 0 番始まりです。
  - URI 内の括弧のエスケープ方法をパーセントエンコーディングに変更しました。

    Markdown として本文をコピーした際に、そのままでは URI として機能しない問題に対応しました。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.