### PR TITLE
Upgraded Claude 3.5 Sonnet  V2 in Amazon Bedrock

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -362,6 +362,7 @@ PromptFlow チャットユースケースでは、作成済みの Prompt Flow �
 2024/06 現在、マルチモーダルのモデルは以下です。
 
 ```
+"anthropic.claude-3-5-sonnet-20241022-v2:0",
 "anthropic.claude-3-5-sonnet-20240620-v1:0",
 "anthropic.claude-3-opus-20240229-v1:0",
 "anthropic.claude-3-sonnet-20240229-v1:0",
@@ -382,6 +383,7 @@ PromptFlow チャットユースケースでは、作成済みの Prompt Flow �
 
 ```json
   "modelIds": [
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "anthropic.claude-3-opus-20240229-v1:0",
     "anthropic.claude-3-sonnet-20240229-v1:0",
@@ -409,6 +411,7 @@ PromptFlow チャットユースケースでは、作成済みの Prompt Flow �
 このソリューションが対応しているテキスト生成モデルは以下です。
 
 ```
+"anthropic.claude-3-5-sonnet-20241022-v2:0",
 "anthropic.claude-3-5-sonnet-20240620-v1:0",
 "anthropic.claude-3-opus-20240229-v1:0",
 "anthropic.claude-3-sonnet-20240229-v1:0",
@@ -485,6 +488,7 @@ PromptFlow チャットユースケースでは、作成済みの Prompt Flow �
 ```bash
   "modelRegion": "us-west-2",
   "modelIds": [
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
     "anthropic.claude-3-5-sonnet-20240620-v1:0",
     "anthropic.claude-3-opus-20240229-v1:0",
     "anthropic.claude-3-sonnet-20240229-v1:0",

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -570,6 +570,14 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: (body: ConverseStreamOutput) => string;
   };
 } = {
+  'anthropic.claude-3-5-sonnet-20241022-v2:0': {
+    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutputText: extractConverseOutputText,
+    extractConverseStreamOutputText: extractConverseStreamOutputText,
+  },
   'anthropic.claude-3-5-sonnet-20240620-v1:0': {
     defaultParams: CLAUDE_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -71,6 +71,7 @@ export class Api extends Construct {
 
     // Validate Model Names
     const supportedModelIds = [
+      'anthropic.claude-3-5-sonnet-20241022-v2:0',
       'anthropic.claude-3-5-sonnet-20240620-v1:0',
       'anthropic.claude-3-opus-20240229-v1:0',
       'anthropic.claude-3-sonnet-20240229-v1:0',
@@ -114,6 +115,7 @@ export class Api extends Construct {
       'cohere.command-r-plus-v1:0',
     ];
     const multiModalModelIds = [
+      'anthropic.claude-3-5-sonnet-20241022-v2:0',
       'anthropic.claude-3-5-sonnet-20240620-v1:0',
       'anthropic.claude-3-opus-20240229-v1:0',
       'anthropic.claude-3-sonnet-20240229-v1:0',


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/684

*Description of changes:*

https://aws.amazon.com/jp/blogs/aws/upgraded-claude-3-5-sonnet-from-anthropic-available-now-computer-use-public-beta-and-claude-3-5-haiku-coming-soon-in-amazon-bedrock/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
