### PR TITLE
WAFのルール設定を変更

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -606,7 +606,7 @@ context の allowedSignUpEmailDomains に 許可するドメインのリスト�
 
 #### IP アドレスによる制限
 
-Web アプリへのアクセスを IP で制限したい場合、AWS WAF による IP 制限を有効化することができます。[packages/cdk/cdk.json](/packages/cdk/cdk.json) の `allowedIpV4AddressRanges` では許可する IPv4 の CIDR を配列で指定することができ、`allowedIpV6AddressRanges` では許可する IPv6 の CIDR を配列で指定することができます。
+Web アプリへのアクセスを IP アドレスで制限したい場合、AWS WAF による IP アドレス制限を有効化することができます。[packages/cdk/cdk.json](/packages/cdk/cdk.json) の `allowedIpV4AddressRanges` では許可する IPv4 の CIDR を配列で指定することができ、`allowedIpV6AddressRanges` では許可する IPv6 の CIDR を配列で指定することができます。
 
 ```json
   "context": {
@@ -619,6 +619,9 @@ Web アプリへのアクセスを IP で制限したい場合、AWS WAF によ�
 
 Web アプリへのアクセスをアクセス元の国で制限したい場合、AWS WAF による地理的制限を有効化することができます。[packages/cdk/cdk.json](/packages/cdk/cdk.json) の `allowedCountryCodes` で許可する国を Country Code の配列で指定することができます。
 指定する国の Country Code は[ISO 3166-2 from wikipedia](https://en.wikipedia.org/wiki/ISO_3166-2)をご参照ください。
+
+「IP アドレスによる制限」も同時に設定している場合は、「送信元の IP アドレスが許可された IP アドレスに含まれている**かつ**、許可された国からのアクセス」のみ許可されます。
+
 ```json
   "context": {
     "allowedCountryCodes": ["JP"], // null から、許可国リストを指定することで有効化

--- a/packages/cdk/lib/construct/common-web-acl.ts
+++ b/packages/cdk/lib/construct/common-web-acl.ts
@@ -40,7 +40,7 @@ export class CommonWebAcl extends Construct {
       },
     });
 
