### PR TITLE
Kendra RAG の リンクの修正

### DIFF
--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -6,6 +6,7 @@ import { ShownMessage } from 'generative-ai-use-cases-jp';
 import { findModelByModelId } from './useModel';
 import { getPrompter } from '../prompts';
 import { RetrieveResultItem, DocumentAttribute } from '@aws-sdk/client-kendra';
+import { cleanEncode } from '../utils/URLUtils';
 
 // 同一のドキュメントとみなす Key 値
 const uniqueKeyOfItem = (item: RetrieveResultItem): string => {
@@ -156,9 +157,7 @@ const useRag = (id: string) => {
                   }](
                   ${
                     item.DocumentURI
-                      ? encodeURI(item.DocumentURI)
-                          .replace(/\(/g, '\\(')
-                          .replace(/\)/g, '\\)')
+                      ? cleanEncode(item.DocumentURI)
                       : ''
                   }${
                     _excerpt_page_number ? `#page=${_excerpt_page_number}` : ''

--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -155,11 +155,7 @@ const useRag = (id: string) => {
                       ? `(${_excerpt_page_number} ページ)`
                       : ''
                   }](
-                  ${
-                    item.DocumentURI
-                      ? cleanEncode(item.DocumentURI)
-                      : ''
-                  }${
+                  ${item.DocumentURI ? cleanEncode(item.DocumentURI) : ''}${
                     _excerpt_page_number ? `#page=${_excerpt_page_number}` : ''
                   })`
                 : '';

--- a/packages/web/src/utils/URLUtils.ts
+++ b/packages/web/src/utils/URLUtils.ts
@@ -1,0 +1,17 @@
+// RFC3986 Encoding
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986
+const encodeRFC3986URI = (uri: string) => {
+  return encodeURI(uri).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+};
+
+export const cleanEncode = (uri: string): string => {
+  // Check if uri is encoded, and encode it if not already encoded
+  if (decodeURI(uri) === uri) {
+    return encodeRFC3986URI(uri);
+  } else {
+    return uri;
+  }
+};


### PR DESCRIPTION
*Issue #, if available:*

#610 #411  #355

*Description of changes:*
- Kendra のリンクが正しく表示されるように修正
  - Kendra の DocumentURI の仕様: S3 パスは日本語空白括弧含め正しくエンコードされている一方ウェブサイトのURLなどはエンコードされておらず日本語は動作するが空白や `)` により URL 自体は問題ないものの Markdown のリンクが壊れる。
  - 現在の実装の課題: Web に合わせた実装になっているためすでにエンコードされている S3 DocumentURI が二重にエンコードされている。
  - 修正点:
    - エンコードされてない場合のみエンコード（日本語と空白と多重エンコードに対応）
    - [RFC3986 に則ったエンコード](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986) （括弧など encodeURI がエンコードしない特殊記号をエンコードし Markdown リンクの崩壊を防ぐ）
- 検証:
  - S3: 日本語、半角スペース、半角括弧等が含まれたファイルを S3 にアップロード し S3 データソースにて検証。 
  - Web Crawler: 日本語、半角スペース、半角括弧等が含まれた[ウェブサイト](https://maekawataiki.github.io/PageTest/index.html)を用意し Web Crawler v3 データソースにて検証。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
