### PR TITLE
デプロイ時に `Custom::CDKBucketDeployment` がタイムアウトするバグの修正

### DIFF
--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -175,8 +175,7 @@ export class Rag extends Construct {
       new s3Deploy.BucketDeployment(this, 'DeployDocs', {
         sources: [s3Deploy.Source.asset('./rag-docs')],
         destinationBucket: dataSourceBucket,
-        // 以前の設定で同 Bucket にアクセスログが残っている可能性があるため、この設定は残す
-        exclude: ['AccessLogs/*'],
+        prune: false,
       });
 
       let index: kendra.CfnIndex;

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -436,8 +436,7 @@ export class RagKnowledgeBaseStack extends Stack {
     new s3Deploy.BucketDeployment(this, 'DeployDocs', {
       sources: [s3Deploy.Source.asset('./rag-docs')],
       destinationBucket: dataSourceBucket,
-      // 以前の設定で同 Bucket にアクセスログが残っている可能性があるため、この設定は残す
-      exclude: ['AccessLogs/*'],
+      prune: false,
     });
 
     this.knowledgeBaseId = knowledgeBase.ref;


### PR DESCRIPTION
## 変更内容の説明
- `Custom::CDKBucketDeployment` がタイムアウトするのは RAG の docs 用の bucket に大量のアクセスログが存在しているから
- 大量のアクセスログが存在してしまっている件は https://github.com/aws-samples/generative-ai-use-cases-jp/pull/689 で修正済み (アクセスログは別の bucket に吐くように修正された)
- ただし、既存ユーザーは RAG の docs 用 bucket に大量のアクセスログがまだ存在するため、デプロイ時にそれらのファイルを削除しようとしてタイムアウトすることがある
- https://github.com/aws-samples/generative-ai-use-cases-jp/pull/672 の対応で `exclude: ['AccessLogs/*']` オプションを追加したが、この対応は **誤り** で、手元のディレクトリから AccessLogs を省くだけの指定になっていた。
- (これが今回の対応) `prune: false` を指定することで、bucket に存在する既存のファイルは削除しないように変更
- (考慮事項) `rag-docs` 以下のファイルを手動削除して `cdk deploy` しなおしても、bucket 上からはファイルが消えないという仕様になったので注意。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/681
