### PR TITLE
Rag Knowledge Base の検索対象をS3プレフィックスごとに選択可能に

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
+        "@types/node": "^22.9.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.13",
@@ -9951,13 +9952,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
-      "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/prop-types": {
@@ -20802,13 +20803,23 @@
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.137",
-        "@types/node": "^20.12.5",
+        "@types/node": "^20.17.6",
         "@typescript-eslint/eslint-plugin": "^7.6.0",
         "@typescript-eslint/parser": "^7.6.0",
         "aws-cdk": "^2.154.1",
         "eslint": "^8.56.0",
         "ts-node": "^10.9.2",
         "typescript": "~5.4.5"
+      }
+    },
+    "packages/cdk/node_modules/@types/node": {
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
       }
     },
     "packages/types": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "run-s root:lint web:lint cdk:lint",
     "root:lint": "npx prettier --write .",
-    "web:devw": "source ./setup-env.sh && VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev",
+    "web:devw": "bash -c 'source ./setup-env.sh && VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev'",
     "web:dev": "VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev",
     "web:build": "VITE_APP_VERSION=${npm_package_version} npm -w packages/web run build",
     "web:lint": "npm -w packages/web run lint",
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",
+    "@types/node": "^22.9.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.13",

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -33,19 +33,28 @@
     "samlAuthEnabled": false,
     "samlCognitoDomainName": "",
     "samlCognitoFederatedIdentityProviderName": "",
-    "modelRegion": "us-east-1",
+    "modelRegion": "us-west-2",
     "modelIds": [
-      "anthropic.claude-3-sonnet-20240229-v1:0"
+      "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "anthropic.claude-3-5-sonnet-20240620-v1:0", 
+      "anthropic.claude-3-sonnet-20240229-v1:0", 
+      "anthropic.claude-3-haiku-20240307-v1:0"
     ],
     "imageGenerationModelIds": [
       "stability.stable-diffusion-xl-v1"
     ],
     "endpointNames": [],
-    "agentEnabled": false,
-    "agentRegion": "us-east-1",
-    "searchAgentEnabled": false,
-    "searchApiKey": "",
-    "agents": [],
+    "agentEnabled": true,
+    "agentRegion": "us-west-2",
+    "searchAgentEnabled": true,
+    "searchApiKey": "BSAmZYZAyNww6rVxV9e7xKXyc-DYAFm",
+    "agents": [
+      {
+        "displayName": "Code Interpreter",
+        "agentId": "IQNVCT4DQK",
+        "aliasId": "YMT6FH2G6F"
+      }
+    ],
     "promptFlows": [],
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,

