### PR TITLE
ファイル添付ボタンのクリック領域を調整

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -488,7 +488,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
 
           {props.fileUpload && (
             <div className="mb-3 flex flex-col">
-              <label>
+              <label className="w-fit">
                 <input
                   hidden
                   type="file"


### PR DESCRIPTION
## 変更内容の説明
label の width が full だったので cursor-pointer じゃない領域でもファイル添付が起動していました。
w-fit に修正しました。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
N/A
