### PR TITLE
[ユースケースビルダー] Help の改善

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import ButtonIcon from '../ButtonIcon';
-import { PiCaretRight, PiCaretUp } from 'react-icons/pi';
+import { PiCaretUp } from 'react-icons/pi';
 import ButtonCopy from '../ButtonCopy';
 
 type PromptSampleProps = {
@@ -11,78 +10,81 @@ const PromptSample: React.FC<PromptSampleProps> = (props) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="rounded border">
+    <div className="mt-3 rounded border border-gray-400">
       <div
-        className="flex cursor-pointer items-center justify-between p-2 px-3 font-bold hover:bg-gray-200"
+        className="flex cursor-pointer items-center justify-between bg-gray-400 px-2 py-1 text-sm text-white hover:opacity-80"
         onClick={() => {
           setIsOpen(!isOpen);
         }}>
-        {props.title}
+        例: {props.title}
         <PiCaretUp className={`${isOpen ? 'rotate-180' : ''} transition-all`} />
       </div>
       {isOpen && (
-        <pre className="relative m-2 mt-1 whitespace-pre-wrap break-words rounded bg-gray-100 p-1 text-sm">
+        <pre className="whitespace-pre-wrap break-words bg-gray-100 p-3 text-sm">
           {props.prompt}
-          <ButtonCopy
-            text={props.prompt}
-            className="absolute bottom-2 right-2"
-          />
+          <div className="flex w-full justify-end">
+            <ButtonCopy text={props.prompt} />
+          </div>
         </pre>
       )}
     </div>
   );
 };
 
