### PR TITLE
Add page number for knowledge base response

### DIFF
--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -18,7 +18,9 @@ const uniqueKeyOfItem = (item: RetrieveResultItem): string => {
   return `${uri}_${pageNumber}`;
 };
 
-const arrangeItems = (items: RetrieveResultItem[]): RetrieveResultItem[] => {
+export const arrangeItems = (
+  items: RetrieveResultItem[]
+): RetrieveResultItem[] => {
   const res: Record<string, RetrieveResultItem> = {};
 
   for (const item of items) {

--- a/packages/web/src/hooks/useRagKnowledgeBase.ts
+++ b/packages/web/src/hooks/useRagKnowledgeBase.ts
@@ -5,6 +5,7 @@ import { getPrompter } from '../prompts';
 import { RetrieveResultItem } from '@aws-sdk/client-kendra';
 import { ShownMessage } from 'generative-ai-use-cases-jp';
 import { cleanEncode } from '../utils/URLUtils';
+import { arrangeItems } from './useRag';
 
 // s3://<BUCKET>/<PREFIX> から https://s3.<REGION>.amazonaws.com/<BUCKET>/<PREFIX> に変換する
 const convertS3UriToUrl = (s3Uri: string, region: string): string => {
@@ -117,11 +118,12 @@ const useRagKnowledgeBase = (id: string) => {
               : [],
           };
         });
+      const items = arrangeItems(retrievedItemsKendraFormat);
 
       updateSystemContext(
         prompter.ragPrompt({
           promptType: 'SYSTEM_CONTEXT',
-          referenceItems: retrievedItemsKendraFormat,
+          referenceItems: items,
         })
       );
 
@@ -139,7 +141,7 @@ const useRagKnowledgeBase = (id: string) => {
         },
         (message: string) => {
           // 後処理：Footnote の付与
-          const footnote = retrievedItemsKendraFormat
+          const footnote = items
             .map((item, idx) => {
               // 参考にしたページ番号がある場合は、アンカーリンクとして設定する
               const _excerpt_page_number = item.DocumentAttributes?.find(


### PR DESCRIPTION
## 変更内容の説明

- Knowledge Base のレスポンスにページ番号が含まれる場合、footnote に追加する処理を実装
  - 参考: https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-config.html

## チェック項目
- [x] npm run lint を実行した
- [ ] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
- https://github.com/aws-samples/generative-ai-use-cases-jp/issues/543