### PR TITLE
複数スタックデプロイ時のリソース名の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ npm run cdk:deploy
   - [Kendraのインデックスを自動で作成・削除するスケジュールを設定する](/docs/DEPLOY_OPTION.md#Kendraを自動でオン・オフするスケジュールを設定する)
 - [モニタリング用のダッシュボードの有効化](/docs/DEPLOY_OPTION.md#モニタリング用のダッシュボードの有効化)
 - [別 AWS アカウントの Bedrock を利用したい場合](/docs/DEPLOY_OPTION.md#別-AWS-アカウントの-Bedrock-を利用したい場合)
+- [同一アカウントに複数環境デプロイする場合](/docs/DEPLOY_OPTION.md#同一アカウントに複数環境デプロイする場合)
 
 ## その他
  - [アップデート方法](/docs/UPDATE.md)

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -922,3 +922,33 @@ cdk.json 設定例
 ```
 
 設定変更後に `npm run cdk:deploy` を実行して変更内容を反映させます。
+
+## 同一アカウントに複数環境デプロイする場合
+
+同一アカウントで複数環境をデプロイする場合、異なる名前のスタックでデプロイする必要があります。
+
+`cdk.json` の `stage` を設定すると各スタックの Suffix として付与され別環境としてデプロイされます。
+
+cdk.json には以下の値を設定します。
+
+- `stage` ... ステージ名 (デフォルト: "" (空文字))
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+
+```json
+{
+  "context": {
+    "stage": "スタック名に付与される Suffix"
+  }
+}
+```
+
+cdk.json 設定例
+
+```json
+{
+  "context": {
+    "stage": "-dev"
+  }
+}
+```

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -927,18 +927,18 @@ cdk.json 設定例
 
 同一アカウントで複数環境をデプロイする場合、異なる名前のスタックでデプロイする必要があります。
 
-`cdk.json` の `stage` を設定すると各スタックの Suffix として付与され別環境としてデプロイされます。
+`cdk.json` の `env` を設定すると各スタックの Suffix として付与され別環境としてデプロイされます。
 
 cdk.json には以下の値を設定します。
 
-- `stage` ... ステージ名 (デフォルト: "" (空文字))
+- `env` ... 環境名 (デフォルト: "" (空文字))
 
 **[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
 
 ```json
 {
   "context": {
-    "stage": "スタック名に付与される Suffix"
+    "env": "スタック名に付与される Suffix"
   }
 }
 ```
@@ -948,7 +948,7 @@ cdk.json 設定例
 ```json
 {
   "context": {
-    "stage": "-dev"
+    "env": "-dev"
   }
 }
 ```

--- a/packages/cdk/bin/generative-ai-use-cases.ts
+++ b/packages/cdk/bin/generative-ai-use-cases.ts
@@ -21,9 +21,7 @@ class DeletionPolicySetter implements cdk.IAspect {
 
 const app = new cdk.App();
 
-const stage: string[] | null = app.node.tryGetContext(
-  'stage'
-) ?? "";
+const env: string[] | null = app.node.tryGetContext('env') ?? '';
 
 const allowedIpV4AddressRanges: string[] | null = app.node.tryGetContext(
   'allowedIpV4AddressRanges'
@@ -83,7 +81,7 @@ if (
   hostName
 ) {
   // WAF v2 は us-east-1 でのみデプロイ可能なため、Stack を分けている
-  cloudFrontWafStack = new CloudFrontWafStack(app, `CloudFrontWafStack${stage}`, {
+  cloudFrontWafStack = new CloudFrontWafStack(app, `CloudFrontWafStack${env}`, {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: 'us-east-1',
@@ -109,7 +107,7 @@ const modelRegion: string = app.node.tryGetContext('modelRegion')!;
 const ragKnowledgeBaseEnabled =
   app.node.tryGetContext('ragKnowledgeBaseEnabled') || false;
 const ragKnowledgeBaseStack = ragKnowledgeBaseEnabled
-  ? new RagKnowledgeBaseStack(app, `RagKnowledgeBaseStack${stage}`, {
+  ? new RagKnowledgeBaseStack(app, `RagKnowledgeBaseStack${env}`, {
       env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: modelRegion,
@@ -124,7 +122,7 @@ const searchAgentEnabled =
   app.node.tryGetContext('searchAgentEnabled') || false;
 const agentRegion = app.node.tryGetContext('agentRegion') || 'us-east-1';
 const searchAgentStack = searchAgentEnabled
-  ? new SearchAgentStack(app, `WebSearchAgentStack${stage}`, {
+  ? new SearchAgentStack(app, `WebSearchAgentStack${env}`, {
       env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: agentRegion,
@@ -136,7 +134,7 @@ const searchAgentStack = searchAgentEnabled
 const guardrailEnabled: boolean =
   app.node.tryGetContext('guardrailEnabled') || false;
 const guardrail = guardrailEnabled
-  ? new GuardrailStack(app, `GuardrailStack${stage}`, {
+  ? new GuardrailStack(app, `GuardrailStack${env}`, {
       env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: modelRegion,
@@ -149,7 +147,7 @@ const guardrail = guardrailEnabled
 
 const generativeAiUseCasesStack = new GenerativeAiUseCasesStack(
   app,
-  `GenerativeAiUseCasesStack${stage}`,
+  `GenerativeAiUseCasesStack${env}`,
   {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -183,7 +181,7 @@ cdk.Aspects.of(generativeAiUseCasesStack).add(
 const dashboard: boolean = app.node.tryGetContext('dashboard')!;
 
 if (dashboard) {
-  new DashboardStack(app, `GenerativeAiUseCasesDashboardStack${stage}`, {
+  new DashboardStack(app, `GenerativeAiUseCasesDashboardStack${env}`, {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: modelRegion,

--- a/packages/cdk/bin/generative-ai-use-cases.ts
+++ b/packages/cdk/bin/generative-ai-use-cases.ts
@@ -21,6 +21,10 @@ class DeletionPolicySetter implements cdk.IAspect {
 
 const app = new cdk.App();
 
+const stage: string[] | null = app.node.tryGetContext(
+  'stage'
+) ?? "";
+
 const allowedIpV4AddressRanges: string[] | null = app.node.tryGetContext(
   'allowedIpV4AddressRanges'
 )!;
@@ -79,7 +83,7 @@ if (
   hostName
 ) {
   // WAF v2 は us-east-1 でのみデプロイ可能なため、Stack を分けている
-  cloudFrontWafStack = new CloudFrontWafStack(app, 'CloudFrontWafStack', {
+  cloudFrontWafStack = new CloudFrontWafStack(app, `CloudFrontWafStack${stage}`, {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: 'us-east-1',
@@ -105,7 +109,7 @@ const modelRegion: string = app.node.tryGetContext('modelRegion')!;
 const ragKnowledgeBaseEnabled =
   app.node.tryGetContext('ragKnowledgeBaseEnabled') || false;
 const ragKnowledgeBaseStack = ragKnowledgeBaseEnabled
-  ? new RagKnowledgeBaseStack(app, 'RagKnowledgeBaseStack', {
+  ? new RagKnowledgeBaseStack(app, `RagKnowledgeBaseStack${stage}`, {
       env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: modelRegion,
@@ -120,7 +124,7 @@ const searchAgentEnabled =
   app.node.tryGetContext('searchAgentEnabled') || false;
 const agentRegion = app.node.tryGetContext('agentRegion') || 'us-east-1';
 const searchAgentStack = searchAgentEnabled
-  ? new SearchAgentStack(app, 'WebSearchAgentStack', {
+  ? new SearchAgentStack(app, `WebSearchAgentStack${stage}`, {
       env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: agentRegion,
@@ -132,7 +136,7 @@ const searchAgentStack = searchAgentEnabled
 const guardrailEnabled: boolean =
   app.node.tryGetContext('guardrailEnabled') || false;
 const guardrail = guardrailEnabled
-  ? new GuardrailStack(app, 'GuardrailStack', {
+  ? new GuardrailStack(app, `GuardrailStack${stage}`, {
       env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: modelRegion,
@@ -145,7 +149,7 @@ const guardrail = guardrailEnabled
 
 const generativeAiUseCasesStack = new GenerativeAiUseCasesStack(
   app,
-  'GenerativeAiUseCasesStack',
+  `GenerativeAiUseCasesStack${stage}`,
   {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
@@ -179,7 +183,7 @@ cdk.Aspects.of(generativeAiUseCasesStack).add(
 const dashboard: boolean = app.node.tryGetContext('dashboard')!;
 
 if (dashboard) {
-  new DashboardStack(app, 'GenerativeAiUseCasesDashboardStack', {
+  new DashboardStack(app, `GenerativeAiUseCasesDashboardStack${stage}`, {
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: modelRegion,

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -17,6 +17,7 @@
     ]
   },
   "context": {
+    "stage": "",
     "ragEnabled": false,
     "kendraIndexArn": null,
     "kendraDataSourceBucketName": null,

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -17,7 +17,7 @@
     ]
   },
   "context": {
-    "stage": "",
+    "env": "",
     "ragEnabled": false,
     "kendraIndexArn": null,
     "kendraDataSourceBucketName": null,

--- a/packages/cdk/lib/construct/agent.ts
+++ b/packages/cdk/lib/construct/agent.ts
@@ -1,4 +1,4 @@
-import { Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { Duration, Lazy, Names, RemovalPolicy } from 'aws-cdk-lib';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -23,6 +23,8 @@ export class Agent extends Construct {
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
+
+    const suffix = Lazy.string({ produce: () => Names.uniqueId(this) });
 
     // search api
     const searchApiKey = this.node.tryGetContext('searchApiKey') || '';
@@ -82,7 +84,7 @@ export class Agent extends Construct {
     });
 
     const searchAgent = new CfnAgent(this, 'SearchAgent', {
-      agentName: `SearchEngineAgent-${id}`,
+      agentName: `SearchEngineAgent-${suffix}`,
       actionGroups: [
         {
           actionGroupName: 'Search',
@@ -117,7 +119,7 @@ export class Agent extends Construct {
     });
 
     const codeInterpreterAgent = new CfnAgent(this, 'CodeInterpreterAgent', {
-      agentName: `CodeInterpreterAgent-${id}`,
+      agentName: `CodeInterpreterAgent-${suffix}`,
       actionGroups: [
         {
           actionGroupName: 'CodeInterpreter',

--- a/packages/cdk/lib/construct/common-web-acl.ts
+++ b/packages/cdk/lib/construct/common-web-acl.ts
@@ -1,3 +1,4 @@
+import { Lazy, Names } from 'aws-cdk-lib';
 import { CfnIPSet, CfnWebACL, CfnWebACLProps } from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 
@@ -13,6 +14,8 @@ export class CommonWebAcl extends Construct {
 
   constructor(scope: Construct, id: string, props: CommonWebAclProps) {
     super(scope, id);
+
+    const suffix = Lazy.string({ produce: () => Names.uniqueId(this) });
 
     const rules: CfnWebACLProps['rules'] = [];
 
@@ -139,12 +142,12 @@ export class CommonWebAcl extends Construct {
 
     const webAcl = new CfnWebACL(this, `WebAcl${id}`, {
       defaultAction: { block: {} },
-      name: `WebAcl${id}`,
+      name: `WebAcl-${suffix}`,
       scope: props.scope,
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
         sampledRequestsEnabled: true,
-        metricName: `WebAcl${id}`,
+        metricName: `WebAcl-${suffix}`,
       },
       rules: rules,
     });

--- a/packages/cdk/lib/construct/guardrail.ts
+++ b/packages/cdk/lib/construct/guardrail.ts
@@ -1,17 +1,20 @@
 import { Construct } from 'constructs';
-import { aws_bedrock as bedrock } from 'aws-cdk-lib';
+import { aws_bedrock as bedrock, Lazy, Names } from 'aws-cdk-lib';
 
 export class Guardrail extends Construct {
   public readonly guardrailIdentifier: string;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
+
+    const suffix = Lazy.string({ produce: () => Names.uniqueId(this) });
+
     const cfnGuardrail = new bedrock.CfnGuardrail(this, `guardrail`, {
       blockedInputMessaging:
         '禁止された入力を検出しました。会話を最初からやり直すか、管理者にお問い合わせください。',
       blockedOutputsMessaging:
         'システムが禁じている内容の出力を検出しました。会話を最初からやり直すか、管理者にお問い合わせください。',
-      name: `Guardrail${id}`,
+      name: `Guardrail-${suffix}`,
       sensitiveInformationPolicyConfig: {
         // NAME, DRIVER_ID は日本のものが機能しないので設定しない
         // CA_*, US_*, UK_* はそれぞれの国固有のものなので設定しない

--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -94,9 +94,7 @@ export class Rag extends Construct {
   constructor(scope: Construct, id: string, props: RagProps) {
     super(scope, id);
 
-    const stage: string[] | null = this.node.tryGetContext(
-      'stage'
-    ) ?? "";
+    const env: string[] | null = this.node.tryGetContext('env') ?? '';
 
     const kendraIndexArnInCdkContext =
       this.node.tryGetContext('kendraIndexArn');
@@ -185,7 +183,7 @@ export class Rag extends Construct {
 
       let index: kendra.CfnIndex;
       const indexProps: kendra.CfnIndexProps = {
-        name: `generative-ai-use-cases-index${stage}`,
+        name: `generative-ai-use-cases-index${env}`,
         edition: 'DEVELOPER_EDITION',
         roleArn: indexRole.roleArn,
 

--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -94,6 +94,10 @@ export class Rag extends Construct {
   constructor(scope: Construct, id: string, props: RagProps) {
     super(scope, id);
 
+    const stage: string[] | null = this.node.tryGetContext(
+      'stage'
+    ) ?? "";
+
     const kendraIndexArnInCdkContext =
       this.node.tryGetContext('kendraIndexArn');
 
@@ -181,7 +185,7 @@ export class Rag extends Construct {
 
       let index: kendra.CfnIndex;
       const indexProps: kendra.CfnIndexProps = {
-        name: 'generative-ai-use-cases-index',
+        name: `generative-ai-use-cases-index${stage}`,
         edition: 'DEVELOPER_EDITION',
         roleArn: indexRole.roleArn,
 

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -133,6 +133,10 @@ export class RagKnowledgeBaseStack extends Stack {
   constructor(scope: Construct, id: string, props: RagKnowledgeBaseStackProps) {
     super(scope, id, props);
 
+    const stage: string[] | null = this.node.tryGetContext(
+      'stage'
+    ) ?? "";
+
     const embeddingModelId: string | null | undefined =
       this.node.tryGetContext('embeddingModelId')!;
 
@@ -148,7 +152,7 @@ export class RagKnowledgeBaseStack extends Stack {
       );
     }
 
-    const collectionName = props.collectionName ?? 'generative-ai-use-cases-jp';
+    const collectionName = props.collectionName ?? `generative-ai-use-cases-jp${stage}`;
     const vectorIndexName =
       props.vectorIndexName ?? 'bedrock-knowledge-base-default';
     const vectorField =

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -133,9 +133,7 @@ export class RagKnowledgeBaseStack extends Stack {
   constructor(scope: Construct, id: string, props: RagKnowledgeBaseStackProps) {
     super(scope, id, props);
 
-    const stage: string[] | null = this.node.tryGetContext(
-      'stage'
-    ) ?? "";
+    const env: string[] | null = this.node.tryGetContext('env') ?? '';
 
     const embeddingModelId: string | null | undefined =
       this.node.tryGetContext('embeddingModelId')!;
@@ -152,7 +150,8 @@ export class RagKnowledgeBaseStack extends Stack {
       );
     }
 
-    const collectionName = props.collectionName ?? `generative-ai-use-cases-jp${stage}`;
+    const collectionName =
+      props.collectionName ?? `generative-ai-use-cases-jp${env}`;
     const vectorIndexName =
       props.vectorIndexName ?? 'bedrock-knowledge-base-default';
     const vectorField =

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -2,7 +2,10 @@
 
 set -eu
 
-STACK_NAME='GenerativeAiUseCasesStack'
+# Parse packages/cdk/cdk.json and get context.env
+env=$(cat packages/cdk/cdk.json | jq -r '.context.env')
+
+STACK_NAME="GenerativeAiUseCasesStack${env}"
 
 function extract_value {
     echo $1 | jq -r ".Stacks[0].Outputs[] | select(.OutputKey==\"$2\") | .OutputValue"


### PR DESCRIPTION
## 変更内容の説明

- 複数スタックでデプロイした際に競合しうる、リソースを修正。
    - 新たに `env` を context に追加。デフォルトは空文字で既存ユーザーは引き続き同様に利用できるが、env を設定すると別スタックとしてまとめてデプロイすることが可能。
    - Agent / Guardrail / WAF の物理名にユニークな Suffix を付与。物理名の変更のためリソースは再作成されるがドリフトがない限りは既存ユーザーへの影響はない。
    - Kendra および Knowledge Base はデータへの影響がある可能性があるためユニークな Suffix ではなく `env` を Suffix として利用。（デフォルトは空文字なので既存環境への影響はない）

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
関連する Issue を可能な限り挙げてください。

#500 
#646 
#787