-type Props = {
-  isOpen: boolean;
-  onClose: () => void;
+const Placeholder: React.FC<{ inputType: string; label?: string }> = (
+  props
+) => {
+  return (
+    <span className="rounded bg-gray-200 px-1 py-0.5">
+      {`{{${props.inputType}${props.label ? ':' + props.label : ''}}}`}
+    </span>
+  );
 };
 
-const UseCaseBuilderHelp: React.FC<Props> = (props) => {
+const UseCaseBuilderHelp: React.FC<{}> = () => {
   return (
-    <div
-      className={`${props.isOpen ? 'right-0' : '-right-96'} fixed top-0 z-[9999999] h-screen w-96 overflow-y-auto border-l bg-white px-6 py-3 shadow transition-all`}>
-      <div className="mb-6 flex justify-between p-1 text-xl font-bold">
-        <div>ヘルプ</div>
-        <ButtonIcon onClick={props.onClose}>
-          <PiCaretRight />
-        </ButtonIcon>
+    <div className="flex flex-col gap-y-8 py-4">
+      <div className="flex flex-col gap-y-4">
+        <div className="text-lg font-bold">プロンプトテンプレートとは？</div>
+        <div className="text-sm leading-relaxed">
+          生成 AI
+          に指示を出すための「ひな形」のようなものです。目的に応じて、あらかじめ指示文の型を用意しておくことができます。
+          プロンプトテンプレートには実行時にテキストを埋め込むための placeholder
+          が定義できます。
+        </div>
       </div>
 
-      <div className="flex flex-col gap-4">
-        <div>
-          <div className="text-lg font-bold">
-            プロンプトテンプレートについて
-          </div>
-          <div className="mt-1 text-sm">
-            ユースケースごとに、プロンプトテンプレートを定義することができます。ユースケースを実行すると、ここで定義したプロンプトテンプレートをもとに、生成
-            AI が推論を行います。
-          </div>
+      <div className="flex flex-col gap-y-4">
+        <div className="text-lg font-bold">Placeholder</div>
+        <div className="text-sm leading-relaxed">
+          Placeholder は <Placeholder inputType="入力タイプ" label="ラベル" />{' '}
+          のように書きます。 ラベルが識別子になるため、同一のラベルを持つ
+          placeholder は同じ入力であるとみなされます。 ラベルを省略して{' '}
+          <Placeholder inputType="入力タイプ" />{' '}
+          のように書くことも可能です。その場合、無ラベルの placeholder
+          は同じ入力であるとみなされます。 実際に実行されたプロンプトは GenU
+          の会話履歴から確認できます。
         </div>
-        <div>
-          <div className="text-lg font-bold">可変項目の設定</div>
-          <div className="mt-1 text-sm">
-            プロンプトテンプレートの中には、可変項目を設定することができます。この可変項目を設定すると、自動的に画面上に入力欄が配置されます。ユースケースを実行すると、プロンプトテンプレート内の可変項目が対応する画面の入力値で置換されます。
-          </div>
-        </div>
-        <div>
-          <div className="text-base font-bold">可変項目の設定方法</div>
-          <div className="mt-1 text-sm">
-            プロンプトテンプレート内に、
-            <span className="rounded bg-gray-200 px-2 py-0.5 font-light">
-              {'{{text:見出し}}'}
-            </span>
-            の形式で入力してください。「見出し」は画面上に表示される入力項目のラベルとなります。
-          </div>
-        </div>
-        <div>
-          <div className="text-lg font-bold">
-            プロンプトテンプレートサンプル
-          </div>
-          <div className="mt-1 flex flex-col gap-2">
-            <PromptSample
-              title="メール返信の例"
-              prompt={`あなたは、メール返信の担当者です。
+      </div>
+
+      <div className="flex flex-col gap-y-4">
+        <div className="text-lg font-bold">Placeholder 一覧</div>
+
+        <div className="flex flex-col gap-y-10">
+          <div className="flex flex-col gap-y-4">
+            <div className="text-base font-bold">
+              <Placeholder inputType="text" />
+            </div>
+            <div className="text-sm leading-relaxed">
+              <Placeholder inputType="text" /> は最も基本的な placeholder です。
+              <Placeholder inputType="text" /> あるいは{' '}
+              <Placeholder inputType="text" label="ラベル" />{' '}
+              のように記述します。
+              <Placeholder inputType="text" />{' '}
+              はテキスト入力を受け付けるフォームを作成し、入力した値をそのままプロンプトテンプレートに埋め込みます。
+              <PromptSample
+                title="メール返信の例"
+                prompt={`あなたは、メール返信の担当者です。
 以下のルールを守って、返信用のメールを作成してください。
 <ルール>
 - 取引先へのメールです。敬語を使う必要がありますが、関係構築ができているので、かしこまりすぎた文章である必要はありません。
@@ -95,24 +97,111 @@ const UseCaseBuilderHelp: React.FC<Props> = (props) => {
 <返信内容>
 {{text:返信内容}}
 </返信内容>`}
-            />
-            <PromptSample
-              title="CDK のコード出力"
-              prompt={`あなたはAWSの専門家で優秀な開発者でもあります。
-利用者から構築したいシステムの構成が示されます。
-あなたは、その内容をもとにAWS CDKのコードを生成してください。
-ただし、コード生成ルールは必ず守ってください。例外はありません。
+              />
+            </div>
+          </div>
 
-<コード生成ルール>
-- 利用者から指定されなかった場合、AWS CDKのTypeScriptでコードを作成してください。
-- 適度にコメントを入れて、わかりやすくしてください。
-- セキュリティ的に安全なコードを生成してください。
-</コード生成ルール>
+          <div className="flex flex-col gap-y-4">
+            <div className="text-base font-bold">
+              <Placeholder inputType="retrieveKendra" />
+            </div>
+            <div className="text-sm leading-relaxed">
+              <Placeholder inputType="retrieveKendra" /> は Amazon Kendra から
+              retrieve した結果をプロンプトテンプレートに埋め込みます。
+              <Placeholder inputType="retrieveKendra" /> あるいは{' '}
+              <Placeholder inputType="retrieveKendra" label="ラベル" />{' '}
+              のように記述します。
+              <Placeholder inputType="retrieveKendra" /> は
+              <span className="font-bold">
+                検索クエリを入力するための placeholder (
+                <Placeholder inputType="text" />) が別に必要
+              </span>
+              です。それらは同一ラベルである必要があります。
+              実際に埋め込まれる値は Amazon Kendra の Retrieve API の{' '}
+              <a
+                className="text-aws-smile"
+                href="https://docs.aws.amazon.com/kendra/latest/APIReference/API_Retrieve.html#API_Retrieve_ResponseSyntax"
+                target="_blank">
+                ResultItems を JSON にした文字列
+              </a>{' '}
+              です。 この機能を利用するためには、GenU で RAG チャット (Amazon
+              Kendra) が有効になっている必要があります。有効化の方法は{' '}
+              <a
+                className="text-aws-smile"
+                href="https://github.com/aws-samples/generative-ai-use-cases-jp/blob/main/docs/DEPLOY_OPTION.md#rag-%E3%83%81%E3%83%A3%E3%83%83%E3%83%88-amazon-kendra-%E3%83%A6%E3%83%BC%E3%82%B9%E3%82%B1%E3%83%BC%E3%82%B9%E3%81%AE%E6%9C%89%E5%8A%B9%E5%8C%96"
+                target="_blank">
+                こちら
+              </a>
+              。
+              <PromptSample
+                title="シンプルな RAG"
+                prompt={`あなたは、ユーザーの質問に答える AI アシスタントです。
+以下の情報を読み込んでください。
 
-<構築したいシステムの構成>
-{{text:CDK で生成したい構成の概要}}
-</構築したいシステムの構成>`}
-            />
+<情報>
+{{retrieveKendra:質問}}
+</情報>
+
+上の情報を参考に、以下の質問に答えてください。
+
+<質問>
+{{text:質問}}
+</質問>`}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-4">
+            <div className="text-base font-bold">
+              <Placeholder inputType="retrieveKnowledgeBase" />
+            </div>
+            <div className="text-sm leading-relaxed">
+              <Placeholder inputType="retrieveKnowledgeBase" /> は Knowledge
+              Base から retrieve
+              した結果をプロンプトテンプレートに埋め込みます。
+              <Placeholder inputType="retrieveKnowledgeBase" /> あるいは{' '}
+              <Placeholder inputType="retrieveKnowledgeBase" label="ラベル" />{' '}
+              のように記述します。
+              <Placeholder inputType="retrieveKnowledgeBase" /> は
+              <span className="font-bold">
+                検索クエリを入力するための placeholder (
+                <Placeholder inputType="text" />) が別に必要
+              </span>
+              です。それらは同一ラベルである必要があります。
+              実際に埋め込まれる値は Knowledge Base の Retrieve API の{' '}
+              <a
+                className="text-aws-smile"
+                href="https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_Retrieve.html#API_agent-runtime_Retrieve_ResponseSyntax"
+                target="_blank">
+                retrievalResults を JSON にした文字列
+              </a>{' '}
+              です。 この機能を利用するためには、GenU で RAG チャット (Knowledge
+              Base) が有効になっている必要があります。有効化の方法は{' '}
+              <a
+                className="text-aws-smile"
+                href="https://github.com/aws-samples/generative-ai-use-cases-jp/blob/main/docs/DEPLOY_OPTION.md#rag-%E3%83%81%E3%83%A3%E3%83%83%E3%83%88-knowledge-base-%E3%83%A6%E3%83%BC%E3%82%B9%E3%82%B1%E3%83%BC%E3%82%B9%E3%81%AE%E6%9C%89%E5%8A%B9%E5%8C%96"
+                target="_blank">
+                こちら
+              </a>
+              。
+              <PromptSample
+                title="社内ドキュメントでクイズを生成"
+                prompt={`あなたは、与えられた情報からクイズを生成する AI アシスタントです。
+以下の情報を読み込んでください。
+情報検索クエリはクイズを生成する上で不必要なので、無視してください。
+
+<情報検索クエリ>
+{{text:クイズの元になる情報を検索}}
+<情報検索クエリ>
+
+<情報>
+{{retrieveKnowledgeBase:クイズの元になる情報を検索}}
+</情報>
+
+上の情報を参考に、4 択クイズを生成してください。
+正解もセットで教えてください。`}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
@@ -41,7 +41,7 @@ const Placeholder: React.FC<{ inputType: string; label?: string }> = (
   );
 };
 
-const UseCaseBuilderHelp: React.FC<{}> = () => {
+const UseCaseBuilderHelp = () => {
   return (
     <div className="flex flex-col gap-y-8 py-4">
       <div className="flex flex-col gap-y-4">

--- a/packages/web/src/pages/useCaseBuilder/UseCaseBuilderEditPage.tsx
+++ b/packages/web/src/pages/useCaseBuilder/UseCaseBuilderEditPage.tsx
@@ -6,7 +6,7 @@ import { create } from 'zustand';
 import RowItem from '../../components/RowItem';
 import AppBuilderView from '../../components/useCaseBuilder/UseCaseBuilderView';
 import InputText from '../../components/InputText';
-import { PiPlus, PiQuestion, PiTrash } from 'react-icons/pi';
+import { PiPlus, PiQuestion, PiTrash, PiEye } from 'react-icons/pi';
 import useMyUseCases from '../../hooks/useCaseBuilder/useMyUseCases';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import useUseCase from '../../hooks/useCaseBuilder/useUseCase';
@@ -152,7 +152,7 @@ const UseCaseBuilderEditPage: React.FC = () => {
   const [isOpenDeleteDialog, setIsOpenDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isPosting, setIsPosting] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isPreview, setIsPreview] = useState(true);
 
   const { modelIds: availableModels } = MODELS;
 
@@ -320,13 +320,6 @@ const UseCaseBuilderEditPage: React.FC = () => {
         </div>
       )}
 
-      <UseCaseBuilderHelp
-        isOpen={isOpen}
-        onClose={() => {
-          setIsOpen(false);
-        }}
-      />
-
       <div className="grid h-screen grid-cols-12 gap-4 p-4">
         <div className="invisible col-span-12 my-0 flex h-0 items-center justify-center lg:visible lg:h-min print:visible print:h-min">
           <div className=" text-xl font-semibold">
@@ -336,15 +329,6 @@ const UseCaseBuilderEditPage: React.FC = () => {
 
         <div className="col-span-12 lg:col-span-6">
           <Card label="アプリの定義" className="relative">
-            <Button
-              outlined
-              className="absolute right-5 top-5 text-sm"
-              onClick={() => {
-                setIsOpen(!isOpen);
-              }}>
-              <PiQuestion className="mr-1" />
-              ヘルプ
-            </Button>
             <RowItem>
               <InputText
                 label="タイトル"
@@ -542,15 +526,40 @@ const UseCaseBuilderEditPage: React.FC = () => {
           </Card>
         </div>
         <div className="col-span-12 min-h-[calc(100vh-2rem)] lg:col-span-6">
-          <Card label="プレビュー">
-            <AppBuilderView
-              title={title}
-              promptTemplate={promptTemplate}
-              description={description}
-              inputExamples={inputExamples}
-              fixedModelId={fixedModelId}
-              previewMode
-            />
+          <Card
+            label={`${isPreview ? 'プレビュー' : 'ヘルプ'}`}
+            className="relative">
+            <div className="absolute right-3 top-3 flex rounded border text-xs font-bold">
+              <div
+                className={`my-1 ml-1 flex cursor-pointer items-center rounded px-2 py-1 ${isPreview ? 'bg-gray-600 text-white' : 'text-gray-600'}`}
+                onClick={() => {
+                  setIsPreview(true);
+                }}>
+                <PiEye className="mr-1 text-base" />
+                プレビュー
+              </div>
+              <div
+                className={`my-1 mr-1 flex cursor-pointer items-center rounded px-4 py-1.5 ${isPreview ? 'text-gray-600' : 'bg-gray-600 text-white'}`}
+                onClick={() => {
+                  setIsPreview(false);
+                }}>
+                <PiQuestion className="mr-1 text-base" />
+                ヘルプ
+              </div>
+            </div>
+
+            {isPreview ? (
+              <AppBuilderView
+                title={title}
+                promptTemplate={promptTemplate}
+                description={description}
+                inputExamples={inputExamples}
+                fixedModelId={fixedModelId}
+                previewMode
+              />
+            ) : (
+              <UseCaseBuilderHelp />
+            )}
           </Card>
         </div>
       </div>


### PR DESCRIPTION
## 変更内容の説明
`{{retrieveKendra}}` `{{retrieveKnowledgeBase}}` をサイレントリリースしたことに伴い、説明を体系化した。
Help を右から遷移させるような表示方法ではなく、プレビュー画面が置き換わるような実装に変更した。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/733
