### PR TITLE
[ユースケースビルダー] モデルの固定化

### DIFF
--- a/packages/cdk/lambda/useCaseBuilder/useCaseBuilderRepository.ts
+++ b/packages/cdk/lambda/useCaseBuilder/useCaseBuilderRepository.ts
@@ -156,6 +156,7 @@ export const createUseCase = async (
     description: content.description,
     promptTemplate: content.promptTemplate,
     inputExamples: content.inputExamples,
+    fixedModelId: content.fixedModelId,
     isShared: false,
   };
 
@@ -257,12 +258,13 @@ export const updateUseCase = async (
         dataType: useCaseInTable.dataType,
       },
       UpdateExpression:
-        'set title = :title, promptTemplate = :promptTemplate, description = :description, inputExamples = :inputExamples',
+        'set title = :title, promptTemplate = :promptTemplate, description = :description, inputExamples = :inputExamples, fixedModelId = :fixedModelId',
       ExpressionAttributeValues: {
         ':title': content.title,
         ':promptTemplate': content.promptTemplate,
         ':description': content.description ?? '',
         ':inputExamples': content.inputExamples ?? [],
+        ':fixedModelId': content.fixedModelId ?? '',
       },
     })
   );

--- a/packages/types/src/useCaseBuilder.d.ts
+++ b/packages/types/src/useCaseBuilder.d.ts
@@ -18,6 +18,7 @@ export type UseCaseContent = {
   description?: string;
   promptTemplate: string;
   inputExamples?: UseCaseInputExample[];
+  fixedModelId?: string;
 };
 
 // Table に記録されている内容

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -221,7 +221,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
         <div className="pb-4 text-sm text-gray-600">{props.description}</div>
       )}
 
-      {props.fixedModelId === '' && (
+      {!props.isLoading && props.fixedModelId === '' && (
         <div className="mb-2 flex w-full flex-col justify-between sm:flex-row">
           <Select
             value={modelId}

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -28,6 +28,7 @@ type Props = {
   promptTemplate: string;
   description?: string;
   inputExamples?: UseCaseInputExample[];
+  fixedModelId: string;
   isLoading?: boolean;
 } & (
   | {
@@ -93,7 +94,13 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
     postChat,
     clear: clearChat,
   } = useChat(pathname);
-  const modelId = getModelId();
+  const modelId = useMemo(() => {
+    if (props.fixedModelId !== '') {
+      return props.fixedModelId;
+    } else {
+      return getModelId();
+    }
+  }, [getModelId, props.fixedModelId]);
   const { modelIds: availableModels } = MODELS;
   const { setTypingTextInput, typingTextOutput } = useTyping(loading);
   const { updateRecentUseUseCase } = useMyUseCases();
@@ -214,15 +221,18 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
         <div className="pb-4 text-sm text-gray-600">{props.description}</div>
       )}
 
-      <div className="mb-2 flex w-full flex-col justify-between sm:flex-row">
-        <Select
-          value={modelId}
-          onChange={setModelId}
-          options={availableModels.map((m) => {
-            return { value: m, label: m };
-          })}
-        />
-      </div>
+      {props.fixedModelId === '' && (
+        <div className="mb-2 flex w-full flex-col justify-between sm:flex-row">
+          <Select
+            value={modelId}
+            onChange={setModelId}
+            options={availableModels.map((m) => {
+              return { value: m, label: m };
+            })}
+          />
+        </div>
+      )}
+
       {props.isLoading && (
         <div className="my-3 flex flex-col gap-3">
           <Skeleton className="h-28" />

--- a/packages/web/src/hooks/useCaseBuilder/useMyUseCases.ts
+++ b/packages/web/src/hooks/useCaseBuilder/useMyUseCases.ts
@@ -50,6 +50,7 @@ const useMyUseCases = () => {
       promptTemplate: string;
       description?: string;
       inputExamples?: UseCaseInputExample[];
+      fixedModelId?: string;
     }) => {
       return createUseCase(params).finally(() => {
         mutateMyUseCases();
@@ -61,6 +62,7 @@ const useMyUseCases = () => {
       promptTemplate: string;
       description?: string;
       inputExamples?: UseCaseInputExample[];
+      fixedModelId?: string;
     }) => {
       // 一覧の更新
       const index = findIndex(params.useCaseId);
@@ -80,6 +82,7 @@ const useMyUseCases = () => {
         promptTemplate: params.promptTemplate,
         description: params.description,
         inputExamples: params.inputExamples,
+        fixedModelId: params.fixedModelId,
       }).finally(() => {
         mutateMyUseCases();
         mutateFavoriteUseCases();

--- a/packages/web/src/pages/useCaseBuilder/UseCaseBuilderExecutePage.tsx
+++ b/packages/web/src/pages/useCaseBuilder/UseCaseBuilderExecutePage.tsx
@@ -108,6 +108,7 @@ const UseCaseBuilderExecutePage: React.FC = () => {
               promptTemplate={useCase?.promptTemplate ?? ''}
               description={useCase?.description}
               inputExamples={useCase?.inputExamples}
+              fixedModelId={useCase?.fixedModelId ?? ''}
               isShared={useCase?.isShared ?? false}
               isFavorite={useCase?.isFavorite ?? false}
               useCaseId={useCaseId ?? ''}

--- a/packages/web/src/pages/useCaseBuilder/UseCaseBuilderMyUseCasePage.tsx
+++ b/packages/web/src/pages/useCaseBuilder/UseCaseBuilderMyUseCasePage.tsx
@@ -105,7 +105,7 @@ const UseCaseBuilderMyUseCasePage: React.FC = () => {
             return (
               <div
                 key={useCase.useCaseId}
-                className={`flex flex-row items-center gap-x-2 p-2 last:border-b hover:bg-gray-100 ${idx > 0 ? 'border-t' : ''}`}>
+                className={`flex flex-row items-center gap-x-2 p-2 hover:bg-gray-100 ${idx > 0 ? 'border-t' : ''}`}>
                 <div
                   className="flex flex-1 cursor-pointer flex-col justify-start"
                   onClick={() => {


### PR DESCRIPTION
## 変更内容の説明
ユースケースビルダーの利用者目線では、モデルの選択が必要ないケースが多い。
むしろ隠すことで、利用する際の心理的障壁を取り除く意図がある。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/751
