### PR TITLE
[ユースケースビルダー] Amazon Kendra と Knowledge Base の Retrieve に対応 (埋め込みのみバージョン)

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
@@ -21,11 +21,12 @@ const PromptSample: React.FC<PromptSampleProps> = (props) => {
         <PiCaretUp className={`${isOpen ? 'rotate-180' : ''} transition-all`} />
       </div>
       {isOpen && (
-        <pre className="m-2 mt-1 whitespace-pre-wrap break-words rounded bg-gray-100 p-1 text-sm">
+        <pre className="relative m-2 mt-1 whitespace-pre-wrap break-words rounded bg-gray-100 p-1 text-sm">
           {props.prompt}
-          <div className="flex w-full justify-end">
-            <ButtonCopy text={props.prompt} className="" />
-          </div>
+          <ButtonCopy
+            text={props.prompt}
+            className="absolute bottom-2 right-2"
+          />
         </pre>
       )}
     </div>
@@ -50,76 +51,28 @@ const UseCaseBuilderHelp: React.FC<Props> = (props) => {
 
       <div className="flex flex-col gap-4">
         <div>
-          <div className="text-lg font-bold">プロンプトテンプレートとは?</div>
+          <div className="text-lg font-bold">
+            プロンプトテンプレートについて
+          </div>
           <div className="mt-1 text-sm">
-            生成AIに指示を出すための「ひな形」のようなものです。目的に応じて、あらかじめ指示文の型を用意しておくことができます。
+            ユースケースごとに、プロンプトテンプレートを定義することができます。ユースケースを実行すると、ここで定義したプロンプトテンプレートをもとに、生成
+            AI が推論を行います。
           </div>
         </div>
         <div>
-          <div className="text-lg font-bold">可変項目</div>
+          <div className="text-lg font-bold">可変項目の設定</div>
           <div className="mt-1 text-sm">
-            プロンプトテンプレートの中に「後から内容を入れられる場所」（可変項目）を作れます。例えるなら、穴埋め問題の空欄のようなものです。
-            可変項目を定義すると、自動的に入力用の欄が画面に表示されます。
-            また、入力された内容が実行時にテンプレート内の該当箇所に自動で入ります。
+            プロンプトテンプレートの中には、可変項目を設定することができます。この可変項目を設定すると、自動的に画面上に入力欄が配置されます。ユースケースを実行すると、プロンプトテンプレート内の可変項目が対応する画面の入力値で置換されます。
           </div>
         </div>
         <div>
           <div className="text-base font-bold">可変項目の設定方法</div>
           <div className="mt-1 text-sm">
-            プロンプトテンプレート内に以下の形式で記述します。
-            <br />
-            <span className="rounded bg-gray-200 px-1 py-0.5 font-light">
-              {'{{入力タイプ:見出し}}'}
-            </span>
-            <br />
-            ※「見出し」は入力欄のラベルとなります（省略可）
-          </div>
-        </div>
-        <div>
-          <div className="text-base font-bold">可変項目一覧</div>
-          <div className="mt-3 text-sm">
-            <div className="mb-1 w-fit rounded bg-gray-200 px-1 py-0.5 font-light">
+            プロンプトテンプレート内に、
+            <span className="rounded bg-gray-200 px-2 py-0.5 font-light">
               {'{{text:見出し}}'}
-            </div>
-            自由入力を受け付けます。入力された内容をそのまま可変項目が定義された場所に埋め込みます。
-          </div>
-          <div className="mt-3 text-sm">
-            <div className="mb-1 w-fit rounded bg-gray-200 px-1 py-0.5 font-light">
-              {'{{retrieveKendra:見出し}}'}
-            </div>
-            Amazon Kendra から Retrieve
-            した結果を可変項目が定義された場所に埋め込みます。Retrieve
-            した結果は Amazon Kendra の Retrieve API の
-            <a
-              href="https://docs.aws.amazon.com/kendra/latest/APIReference/API_Retrieve.html#kendra-Retrieve-response-ResultItems"
-              className="text-aws-smile"
-              target="_blank">
-              ResultItems を JSON にした文字列
-            </a>
-            です。
-            <span className="font-bold">
-              この機能を利用するためには、GenU で RAG チャット (Amazon Kendra)
-              が有効になっている必要があります。
             </span>
-          </div>
-          <div className="mt-3 text-sm">
-            <div className="mb-1 w-fit rounded bg-gray-200 px-1 py-0.5 font-light">
-              {'{{retrieveKnowledgeBase:見出し}}'}
-            </div>
-            Knowledge Base から Retrieve
-            した結果を可変項目が定義された場所に埋め込みます。Retrieve
-            した結果は Knowledge Base の Retrieve API の
-            <a
-              href="https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_Retrieve.html#API_agent-runtime_Retrieve_ResponseSyntax"
-              className="text-aws-smile"
-              target="_blank">
-              retrievalResults を JSON にした文字列
-            </a>
-            です。
-            <span className="font-bold">
-              この機能を利用するためには、GenU で RAG チャット (Knowledge Base)
-              が有効になっている必要があります。
-            </span>
+            の形式で入力してください。「見出し」は画面上に表示される入力項目のラベルとなります。
           </div>
         </div>
         <div>
@@ -159,20 +112,6 @@ const UseCaseBuilderHelp: React.FC<Props> = (props) => {
 <構築したいシステムの構成>
 {{text:CDK で生成したい構成の概要}}
 </構築したいシステムの構成>`}
-            />
-            <PromptSample
-              title="Knowledge Base を利用した基本的な RAG"
-              prompt={`あなたはユーザーの質問に答える AI アシスタントです。
-ユーザーの質問と取得した情報を与えるので、情報を元に質問に答えてください。
-必ず与えられた情報のみを参照してください。既成事実や憶測で答えてはいけません。
-
-<質問>
-{{text:質問}}
-</質問>
-
-<情報>
-{{retrieveKnowledgeBase:検索クエリ}}
-</情報>`}
             />
           </div>
         </div>

--- a/packages/web/src/utils/UseCaseBuilderUtils.ts
+++ b/packages/web/src/utils/UseCaseBuilderUtils.ts
@@ -2,11 +2,18 @@
 // 空文字だと DynamoDB に inputExample を挿入した際にエラーになる
 export const NOLABEL = 'NOLABEL';
 
-const SUPPORTED_TYPES: string[] = [
+export type BuilderItem = {
+  inputType: string;
+  label: string;
+};
+
+export const SUPPORTED_TYPES: string[] = [
   'text',
   'retrieveKendra',
   'retrieveKnowledgeBase',
 ];
+
+export const TEXT_FORM_TYPES: string[] = ['text'];
 
 export const extractPlaceholdersFromPromptTemplate = (
   promptTemplate: string
@@ -14,7 +21,9 @@ export const extractPlaceholdersFromPromptTemplate = (
   return promptTemplate.match(/\{\{[^}]*\}\}/g) ?? [];
 };
 
-export const getItemsFromPlaceholders = (placeholders: string[]) => {
+export const getItemsFromPlaceholders = (
+  placeholders: string[]
+): BuilderItem[] => {
   return (
     placeholders
       .map((match) => {
@@ -39,4 +48,10 @@ export const getItemsFromPlaceholders = (placeholders: string[]) => {
           ) === idx
       ) ?? []
   );
+};
+
+export const getTextFormItemsFromItems = (
+  items: BuilderItem[]
+): BuilderItem[] => {
+  return items.filter((i) => TEXT_FORM_TYPES.includes(i.inputType));
 };


### PR DESCRIPTION
## 変更内容の説明
`retrieve*` だけでは入力フォームはできず、`{{text}}` とセットで使うパターン

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した => Help を元に戻しました
- [x] 手元の環境で動作確認済み

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/733
