### PR TITLE
既存の ACM 証明書を指定してカスタムドメインを利用可能にする

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -678,8 +678,6 @@ PDF や Excel などのファイルをアップロードしてテキストを抽
 
 Web サイトの URL としてカスタムドメインを使用することができます。同一 AWS アカウントの Route53 にパブリックホストゾーンが作成済みであることが必要です。パブリックホストゾーンについてはこちらをご参照ください: [パブリックホストゾーンの使用 - Amazon Route 53](https://docs.aws.amazon.com/ja_jp/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html)
 
-同一 AWS アカウントにパブリックホストゾーンを持っていない場合は、AWS ACM による SSL 証明書の検証時に手動で DNS レコードを追加する方法や、Eメール検証を行う方法もあります。これらの方法を利用する場合は、CDK のドキュメントを参照してカスタマイズしてください: [aws-cdk-lib.aws_certificatemanager module · AWS CDK](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager-readme.html)
-
 cdk.json には以下の値を設定します。
 
 - `hostName` ... Web サイトのホスト名です。A レコードは CDK によって作成されます。事前に作成する必要はありません
@@ -697,6 +695,30 @@ cdk.json には以下の値を設定します。
   }
 }
 ```
+
+パブリックホストゾーンを別アカウントで管理している等の環境では、作成済みの AWS ACM 証明書を使用することもできます。
+
+cdk.json には以下の値を設定します。
+
+- `hostName` ... Web サイトのホスト名です。**A レコードは CDK によって自動で追加されません。** 別アカウントのパブリックホステッドゾーンに手動で追加してください
+- `domainName` ... 別アカウントに作成されたパブリックホストゾーンのドメイン名です
+- `certificateArn` ... 事前に作成したバージニア北部リージョンの AWS ACM 証明書 ARN です
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+
+```json
+{
+  "context": {
+    "hostName": "genai",
+    "domainName": "example.com",
+    "certificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+}
+```
+
+`hostedZoneId` と `certificateArn` は同時に指定できません。
+
+その他、AWS ACM による SSL 証明書の検証時に手動で DNS レコードを追加する方法や、Eメール検証を行う方法もあります。これらの方法を利用する場合は、CDK のドキュメントを参照してカスタマイズしてください: [aws-cdk-lib.aws_certificatemanager module · AWS CDK](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_certificatemanager-readme.html)
 
 ## 別 AWS アカウントの Bedrock を利用したい場合
 

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -50,6 +50,7 @@
     "hostName": null,
     "domainName": null,
     "hostedZoneId": null,
+    "certificateArn": null,
     "dashboard": false,
     "anonymousUsageTracking": true,
     "recognizeFileEnabled": false,

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -78,8 +78,7 @@ export class Web extends Construct {
     if (
       props.cert &&
       props.hostName &&
-      props.domainName &&
-      props.hostedZoneId
+      props.domainName
     ) {
       cloudFrontToS3Props.cloudFrontDistributionProps.certificate = props.cert;
       cloudFrontToS3Props.cloudFrontDistributionProps.domainNames = [
@@ -93,28 +92,28 @@ export class Web extends Construct {
       cloudFrontToS3Props
     );
 
-    if (
-      props.cert &&
-      props.hostName &&
-      props.domainName &&
-      props.hostedZoneId
-    ) {
-      // DNS record for custom domain
-      const hostedZone = HostedZone.fromHostedZoneAttributes(
-        this,
-        'HostedZone',
-        {
-          hostedZoneId: props.hostedZoneId,
-          zoneName: props.domainName,
-        }
-      );
-      new ARecord(this, 'ARecord', {
-        zone: hostedZone,
-        recordName: props.hostName,
-        target: RecordTarget.fromAlias(
-          new CloudFrontTarget(cloudFrontWebDistribution)
-        ),
-      });
+    if (props.hostName && props.domainName) {
+      // DNS records will be created only if hostedZoneId is provided.
+      if (props.hostedZoneId) {
+        // DNS record for custom domain
+        const hostedZone = HostedZone.fromHostedZoneAttributes(
+          this,
+          'HostedZone',
+          {
+            hostedZoneId: props.hostedZoneId,
+            zoneName: props.domainName,
+          }
+        );
+        new ARecord(this, 'ARecord', {
+          zone: hostedZone,
+          recordName: props.hostName,
+          target: RecordTarget.fromAlias(
+            new CloudFrontTarget(cloudFrontWebDistribution)
+          ),
+        });
+      } else {
+        console.warn('hostedZoneId not provided. DNS record will not be created or deleted automatically.');
+      }
     }
 
     if (props.webAclId) {


### PR DESCRIPTION
既存の ACM 証明書を指定してカスタムドメインを利用可能にする

*Issue #, if available:*

*Description of changes:*

同一アカウント内に存在する既存の ACM 証明書を CloudFront ディストリビューションで使用できるようします。これにより、別の AWS アカウントでホストテッドゾーンが管理されている場合でもカスタムドメインを使用することができます。

context に `certificateArn` を追加し、既存の証明書 ARN を受け入れるよう変更しました。`hostedZoneId` が指定された場合はこれまで通り新しい証明書や DNS レコードを作成します。

`certificateArn` と `hostedZoneId` は同時に指定できないため、`hostName`, `domainName`, `hostedZoneId`, `certificateArn` の組み合わせに関するバリデーションチェックも追加しました。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
