### PR TITLE
change memorySize of predictStreamFunction from 128MB(default) to 256MB

### DIFF
--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -183,6 +183,7 @@ export class Api extends Construct {
       runtime: Runtime.NODEJS_18_X,
       entry: './lambda/predictStream.ts',
       timeout: Duration.minutes(15),
+      memorySize: 256,
       environment: {
         MODEL_REGION: modelRegion,
         MODEL_IDS: JSON.stringify(modelIds),


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
大きめのDocumentをインプットにした際に、Lambda(PredictStream)がメモリ不足で終了し、推論が中断される動作を確認したため、対策としてメモリを256MBに増量する。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
