### PR TITLE
タイトル生成モデルを軽量モデルに

### DIFF
--- a/packages/cdk/lambda/predictTitle.ts
+++ b/packages/cdk/lambda/predictTitle.ts
@@ -11,13 +11,19 @@ export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
   try {
-    const req: PredictTitleRequest = JSON.parse(event.body!);
+    if (!event.body) {
+      throw new Error('Request body is missing');
+    }
 
-    // model.type が bedrockAgent の場合は title が生成できないため bedrock のデフォルトモデルを使う
-    const model =
-      req.model.type === 'bedrockAgent'
-        ? defaultModel
-        : req.model || defaultModel;
+    const req = JSON.parse(event.body) as PredictTitleRequest;
+
+    // Validation
+    if (!req.prompt || !req.chat?.id || !req.chat?.createdDate || !req.id) {
+      throw new Error('Invalid request format');
+    }
+
+    // title 生成は軽量なデフォルトモデルを利用する
+    const model = defaultModel;
 
     // タイトル設定用の質問を追加
     const messages: UnrecordedMessage[] = [
@@ -31,7 +37,7 @@ export const handler = async (
     // 出力が <output></output> で囲まれる可能性がある
     // 以下の処理ではそれに対応するため、<output></output> を含む xml タグを削除している
     const title =
-      (await api[model.type].invoke?.(model, messages, req.id))?.replace(
+      (await api['bedrock'].invoke?.(model, messages, req.id))?.replace(
         /<([^>]+)>([\s\S]*?)<\/\1>/,
         '$2'
       ) ?? '';

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -21,7 +21,7 @@ import {
   ConversationRole,
   ContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
-import { lightWeightModels } from '@generative-ai-use-cases-jp/common';
+import { modelFeatureFlags } from '@generative-ai-use-cases-jp/common';
 
 // Default Models
 
@@ -31,8 +31,8 @@ const modelIds: string[] = (
   .map((modelId: string) => modelId.trim())
   .filter((modelId: string) => modelId);
 // 利用できるモデルの中で軽量モデルがあれば軽量モデルを優先する。
-const lightWeightModelIds = modelIds.filter((modelId: string) =>
-  lightWeightModels.has(modelId)
+const lightWeightModelIds = modelIds.filter(
+  (modelId: string) => modelFeatureFlags[modelId].light
 );
 const defaultModelId = lightWeightModelIds[0] || modelIds[0];
 export const defaultModel: Model = {

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -21,25 +21,33 @@ import {
   ConversationRole,
   ContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
+import { lightWeightModels } from '@generative-ai-use-cases-jp/common';
 
 // Default Models
 
-const modelId: string = JSON.parse(process.env.MODEL_IDS!)
-  .map((name: string) => name.trim())
-  .filter((name: string) => name)[0]!;
+const modelIds: string[] = (
+  JSON.parse(process.env.MODEL_IDS || '[]') as string[]
+)
+  .map((modelId: string) => modelId.trim())
+  .filter((modelId: string) => modelId);
+// 利用できるモデルの中で軽量モデルがあれば軽量モデルを優先する。
+const lightWeightModelIds = modelIds.filter((modelId: string) =>
+  lightWeightModels.has(modelId)
+);
+const defaultModelId = lightWeightModelIds[0] || modelIds[0];
 export const defaultModel: Model = {
   type: 'bedrock',
-  modelId: modelId,
+  modelId: defaultModelId,
 };
 
-const imageGenerationModelId: string = JSON.parse(
-  process.env.IMAGE_GENERATION_MODEL_IDS!
+const imageGenerationModelIds: string[] = (
+  JSON.parse(process.env.IMAGE_GENERATION_MODEL_IDS || '[]') as string[]
 )
   .map((name: string) => name.trim())
-  .filter((name: string) => name)[0]!;
+  .filter((name: string) => name);
 export const defaultImageGenerationModel: Model = {
   type: 'bedrock',
-  modelId: imageGenerationModelId,
+  modelId: imageGenerationModelIds[0],
 };
 
 // Prompt Templates

--- a/packages/common/src/model.ts
+++ b/packages/common/src/model.ts
@@ -3,12 +3,15 @@ import { FeatureFlags } from 'generative-ai-use-cases-jp';
 // Manage Model Feature
 // https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html
 const MODEL_FEATURE: Record<string, FeatureFlags> = {
+  // Model Feature Flags
   TEXT_ONLY: { text: true, doc: false, image: false, video: false },
   TEXT_DOC: { text: true, doc: true, image: false, video: false },
   TEXT_DOC_IMAGE: { text: true, doc: true, image: true, video: false },
   TEXT_DOC_IMAGE_VIDEO: { text: true, doc: true, image: true, video: true },
   IMAGE_GEN: { image_gen: true },
   VIDEO_GEN: { video_gen: true },
+  // Additional Flags
+  LIGHT: { light: true },
 };
 export const modelFeatureFlags: Record<string, FeatureFlags> = {
   // Anthropic
@@ -16,21 +19,45 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
   'anthropic.claude-3-5-haiku-20241022-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'anthropic.claude-3-5-sonnet-20240620-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'anthropic.claude-3-opus-20240229-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'anthropic.claude-3-sonnet-20240229-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'anthropic.claude-3-haiku-20240307-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
+  'anthropic.claude-3-sonnet-20240229-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'anthropic.claude-3-haiku-20240307-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
   'us.anthropic.claude-3-5-sonnet-20241022-v2:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-sonnet-20240620-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-opus-20240229-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'us.anthropic.claude-3-sonnet-20240229-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'us.anthropic.claude-3-haiku-20240307-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
+  'us.anthropic.claude-3-sonnet-20240229-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'us.anthropic.claude-3-haiku-20240307-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
   'eu.anthropic.claude-3-5-sonnet-20240620-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'eu.anthropic.claude-3-sonnet-20240229-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'eu.anthropic.claude-3-haiku-20240307-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
+  'eu.anthropic.claude-3-sonnet-20240229-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'eu.anthropic.claude-3-haiku-20240307-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
   'apac.anthropic.claude-3-5-sonnet-20240620-v1:0':
     MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'apac.anthropic.claude-3-sonnet-20240229-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
-  'apac.anthropic.claude-3-haiku-20240307-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
+  'apac.anthropic.claude-3-sonnet-20240229-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'apac.anthropic.claude-3-haiku-20240307-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE,
+    ...MODEL_FEATURE.LIGHT,
+  },
   'anthropic.claude-v2:1': MODEL_FEATURE.TEXT_DOC,
   'anthropic.claude-v2': MODEL_FEATURE.TEXT_DOC,
   'anthropic.claude-instant-v1': MODEL_FEATURE.TEXT_DOC,
@@ -39,11 +66,23 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
   'amazon.titan-text-premier-v1:0': MODEL_FEATURE.TEXT_ONLY,
   // Amazon Nova
   'amazon.nova-pro-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE_VIDEO,
-  'amazon.nova-lite-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE_VIDEO,
-  'amazon.nova-micro-v1:0': MODEL_FEATURE.TEXT_ONLY,
+  'amazon.nova-lite-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE_VIDEO,
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'amazon.nova-micro-v1:0': {
+    ...MODEL_FEATURE.TEXT_ONLY,
+    ...MODEL_FEATURE.LIGHT,
+  },
   'us.amazon.nova-pro-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE, // S3 Video アップロードが us-east-1 のみ対応のため。 Video を利用したい場合は us-east-1 の amazon.nova-pro-v1:0 で利用できます。（注意: リージョン変更の際 RAG を有効化している場合削除されます）
-  'us.amazon.nova-lite-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE, // 同上
-  'us.amazon.nova-micro-v1:0': MODEL_FEATURE.TEXT_ONLY,
+  'us.amazon.nova-lite-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE, // 同上
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'us.amazon.nova-micro-v1:0': {
+    ...MODEL_FEATURE.TEXT_ONLY,
+    ...MODEL_FEATURE.LIGHT,
+  },
   // Meta
   'meta.llama3-8b-instruct-v1:0': MODEL_FEATURE.TEXT_DOC,
   'meta.llama3-70b-instruct-v1:0': MODEL_FEATURE.TEXT_DOC,
@@ -73,33 +112,3 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
   'amazon.titan-image-generator-v1': MODEL_FEATURE.IMAGE_GEN,
   'amazon.nova-canvas-v1:0': MODEL_FEATURE.IMAGE_GEN,
 };
-
-// Light Weight Model preferred to use for light weight task (i.e. title generation)
-export const lightWeightModels = new Set([
-  // Anthropic
-  'anthropic.claude-3-sonnet-20240229-v1:0',
-  'anthropic.claude-3-haiku-20240307-v1:0',
-  'us.anthropic.claude-3-sonnet-20240229-v1:0',
-  'us.anthropic.claude-3-haiku-20240307-v1:0',
-  'eu.anthropic.claude-3-sonnet-20240229-v1:0',
-  'eu.anthropic.claude-3-haiku-20240307-v1:0',
-  'apac.anthropic.claude-3-5-sonnet-20240620-v1:0',
-  'apac.anthropic.claude-3-sonnet-20240229-v1:0',
-  'apac.anthropic.claude-3-haiku-20240307-v1:0',
-  // Amazon
-  'amazon.nova-pro-v1:0',
-  'amazon.nova-lite-v1:0',
-  'amazon.nova-micro-v1:0',
-  'us.amazon.nova-pro-v1:0',
-  'us.amazon.nova-lite-v1:0',
-  'us.amazon.nova-micro-v1:0',
-  // Meta
-  'meta.llama3-8b-instruct-v1:0',
-  'meta.llama3-70b-instruct-v1:0',
-  'meta.llama3-1-8b-instruct-v1:0',
-  'meta.llama3-1-70b-instruct-v1:0',
-  'us.meta.llama3-2-1b-instruct-v1:0',
-  'us.meta.llama3-2-3b-instruct-v1:0',
-  'us.meta.llama3-2-11b-instruct-v1:0',
-  'us.meta.llama3-2-90b-instruct-v1:0',
-]);

--- a/packages/common/src/model.ts
+++ b/packages/common/src/model.ts
@@ -73,3 +73,33 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
   'amazon.titan-image-generator-v1': MODEL_FEATURE.IMAGE_GEN,
   'amazon.nova-canvas-v1:0': MODEL_FEATURE.IMAGE_GEN,
 };
+
+// Light Weight Model preferred to use for light weight task (i.e. title generation)
+export const lightWeightModels = new Set([
+  // Anthropic
+  'anthropic.claude-3-sonnet-20240229-v1:0',
+  'anthropic.claude-3-haiku-20240307-v1:0',
+  'us.anthropic.claude-3-sonnet-20240229-v1:0',
+  'us.anthropic.claude-3-haiku-20240307-v1:0',
+  'eu.anthropic.claude-3-sonnet-20240229-v1:0',
+  'eu.anthropic.claude-3-haiku-20240307-v1:0',
+  'apac.anthropic.claude-3-5-sonnet-20240620-v1:0',
+  'apac.anthropic.claude-3-sonnet-20240229-v1:0',
+  'apac.anthropic.claude-3-haiku-20240307-v1:0',
+  // Amazon
+  'amazon.nova-pro-v1:0',
+  'amazon.nova-lite-v1:0',
+  'amazon.nova-micro-v1:0',
+  'us.amazon.nova-pro-v1:0',
+  'us.amazon.nova-lite-v1:0',
+  'us.amazon.nova-micro-v1:0',
+  // Meta
+  'meta.llama3-8b-instruct-v1:0',
+  'meta.llama3-70b-instruct-v1:0',
+  'meta.llama3-1-8b-instruct-v1:0',
+  'meta.llama3-1-70b-instruct-v1:0',
+  'us.meta.llama3-2-1b-instruct-v1:0',
+  'us.meta.llama3-2-3b-instruct-v1:0',
+  'us.meta.llama3-2-11b-instruct-v1:0',
+  'us.meta.llama3-2-90b-instruct-v1:0',
+]);

--- a/packages/types/src/model.d.ts
+++ b/packages/types/src/model.d.ts
@@ -1,9 +1,12 @@
 // Feature Flag の型を定義
 export type FeatureFlags = {
+  // Model Feature Flags
   text?: boolean;
   doc?: boolean;
   image?: boolean;
   video?: boolean;
   image_gen?: boolean;
   video_gen?: boolean;
+  // Additional Flags
+  light?: boolean;
 };


### PR DESCRIPTION
## 変更内容の説明

- タイトル生成時に使用するモデルをアプリで有効化されているモデルで軽量なモデルを優先
    - 有効化されている軽量モデルのうち最初のものを優先して利用。
    - 軽量なモデルが有効化されていない場合は有効化されているモデルの最初のモデルに Fall back。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
関連する Issue を可能な限り挙げてください。

#719
#789
