### PR TITLE
ユースケースビルダーヘルプのサンプル可変項目のスペースを削除

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
@@ -70,7 +70,7 @@ const UseCaseBuilderHelp: React.FC<Props> = (props) => {
           <div className="mt-1 text-sm">
             プロンプトテンプレート内に、
             <span className="rounded bg-gray-200 px-2 py-0.5 font-light">
-              {'{{ text: 見出し }}'}
+              {'{{text:見出し}}'}
             </span>
             の形式で入力してください。「見出し」は画面上に表示される入力項目のラベルとなります。
           </div>


### PR DESCRIPTION
## 変更内容の説明
ユースケース新規作成/編集画面のヘルプに表示される、サンプルの可変項目のスペースを削除しました。
スペースなしが適切かと思っております。
ご確認のほどよろしくお願いいたします。

## チェック項目
- [ x] npm run lint を実行した
- [ ] 関連するドキュメントを修正した
- [ x] 手元の環境で動作確認済み

## 関連する Issue
N/A
