### PR TITLE
add description to my usecases list

### DIFF
--- a/packages/web/src/pages/useCaseBuilder/UseCaseBuilderMyUseCasePage.tsx
+++ b/packages/web/src/pages/useCaseBuilder/UseCaseBuilderMyUseCasePage.tsx
@@ -107,15 +107,18 @@ const UseCaseBuilderMyUseCasePage: React.FC = () => {
                 key={useCase.useCaseId}
                 className={`flex flex-row items-center gap-x-2 p-2 last:border-b hover:bg-gray-100 ${idx > 0 ? 'border-t' : ''}`}>
                 <div
-                  className="flex flex-1 cursor-pointer items-center"
+                  className="flex flex-1 cursor-pointer flex-col justify-start"
                   onClick={() => {
                     navigate(
                       `${ROUTE_INDEX_USE_CASE_BUILDER}/execute/${useCase.useCaseId}`
                     );
                   }}>
-                  <span className="line-clamp-1 text-sm font-bold">
+                  <div className="line-clamp-1 text-sm font-bold">
                     {useCase.title}
-                  </span>
+                  </div>
+                  <div className="line-clamp-1 text-xs font-light text-gray-400">
+                    {useCase.description}
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <ButtonFavorite


### PR DESCRIPTION
## 変更内容の説明
ビルダーモードの「マイユースケース」にユースケースの概要が表示されるようにしました。
<img width="1190" alt="image" src="https://github.com/user-attachments/assets/3f859602-6d34-4b4a-97b1-667df4a5f82f">


## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
#738 (概要のみ対応)
