### PR TITLE
RAGチャット2回目以降の文書不正対応 (#601)

### DIFF
--- a/packages/web/src/hooks/useRag.ts
+++ b/packages/web/src/hooks/useRag.ts
@@ -140,7 +140,10 @@ const useRag = (id: string) => {
           // 前処理：Few-shot で参考にされてしまうため、過去ログから footnote を削除
           return messages.map((message) => ({
             ...message,
-            content: message.content.replace(/\[\^(\d+)\]:.*/g, ''),
+            content: message.content
+              .replace(/\[\^0\]:[\s\S]*/s, '') // 文末の脚注を削除
+              .replace(/\[\^(\d+)\]/g, '') // 文中の脚注アンカーを削除
+              .trim(), // 前後の空白を削除
           }));
         },
         (message: string) => {

--- a/packages/web/src/hooks/useRagKnowledgeBase.ts
+++ b/packages/web/src/hooks/useRagKnowledgeBase.ts
@@ -136,7 +136,10 @@ const useRagKnowledgeBase = (id: string) => {
           // 前処理：Few-shot で参考にされてしまうため、過去ログから footnote を削除
           return messages.map((message) => ({
             ...message,
-            content: message.content.replace(/\[\^(\d+)\]:.*/g, ''),
+            content: message.content
+              .replace(/\[\^0\]:[\s\S]*/s, '') // 文末の脚注を削除
+              .replace(/\[\^(\d+)\]/g, '') // 文中の脚注アンカーを削除
+              .trim(), // 前後の空白を削除
           }));
         },
         (message: string) => {


### PR DESCRIPTION
## 変更内容の説明
RAGチャットにおいて、2回目以降の会話の根拠文書の紐づけがおかしくなることがある点を修正

### 原因
「前処理：Few-shot で参考にされてしまうため、過去ログから footnote を削除」とコメント記載のある処理において、
末尾の脚注（[^0] [^1] ...）のみが削除されており、footnate全体が除去されていないこと、
メッセージ本文の脚注アンカー部分（[^0] [^1] ...）が残っていることにより、
1回目の会話の脚注と、2回目以降の会話の脚注間で意図せぬ紐づきが発生していた

### 参考：2回目の会話における1回目のメッセージの内容
#### 処理前のメッセージ例
![1_除去前](https://github.com/user-attachments/assets/34cbda1f-14ee-458f-8da6-84ab1e97046f)
#### 処理後のメッセージ（不具合発生時）
**→ 末尾の脚注表記のみが削除されリンクが残っている／メッセージ本文の脚注アンカー部分（[^0] [^1] ...）が残っている**

![2_除去後_BEFORE](https://github.com/user-attachments/assets/2e75fb52-7b4a-4e85-8f2e-890fd8c19c25)
#### 処理後のメッセージ（改善）
**→footnate全体を削除**

![2_除去後_AFTER](https://github.com/user-attachments/assets/1a69e29c-b8a8-4d4b-b8b3-6ce7d796b3f4)

## チェック項目
- [ ✔] npm run lint を実行した
- [ ✔ ] 関連するドキュメントを修正した（対象なし）
- [ ✔ ] 手元の環境で動作確認済み

## 関連する Issue
#601 
