### PR TITLE
fix kendra's query/retrieval parameters

### DIFF
--- a/packages/cdk/lambda/queryKendra.ts
+++ b/packages/cdk/lambda/queryKendra.ts
@@ -1,9 +1,5 @@
 import * as lambda from 'aws-lambda';
-import {
-  AttributeFilter,
-  KendraClient,
-  QueryCommand,
-} from '@aws-sdk/client-kendra';
+import { KendraClient, QueryCommand } from '@aws-sdk/client-kendra';
 import { QueryKendraRequest } from 'generative-ai-use-cases-jp';
 
 const INDEX_ID = process.env.INDEX_ID;
@@ -25,13 +21,10 @@ exports.handler = async (
     };
   }
 
-  const attributeFilter: AttributeFilter = {};
-
   const kendra = new KendraClient({});
   const queryCommand = new QueryCommand({
     IndexId: INDEX_ID,
     QueryText: query,
-    AttributeFilter: attributeFilter,
   });
 
   const queryRes = await kendra.send(queryCommand);

--- a/packages/cdk/lambda/retrieveKendra.ts
+++ b/packages/cdk/lambda/retrieveKendra.ts
@@ -1,9 +1,5 @@
 import * as lambda from 'aws-lambda';
-import {
-  AttributeFilter,
-  KendraClient,
-  RetrieveCommand,
-} from '@aws-sdk/client-kendra';
+import { KendraClient, RetrieveCommand } from '@aws-sdk/client-kendra';
 import { RetrieveKendraRequest } from 'generative-ai-use-cases-jp';
 
 const INDEX_ID = process.env.INDEX_ID;
@@ -25,13 +21,10 @@ exports.handler = async (
     };
   }
 
-  const attributeFilter: AttributeFilter = {};
-
   const kendra = new KendraClient({});
   const retrieveCommand = new RetrieveCommand({
     IndexId: INDEX_ID,
     QueryText: query,
-    AttributeFilter: attributeFilter,
   });
 
   const retrieveRes = await kendra.send(retrieveCommand);


### PR DESCRIPTION
## 変更内容の説明
Kendra の Query/Retrieve における AttributeFilter を削除し、下記のエラーを解消。

> (ValidationException) "AttributeFilter cannot have 0 operators. It must have one and only one."

## チェック項目
- [x] npm run lint を実行した
- [ ] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
N/A