### PR TITLE
converse API で Titan Text のパラメータが動かなくなったものの修正

### DIFF
--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -81,7 +81,7 @@ const CLAUDE_DEFAULT_PARAMS: ConverseInferenceParams = {
 };
 
 const TITAN_TEXT_DEFAULT_PARAMS: ConverseInferenceParams = {
-  maxTokens: 3072,
+  maxTokens: 3000,
   temperature: 0.7,
   topP: 1.0,
 };


### PR DESCRIPTION
#594 