### PR TITLE
feat: GuardrailVersionリソースを削除してDRAFTバージョンを使用する

### DIFF
--- a/packages/cdk/bin/generative-ai-use-cases.ts
+++ b/packages/cdk/bin/generative-ai-use-cases.ts
@@ -177,7 +177,7 @@ const generativeAiUseCasesStack = new GenerativeAiUseCasesStack(
     knowledgeBaseDataSourceBucketName:
       ragKnowledgeBaseStack?.dataSourceBucketName,
     guardrailIdentifier: guardrail?.guardrailIdentifier,
-    guardrailVersion: guardrail?.guardrailVersion,
+    guardrailVersion: 'DRAFT',
   }
 );
 

--- a/packages/cdk/lib/construct/guardrail.ts
+++ b/packages/cdk/lib/construct/guardrail.ts
@@ -3,7 +3,6 @@ import { aws_bedrock as bedrock } from 'aws-cdk-lib';
 
 export class Guardrail extends Construct {
   public readonly guardrailIdentifier: string;
-  public readonly guardrailVersion: string;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -37,16 +36,7 @@ export class Guardrail extends Construct {
         ],
       },
     });
-    const cfnGuardrailVersion = new bedrock.CfnGuardrailVersion(
-      this,
-      `guardrailVersion`,
-      {
-        guardrailIdentifier: cfnGuardrail.attrGuardrailId,
-        description: `GenU PII Guardrail`,
-      }
-    );
 
     this.guardrailIdentifier = cfnGuardrail.attrGuardrailId;
-    this.guardrailVersion = cfnGuardrailVersion.attrVersion;
   }
 }

--- a/packages/cdk/lib/guardrail-stack.ts
+++ b/packages/cdk/lib/guardrail-stack.ts
@@ -6,13 +6,11 @@ interface GuardrailStackProps extends StackProps {}
 
 export class GuardrailStack extends Stack {
   public readonly guardrailIdentifier: string;
-  public readonly guardrailVersion: string;
 
   constructor(scope: Construct, id: string, props: GuardrailStackProps) {
     super(scope, id, props);
 
     const guardrail = new Guardrail(this, 'Guardrail');
     this.guardrailIdentifier = guardrail.guardrailIdentifier;
-    this.guardrailVersion = guardrail.guardrailVersion;
   }
 }


### PR DESCRIPTION
*Issue #:* #641

AWS::Bedrock::GuardrailVersionリソースは、Guardrailの現在の設定のスナップショットを保持するイミュータブルなリソースです。このため、Guardrailの設定を更新しても、作成済みのGuardrailVersionには反映されません。

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-bedrock-guardrailversion.html

GuardrailVersionを使用せず、APIでは `DRAFT` バージョンを指定してGuardrailを適用します。これにより、Guardrailの設定変更は即座にAPIに反映されるようになります。

すでにGuardrailを有効にしてデプロイしたユーザーは、この修正を反映したあとにクロススタック参照のデプロイエラーを経験します。解決策は、GuardrailStackを更新する前にGenerativeAiUseCasesStackを単独で更新することです。

```sh
npx cdk deploy GenerativeAiUseCasesStack --exclusively
npx cdk deploy --all
```

詳細については #641 を参照してください。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