--- a/packages/cdk/lambda/listKnowledgeBasePrefixes.ts
+++ b/packages/cdk/lambda/listKnowledgeBasePrefixes.ts
@@ -1,0 +1,52 @@
+import * as lambda from 'aws-lambda';
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+
+const DATA_SOURCE_BUCKET_NAME = process.env.DATA_SOURCE_BUCKET_NAME!;
+
+// デフォルトだとMODEL_REGIONにs3bucketもできるため、ここではMODEL_REGIONを使用する カスタムしてる環境だと別の環境変数を設定しておく感じになりそう
+const MODEL_REGION = process.env.MODEL_REGION;
+
+export const handler = async () // _event: lambda.APIGatewayProxyEvent
+: Promise<lambda.APIGatewayProxyResult> => {
+  try {
+    // リージョンを指定してS3クライアントを初期化
+    const s3Client = new S3Client({
+      region: MODEL_REGION, // リージョンを指定
+    });
+
+    const command = new ListObjectsV2Command({
+      Bucket: DATA_SOURCE_BUCKET_NAME,
+      Delimiter: '/',
+      Prefix: 'docs/',
+    });
+
+    const response = await s3Client.send(command);
+
+    const prefixes =
+      response.CommonPrefixes?.map((prefix) => prefix.Prefix) || [];
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        prefixes: prefixes,
+      }),
+    };
+  } catch (error) {
+    console.error('Error:', error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        message: 'Error listing prefixes',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lambda/retrieveKnowledgeBase.ts
+++ b/packages/cdk/lambda/retrieveKnowledgeBase.ts
@@ -5,14 +5,21 @@ import {
 } from '@aws-sdk/client-bedrock-agent-runtime';
 import { RetrieveKnowledgeBaseRequest } from 'generative-ai-use-cases-jp';
 
+const DATA_SOURCE_BUCKET_NAME = process.env.DATA_SOURCE_BUCKET_NAME!;
 const KNOWLEDGE_BASE_ID = process.env.KNOWLEDGE_BASE_ID;
 const MODEL_REGION = process.env.MODEL_REGION;
 
 exports.handler = async (
   event: lambda.APIGatewayProxyEvent
 ): Promise<lambda.APIGatewayProxyResult> => {
+  // [変更点1] リクエストからs3datasourceも取り出すように変更
   const req = JSON.parse(event.body!) as RetrieveKnowledgeBaseRequest;
-  const query = req.query;
+  const { query, s3datasource } = req;
+
+  // プレフィックスがある場合、S3 URI形式に変換
+  const s3datasourceUri = s3datasource
+    ? `s3://${DATA_SOURCE_BUCKET_NAME}/${s3datasource}`
+    : undefined;
 
   if (!query) {
     return {
@@ -28,6 +35,8 @@ exports.handler = async (
   const kb = new BedrockAgentRuntimeClient({
     region: MODEL_REGION,
   });
+
+  // [変更点2] RetrieveCommandの設定を変更
   const retrieveCommand = new RetrieveCommand({
     knowledgeBaseId: KNOWLEDGE_BASE_ID,
     retrievalQuery: {
@@ -37,6 +46,16 @@ exports.handler = async (
       vectorSearchConfiguration: {
         numberOfResults: 10,
         overrideSearchType: 'HYBRID',
+        ...(s3datasource && {
+          filter: {
+            startsWith: {
+              // x-amz-bedrock-kb-source-uriは、Knowledge Base内のドキュメントのS3パスを示すメタデータ
+              key: 'x-amz-bedrock-kb-source-uri',
+              // 指定されたS3パスで始まるドキュメントのみを検索対象とする
+              value: s3datasourceUri,
+            },
+          },
+        }),
       },
     },
   });

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.137",
-    "@types/node": "^20.12.5",
+    "@types/node": "^20.17.6",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
     "aws-cdk": "^2.154.1",

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -116,6 +116,7 @@ export type RetrieveKendraResponse = RetrieveCommandOutput;
 
 export type RetrieveKnowledgeBaseRequest = {
   query: string;
+  s3datasource?: string;
 };
 
 export type RetrieveKnowledgeBaseResponse = RetrieveCommandOutputKnowledgeBase;

--- a/packages/web/src/components/Select.tsx
+++ b/packages/web/src/components/Select.tsx
@@ -18,6 +18,10 @@ type Props = RowItemProps & {
 
 const Select: React.FC<Props> = (props) => {
   const selectedLabel = useMemo(() => {
+    if (props.value === '') {
+      return props.options.find((o) => o.value === '')?.label || '';
+    }
+    return props.options.find((o) => o.value === props.value)?.label || '';
     return props.value === ''
       ? ''
       : props.options.filter((o) => o.value === props.value)[0].label;

--- a/packages/web/src/hooks/useKnowledgeBasePrefixes.ts
+++ b/packages/web/src/hooks/useKnowledgeBasePrefixes.ts
@@ -1,0 +1,18 @@
+import useHttp from './useHttp';
+
+type PrefixesResponse = {
+  prefixes: string[];
+};
+
+export const useKnowledgeBasePrefixes = () => {
+  const http = useHttp();
+  const { data, error } = http.get<PrefixesResponse>(
+    '/rag-knowledge-base/prefixes'
+  );
+
+  return {
+    prefixes: data?.prefixes ?? [], // データがない場合は空配列を返す
+    loading: !error && !data, // データ取得中の状態
+    error: error, // エラーがあれば返す
+  };
+};

--- a/packages/web/src/hooks/useRagKnowledgeBase.ts
+++ b/packages/web/src/hooks/useRagKnowledgeBase.ts
@@ -49,7 +49,7 @@ const useRagKnowledgeBase = (id: string) => {
     messages,
     postChat,
     clear,
-    postMessage: async (content: string) => {
+    postMessage: async (content: string, s3datasource?: string) => {
       setLoading(true);
 
       const modelRegion = import.meta.env.VITE_APP_MODEL_REGION!;
@@ -63,7 +63,7 @@ const useRagKnowledgeBase = (id: string) => {
       let retrievedItems = null;
 
       try {
-        retrievedItems = await retrieve(content);
+        retrievedItems = await retrieve(content, s3datasource);
       } catch (e) {
         console.error(e);
         popMessage();

--- a/packages/web/src/hooks/useRagKnowledgeBaseApi.ts
+++ b/packages/web/src/hooks/useRagKnowledgeBaseApi.ts
@@ -7,12 +7,13 @@ import useHttp from './useHttp';
 const useRagKnowledgeBaseApi = () => {
   const http = useHttp();
   return {
-    retrieve: (query: string) => {
+    retrieve: (query: string, s3datasource?: string) => {
       return http.post<
         RetrieveKnowledgeBaseResponse,
         RetrieveKnowledgeBaseRequest
       >('/rag-knowledge-base/retrieve', {
         query,
+        s3datasource, // s3datasource パラメータを追加
       });
     },
   };


### PR DESCRIPTION
## 変更内容の説明
変更内容を詳細に説明して下さい。
既存ユーザーへの影響がある場合 (互換性・デグレ・破壊的変更など) は必ず説明に含めてください。

変更は以下
- Rag Knowledge Base ユースケースにおいて、S3上のプレフィックスごとに検索対象を選択できる機能を追加
- メタデータフィルタリング（key:x-amz-bedrock-kb-source-uri）を使用して検索対象を絞り込み

既存ユーザーでRagKnowledgeBaseユースケース有効化している場合に影響あり
- lambda関数のAPIを1つ修正、1つ追加
- 画面上フォルダを選択のドロップダウンリストを追加

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
関連する Issue を可能な限り挙げてください。

（初プルリクなので変なことしてたらすみません…）