-    const generateIpSetAndGeMatchRule = (
+    const generateIpSetAndGeoMatchRule = (
       priority: number,
       name: string,
       ipSetArn: string,
@@ -86,7 +86,7 @@ export class CommonWebAcl extends Construct {
       if (hasAllowedCountryCodes) {
         // Geo制限を行う場合は、IP制限とのAND条件にする
         rules.push(
-          generateIpSetAndGeMatchRule(
+          generateIpSetAndGeoMatchRule(
             1,
             `IpV4SetAndGeoMatchRule${id}`,
             wafIPv4Set.attrArn,
@@ -109,7 +109,7 @@ export class CommonWebAcl extends Construct {
       if (hasAllowedCountryCodes) {
         // Geo制限を行う場合は、IP制限とのAND条件にする
         rules.push(
-          generateIpSetAndGeMatchRule(
+          generateIpSetAndGeoMatchRule(
             2,
             `IpV6SetAndGeoMatchRule${id}`,
             wafIPv6Set.attrArn,

--- a/packages/cdk/lib/construct/common-web-acl.ts
+++ b/packages/cdk/lib/construct/common-web-acl.ts
@@ -16,12 +16,7 @@ export class CommonWebAcl extends Construct {
 
     const rules: CfnWebACLProps['rules'] = [];
 
-    const generateIpSetRule = (
-      priority: number,
-      name: string,
-      ipSetArn: string
-    ) => ({
-      priority,
+    const commonRulePropreties = (name: string) => ({
       name,
       action: { allow: {} },
       visibilityConfig: {
@@ -29,6 +24,15 @@ export class CommonWebAcl extends Construct {
         cloudWatchMetricsEnabled: true,
         metricName: name,
       },
+    });
+
+    const generateIpSetRule = (
+      priority: number,
+      name: string,
+      ipSetArn: string
+    ): CfnWebACL.RuleProperty => ({
+      priority,
+      ...commonRulePropreties(name),
       statement: {
         ipSetReferenceStatement: {
           arn: ipSetArn,
@@ -36,37 +40,98 @@ export class CommonWebAcl extends Construct {
       },
     });
 
-    if (props.allowedIpV4AddressRanges) {
+    const generateIpSetAndGeMatchRule = (
+      priority: number,
+      name: string,
+      ipSetArn: string,
+      allowedCountryCodes: string[]
+    ): CfnWebACL.RuleProperty => ({
+      priority,
+      ...commonRulePropreties(name),
+      statement: {
+        // ルール間の条件はOR判定になるので、同一ルール内でAND条件で指定する
+        andStatement: {
+          statements: [
+            {
+              ipSetReferenceStatement: {
+                arn: ipSetArn,
+              },
+            },
+            {
+              geoMatchStatement: {
+                countryCodes: allowedCountryCodes,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const hasAllowedIpV4 =
+      props.allowedIpV4AddressRanges &&
+      props.allowedIpV4AddressRanges.length > 0;
+    const hasAllowedIpV6 =
+      props.allowedIpV6AddressRanges &&
+      props.allowedIpV6AddressRanges.length > 0;
+    const hasAllowedCountryCodes =
+      props.allowedCountryCodes && props.allowedCountryCodes.length > 0;
+
+    // IP v4 と v6 それぞれでルールを定義する
+    if (hasAllowedIpV4) {
       const wafIPv4Set = new CfnIPSet(this, `IPv4Set${id}`, {
         ipAddressVersion: 'IPV4',
         scope: props.scope,
-        addresses: props.allowedIpV4AddressRanges,
+        addresses: props.allowedIpV4AddressRanges ?? [],
       });
-      rules.push(generateIpSetRule(1, `IpV4SetRule${id}`, wafIPv4Set.attrArn));
+      if (hasAllowedCountryCodes) {
+        // Geo制限を行う場合は、IP制限とのAND条件にする
+        rules.push(
+          generateIpSetAndGeMatchRule(
+            1,
+            `IpV4SetAndGeoMatchRule${id}`,
+            wafIPv4Set.attrArn,
+            props.allowedCountryCodes ?? []
+          )
+        );
+      } else {
+        rules.push(
+          generateIpSetRule(1, `IpV4SetRule${id}`, wafIPv4Set.attrArn)
+        );
+      }
     }
 
-    if (props.allowedIpV6AddressRanges) {
+    if (hasAllowedIpV6) {
       const wafIPv6Set = new CfnIPSet(this, `IPv6Set${id}`, {
         ipAddressVersion: 'IPV6',
         scope: props.scope,
-        addresses: props.allowedIpV6AddressRanges,
+        addresses: props.allowedIpV4AddressRanges ?? [],
       });
-      rules.push(generateIpSetRule(2, `IpV6SetRule${id}`, wafIPv6Set.attrArn));
+      if (hasAllowedCountryCodes) {
+        // Geo制限を行う場合は、IP制限とのAND条件にする
+        rules.push(
+          generateIpSetAndGeMatchRule(
+            2,
+            `IpV6SetAndGeoMatchRule${id}`,
+            wafIPv6Set.attrArn,
+            props.allowedCountryCodes ?? []
+          )
+        );
+      } else {
+        rules.push(
+          generateIpSetRule(2, `IpV6SetRule${id}`, wafIPv6Set.attrArn)
+        );
+      }
     }
 
-    if (props.allowedCountryCodes) {
+    // IP制限なしのGe制限のみの場合は、Geo制限のルールを定義
+    if (!hasAllowedIpV4 && !hasAllowedIpV6 && hasAllowedCountryCodes) {
+      const name = `GeoMatchRule${id}`;
       rules.push({
         priority: 3,
-        name: `GeoMatchSetRule${id}`,
-        action: { allow: {} },
-        visibilityConfig: {
-          cloudWatchMetricsEnabled: true,
-          metricName: 'FrontendWebAcl',
-          sampledRequestsEnabled: true,
-        },
+        ...commonRulePropreties(name),
         statement: {
           geoMatchStatement: {
-            countryCodes: props.allowedCountryCodes,
+            countryCodes: props.allowedCountryCodes ?? [],
           },
         },
       });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

WAFに IP アドレス制限と国コード制限の両方を設定した場合に、「許可されたIPアドレスかつ、許可された国」のアクセスだけ許可するように変更しました。
※現状は、OR条件で判定している。


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
