### PR TITLE
デプロイ時に Custom::CDKBucketDeployment がタイムアウトするバグの修正

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -29,7 +29,7 @@ context の `ragEnabled` に `true` を指定します。(デフォルトは `fa
 }
 ```
 
-変更後に `npm run cdk:deploy` で再度デプロイして反映させます。また、`/packages/cdk/rag-docs/docs` に保存されているデータが、自動で Kendra データソース用の S3 バケットにアップロードされます。
+変更後に `npm run cdk:deploy` で再度デプロイして反映させます。また、`/packages/cdk/rag-docs/docs` に保存されているデータが、自動で Kendra データソース用の S3 バケットにアップロードされます。(ただし `logs` から始まる名前のファイルは同期されませんので注意してください。)
 
 続いて、Kendra の Data source の Sync を以下の手順で行ってください。
 
@@ -111,7 +111,7 @@ context の `ragKnowledgeBaseEnabled` に `true` を指定します。(デフォ
 npx -w packages/cdk cdk bootstrap --region us-east-1
 ```
 
-デプロイ時に `/packages/cdk/rag-docs/docs` に保存されているデータが、自動で Knowledge Base データソース用の S3 バケットにアップロードされます。デプロイ完了後、以下の手順で Knowledge Base の Data source を Sync してください。
+デプロイ時に `/packages/cdk/rag-docs/docs` に保存されているデータが、自動で Knowledge Base データソース用の S3 バケットにアップロードされます。(ただし `logs` から始まる名前のファイルは同期されませんので注意してください。) デプロイ完了後、以下の手順で Knowledge Base の Data source を Sync してください。
 
 1. [Knowledge Base のコンソール画面](https://console.aws.amazon.com/bedrock/home#/knowledge-bases) を開く
 1. generative-ai-use-cases-jp をクリック

--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -176,7 +176,7 @@ export class Rag extends Construct {
         sources: [s3Deploy.Source.asset('./rag-docs')],
         destinationBucket: dataSourceBucket,
         // 以前の設定で同 Bucket にアクセスログが残っている可能性があるため、この設定は残す
-        exclude: ['AccessLogs/*'],
+        exclude: ['AccessLogs/*', 'logs*'],
       });
 
       let index: kendra.CfnIndex;

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -437,7 +437,7 @@ export class RagKnowledgeBaseStack extends Stack {
       sources: [s3Deploy.Source.asset('./rag-docs')],
       destinationBucket: dataSourceBucket,
       // 以前の設定で同 Bucket にアクセスログが残っている可能性があるため、この設定は残す
-      exclude: ['AccessLogs/*'],
+      exclude: ['AccessLogs/*', 'logs*'],
     });
 
     this.knowledgeBaseId = knowledgeBase.ref;


### PR DESCRIPTION
## 変更内容の説明
- Custom::CDKBucketDeployment がタイムアウトするのは RAG の docs 用の bucket に大量のアクセスログが存在しているから
- 大量のアクセスログが存在してしまっている件は https://github.com/aws-samples/generative-ai-use-cases-jp/pull/689 で修正済み (アクセスログは別の bucket に吐くように修正された)
- ただし、既存ユーザーは RAG の docs 用 bucket に大量のアクセスログがまだ存在するため、デプロイ時にそれらのファイルを削除しようとしてタイムアウトすることがある
- https://github.com/aws-samples/generative-ai-use-cases-jp/pull/672 の対応で exclude: ['AccessLogs/*'] オプションを追加したが、この対応は不完全で、ログの出力先を AccessLogs に変更した対応の前から存在する logs* ファイルが排除されていなかった。
(これが今回の対応) exclude の対象に logs* を追加することで、全てのログファイルを対象外に

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
関連する Issue を可能な限り挙げてください。
- https://github.com/aws-samples/generative-ai-use-cases-jp/issues/681
- https://github.com/aws-samples/generative-ai-use-cases-jp/pull/693 (間違った対応。マージされていない。)