### PR TITLE
Add Nova Cross Region Model IDs

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -476,6 +476,9 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
 "amazon.nova-pro-v1:0",
 "amazon.nova-lite-v1:0",
 "amazon.nova-micro-v1:0"
+"us.amazon.nova-pro-v1:0",
+"us.amazon.nova-lite-v1:0",
+"us.amazon.nova-micro-v1:0"
 ```
 
 
@@ -562,7 +565,11 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
     "us.amazon.nova-micro-v1:0",
     "cohere.command-r-plus-v1:0",
     "cohere.command-r-v1:0",
-    "mistral.mistral-large-2407-v1:0"
+    "mistral.mistral-large-2407-v1:0",
+    "us.amazon.nova-pro-v1:0",
+    "us.amazon.nova-lite-v1:0",
+    "us.amazon.nova-micro-v1:0"
+
   ],
   "imageGenerationModelIds": [
     "amazon.titan-image-generator-v2:0",

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -557,6 +557,9 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
     "us.meta.llama3-2-11b-instruct-v1:0",
     "us.meta.llama3-2-3b-instruct-v1:0",
     "us.meta.llama3-2-1b-instruct-v1:0",
+    "us.amazon.nova-pro-v1:0",
+    "us.amazon.nova-lite-v1:0",
+    "us.amazon.nova-micro-v1:0",
     "cohere.command-r-plus-v1:0",
     "cohere.command-r-v1:0",
     "mistral.mistral-large-2407-v1:0"

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -475,7 +475,7 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
 "mistral.mistral-7b-instruct-v0:2",
 "amazon.nova-pro-v1:0",
 "amazon.nova-lite-v1:0",
-"amazon.nova-micro-v1:0"
+"amazon.nova-micro-v1:0",
 "us.amazon.nova-pro-v1:0",
 "us.amazon.nova-lite-v1:0",
 "us.amazon.nova-micro-v1:0"

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -569,7 +569,6 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
     "us.amazon.nova-pro-v1:0",
     "us.amazon.nova-lite-v1:0",
     "us.amazon.nova-micro-v1:0"
-
   ],
   "imageGenerationModelIds": [
     "amazon.titan-image-generator-v2:0",

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -917,6 +917,30 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseOutputText: extractConverseOutputText,
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
+  'us.amazon.nova-pro-v1:0': {
+    defaultParams: NOVA_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutputText: extractConverseOutputText,
+    extractConverseStreamOutputText: extractConverseStreamOutputText,
+  },
+  'us.amazon.nova-lite-v1:0': {
+    defaultParams: NOVA_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutputText: extractConverseOutputText,
+    extractConverseStreamOutputText: extractConverseStreamOutputText,
+  },
+  'us.amazon.nova-micro-v1:0': {
+    defaultParams: NOVA_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutputText: extractConverseOutputText,
+    extractConverseStreamOutputText: extractConverseStreamOutputText,
+  },
 };
 
 // 画像生成に関する、各のModel のパラメーターや関数の定義

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -121,6 +121,9 @@ export class Api extends Construct {
       'amazon.nova-pro-v1:0',
       'amazon.nova-lite-v1:0',
       'amazon.nova-micro-v1:0',
+      'us.amazon.nova-pro-v1:0',
+      'us.amazon.nova-lite-v1:0',
+      'us.amazon.nova-micro-v1:0',
     ];
     const multiModalModelIds = [
       'anthropic.claude-3-5-sonnet-20241022-v2:0',
@@ -143,6 +146,8 @@ export class Api extends Construct {
       'us.meta.llama3-2-90b-instruct-v1:0',
       'amazon.nova-pro-v1:0',
       'amazon.nova-lite-v1:0',
+      'us.amazon.nova-pro-v1:0',
+      'us.amazon.nova-lite-v1:0',
     ];
     for (const modelId of modelIds) {
       if (!supportedModelIds.includes(modelId)) {


### PR DESCRIPTION
## 変更内容の説明
Novaのクロスリージョン推論用のモデルIDを追加しました
    "us.amazon.nova-pro-v1:0",
    "us.amazon.nova-lite-v1:0",
    "us.amazon.nova-micro-v1:0",

## チェック項目
- [x ] npm run lint を実行した
- [x ] 関連するドキュメントを修正した
- [x ] 手元の環境で動作確認済み

