### PR TITLE
画像生成 Titan v2 & Nova Canvas 新機能対応

### DIFF
--- a/packages/types/src/image.d.ts
+++ b/packages/types/src/image.d.ts
@@ -1,5 +1,25 @@
+export type ControlMode = 'CANNY_EDGE' | 'SEGMENTATION';
+export type AmazonBaseImageGenerationMode =
+  | 'TEXT_IMAGE'
+  | 'IMAGE_VARIATION'
+  | 'INPAINTING'
+  | 'OUTPAINTING';
+// Titan v2, Nova Canvas
+export type AmazonAdvancedImageGenerationMode =
+  | 'IMAGE_CONDITIONING'
+  | 'COLOR_GUIDED_GENERATION'
+  | 'BACKGROUND_REMOVAL';
+// UI 表示用
+export type AmazonUIImageGenerationMode =
+  | AmazonBaseImageGenerationMode
+  | AmazonAdvancedImageGenerationMode;
+// API通信用
+export type AmazonAPIImageGenerationMode =
+  | AmazonBaseImageGenerationMode
+  | Exclude<AmazonAdvancedImageGenerationMode, 'IMAGE_CONDITIONING'>;
 // 標準化したパラメータ
 export type GenerateImageParams = {
+  taskType?: AmazonAPIImageGenerationMode;
   textPrompt: {
     text: string;
     weight: number;
@@ -17,7 +37,11 @@ export type GenerateImageParams = {
   // Inpaint / Outpaint
   maskImage?: string;
   maskPrompt?: string;
-  maskMode?: 'INPAINTING' | 'OUTPAINTING';
+  // Color Guided Generation
+  colors?: string[];
+  // Image Conditioning
+  controlStrength?: number;
+  controlMode?: ControlMode;
 };
 
 // Stable Diffusion
@@ -57,12 +81,8 @@ export type StabilityAI2024ModelParams = {
   strength?: number;
 };
 
-// Titan Image
-// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-image.html
-// Amazon Nova
-// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-access.html
-export type AmazonImageParams = {
-  taskType: 'TEXT_IMAGE' | 'INPAINTING' | 'OUTPAINTING' | 'IMAGE_VARIATION';
+export type AmazonGeneralImageParams = {
+  taskType: AmazonBaseImageGenerationMode;
   textToImageParams?: {
     text: string;
     negativeText?: string;
@@ -95,6 +115,30 @@ export type AmazonImageParams = {
     width: number;
     cfgScale: number;
     seed?: number;
+  };
+};
+// Titan Image
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-image.html
+// Amazon Nova
+// https://docs.aws.amazon.com/nova/latest/userguide/image-gen-access.html
+export type AmazonAdvancedImageParams = Omit<
+  AmazonGeneralImageParams,
+  'taskType'
+> & {
+  taskType: AmazonAPIImageGenerationMode;
+  textToImageParams: AmazonGeneralImageParams['textToImageParams'] & {
+    conditionImage?: string; // base64 encoded image
+    controlMode?: ControlMode;
+    controlStrength?: number;
+  };
+  colorGuidedGenerationParams?: {
+    text: string;
+    negativeText?: string;
+    referenceImage?: string; // base64 encoded image
+    colors: string[]; // list of color hex codes
+  };
+  backgroundRemovalParams?: {
+    image: string; // base64 encoded image
   };
 };
 

--- a/packages/web/src/components/Select.tsx
+++ b/packages/web/src/components/Select.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useCallback, useMemo } from 'react';
+import React, { Fragment, useCallback, useMemo } from 'react';
 import { Listbox, Transition } from '@headlessui/react';
 import { PiCaretUpDown, PiCheck, PiX } from 'react-icons/pi';
 import RowItem, { RowItemProps } from './RowItem';
 import ButtonIcon from './ButtonIcon';
+import Help from './Help';
 
 type Props = RowItemProps & {
   label?: string;
@@ -11,8 +12,10 @@ type Props = RowItemProps & {
     value: string;
     label: string;
   }[];
+  help?: string;
   clearable?: boolean;
   fullWidth?: boolean;
+  showColorChips?: boolean;
   onChange: (value: string) => void;
 };
 
@@ -27,18 +30,50 @@ const Select: React.FC<Props> = (props) => {
     props.onChange('');
   }, [props]);
 
+  const ColorChips: React.FC<{ colors: string[] }> = ({ colors }) => (
+    <div className="flex items-center gap-1">
+      {colors.map((color, index) => (
+        <div
+          key={index}
+          className="h-4 w-4 border border-gray-300"
+          style={{ backgroundColor: color }}
+        />
+      ))}
+    </div>
+  );
+
+  const OptionContent: React.FC<{ value: string; label: string }> = ({
+    value,
+    label,
+  }) => {
+    if (!props.showColorChips) return <>{label}</>;
+
+    const colors = value.split(',').map((color) => color.trim());
+    return (
+      <div className="flex items-center gap-2">
+        <ColorChips colors={colors} />
+        <span>{label}</span>
+      </div>
+    );
+  };
+
   return (
     <RowItem notItem={props.notItem} className="relative">
       {props.label && (
-        <div>
+        <div className="flex items-center">
           <span className="text-sm">{props.label}</span>
+          {props.help && <Help className="ml-1" message={props.help} />}
         </div>
       )}
       <Listbox value={props.value} onChange={props.onChange}>
         <div className="relative">
           <Listbox.Button
             className={`relative h-8 cursor-pointer rounded border border-black/30 bg-white pl-3 pr-10 text-left focus:outline-none ${props.fullWidth ? 'w-full' : 'w-fit'}`}>
-            <span className="block truncate">{selectedLabel}</span>
+            <span className="block truncate">
+              {props.value && (
+                <OptionContent value={props.value} label={selectedLabel} />
+              )}
+            </span>
 
             <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
               <PiCaretUpDown className="text-sm" />
@@ -73,7 +108,10 @@ const Select: React.FC<Props> = (props) => {
                       className={`block truncate ${
                         selected ? 'font-medium' : 'font-normal'
                       }`}>
-                      {option.label}
+                      <OptionContent
+                        value={option.value}
+                        label={option.label}
+                      />
                     </span>
                     {selected ? (
                       <span className="text-aws-smile absolute inset-y-0 left-0 flex items-center pl-3">

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -23,6 +23,11 @@ import { MODELS } from '../hooks/useModel';
 import { getPrompter } from '../prompts';
 import queryString from 'query-string';
 import { GenerateImageParams } from 'generative-ai-use-cases-jp';
+import {
+  AmazonBaseImageGenerationMode,
+  AmazonUIImageGenerationMode,
+  ControlMode,
+} from 'generative-ai-use-cases-jp';
 
 const MAX_SAMPLE = 7;
 
@@ -37,19 +42,28 @@ const STABILITY_AI_MODELS = {
   STABLE_IMAGE_CORE: 'stability.stable-image-core-v1:0',
   STABLE_IMAGE_ULTRA: 'stability.stable-image-ultra-v1:0',
 };
-const GENERATION_MODES = {
+const GENERATION_MODES: Record<
+  AmazonBaseImageGenerationMode,
+  AmazonBaseImageGenerationMode
+> = {
   TEXT_IMAGE: 'TEXT_IMAGE',
   IMAGE_VARIATION: 'IMAGE_VARIATION',
   INPAINTING: 'INPAINTING',
   OUTPAINTING: 'OUTPAINTING',
 } as const;
-type GenerationMode = (typeof GENERATION_MODES)[keyof typeof GENERATION_MODES];
-const modeOptions = Object.values(GENERATION_MODES).map((mode) => ({
-  value: mode,
-  label: mode,
-}));
-type ModelInfo = {
-  supportedModes: GenerationMode[];
+const AMAZON_ADVANCED_GENERATION_MODE: Record<
+  AmazonUIImageGenerationMode,
+  AmazonUIImageGenerationMode
+> = {
+  ...GENERATION_MODES,
+  IMAGE_CONDITIONING: 'IMAGE_CONDITIONING',
+  COLOR_GUIDED_GENERATION: 'COLOR_GUIDED_GENERATION',
+  BACKGROUND_REMOVAL: 'BACKGROUND_REMOVAL',
+};
+type ModelInfo<T extends 'base' | 'advanced'> = {
+  supportedModes: T extends 'base'
+    ? AmazonBaseImageGenerationMode[]
+    : AmazonUIImageGenerationMode[];
   resolutionPresets: { value: string; label: string }[];
 };
 const defaultModelPresets = [
@@ -65,7 +79,7 @@ const stabilityAi2024ModelPresets = [
   { value: '16:9', label: '1344 x 768' },
   { value: '21:9', label: '1536 x 640' },
 ];
-const modelInfo: Record<string, ModelInfo> = {
+const modelInfo: Record<string, ModelInfo<'base' | 'advanced'>> = {
   [STABILITY_AI_MODELS.STABLE_DIFFUSION_XL]: {
     supportedModes: [
       GENERATION_MODES.TEXT_IMAGE,
@@ -101,23 +115,84 @@ const modelInfo: Record<string, ModelInfo> = {
   },
   [AMAZON_MODELS.TITAN_V2]: {
     supportedModes: [
-      GENERATION_MODES.TEXT_IMAGE,
-      GENERATION_MODES.IMAGE_VARIATION,
-      GENERATION_MODES.INPAINTING,
-      GENERATION_MODES.OUTPAINTING,
+      AMAZON_ADVANCED_GENERATION_MODE.TEXT_IMAGE,
+      AMAZON_ADVANCED_GENERATION_MODE.IMAGE_VARIATION,
+      AMAZON_ADVANCED_GENERATION_MODE.INPAINTING,
+      AMAZON_ADVANCED_GENERATION_MODE.OUTPAINTING,
+      AMAZON_ADVANCED_GENERATION_MODE.IMAGE_CONDITIONING,
+      AMAZON_ADVANCED_GENERATION_MODE.COLOR_GUIDED_GENERATION,
+      AMAZON_ADVANCED_GENERATION_MODE.BACKGROUND_REMOVAL,
     ],
     resolutionPresets: defaultModelPresets,
   },
   [AMAZON_MODELS.NOVA_CANVAS]: {
     supportedModes: [
-      GENERATION_MODES.TEXT_IMAGE,
-      GENERATION_MODES.IMAGE_VARIATION,
-      GENERATION_MODES.INPAINTING,
-      GENERATION_MODES.OUTPAINTING,
+      AMAZON_ADVANCED_GENERATION_MODE.TEXT_IMAGE,
+      AMAZON_ADVANCED_GENERATION_MODE.IMAGE_VARIATION,
+      AMAZON_ADVANCED_GENERATION_MODE.INPAINTING,
+      AMAZON_ADVANCED_GENERATION_MODE.OUTPAINTING,
+      AMAZON_ADVANCED_GENERATION_MODE.IMAGE_CONDITIONING,
+      AMAZON_ADVANCED_GENERATION_MODE.COLOR_GUIDED_GENERATION,
+      AMAZON_ADVANCED_GENERATION_MODE.BACKGROUND_REMOVAL,
     ],
     resolutionPresets: defaultModelPresets,
   },
 };
+
+const colorsOptions = [
+  {
+    value: '#efd9b4,#d6a692,#a39081,#4d6164,#292522',
+    label: 'Earthy Neutrals',
+  },
+  {
+    value: '#001449,#012677,#005bc5,#00b4fc,#17f9ff',
+    label: 'Ocean Blues',
+  },
+  {
+    value: '#c7003f,#f90050,#f96a00,#faab00,#daf204',
+    label: 'Fiery Sunset',
+  },
+  {
+    value: '#ffd100,#ffee32,#ffd100,#00a86b,#004b23',
+    label: 'Lemon Lime',
+  },
+  {
+    value: '#006400,#228B22,#32CD32,#90EE90,#98FB98',
+    label: 'Forest Greens',
+  },
+  {
+    value: '#4B0082,#8A2BE2,#9370DB,#BA55D3,#DDA0DD',
+    label: 'Royal Purples',
+  },
+  {
+    value: '#FF8C00,#FFA500,#FFD700,#FFFF00,#F0E68C',
+    label: 'Golden Ambers',
+  },
+  {
+    value: '#FFB6C1,#FFC0CB,#FFE4E1,#E6E6FA,#F0F8FF',
+    label: 'Soft Pastels',
+  },
+  {
+    value: '#FF00FF,#00FFFF,#FF0000,#00FF00,#0000FF',
+    label: 'Vivid Rainbow',
+  },
+  {
+    value: '#000000,#333333,#666666,#999999,#CCCCCC',
+    label: 'Classic Monochrome',
+  },
+  {
+    value: '#FFFFFF,#F2F2F2,#E6E6E6,#D9D9D9,#CCCCCC',
+    label: 'Light Grayscale',
+  },
+  {
+    value: '#704214,#8B4513,#A0522D,#CD853F,#DEB887',
+    label: 'Vintage Sepia',
+  },
+  {
+    value: '#FF9900,#232F3E,#ffffff,#00464F,#6C7778',
+    label: 'Smile and Sky',
+  },
+];
 
 const getModeOptions = (imageGenModelId: string) => {
   if (imageGenModelId in modelInfo) {
@@ -162,14 +237,20 @@ type StateType = {
   setCfgScale: (n: number) => void;
   imageStrength: number;
   setImageStrength: (n: number) => void;
-  generationMode: GenerationMode;
-  setGenerationMode: (s: GenerationMode) => void;
+  controlStrength: number;
+  setControlStrength: (n: number) => void;
+  controlMode: ControlMode;
+  setControlMode: (s: ControlMode) => void;
+  generationMode: AmazonUIImageGenerationMode;
+  setGenerationMode: (s: AmazonUIImageGenerationMode) => void;
   initImage: Canvas;
   setInitImage: (s: Canvas) => void;
   maskImage: Canvas;
   setMaskImage: (s: Canvas) => void;
   maskPrompt: string;
   setMaskPrompt: (s: string) => void;
+  colors: string;
+  setColors: (colors: string) => void;
   imageSample: number;
   setImageSample: (n: number) => void;
   image: {
@@ -200,7 +281,9 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
     step: 50,
     cfgScale: 7,
     imageStrength: 0.35,
-    generationMode: modeOptions[0]['value'],
+    controlStrength: 0.7,
+    controlMode: 'CANNY_EDGE' as ControlMode,
+    generationMode: 'TEXT_IMAGE' as AmazonUIImageGenerationMode,
     initImage: {
       imageBase64: '',
       foregroundBase64: '',
@@ -212,6 +295,7 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
       backgroundColor: '',
     },
     maskPrompt: '',
+    colors: colorsOptions[0].value,
     imageSample: 3,
     image: new Array(MAX_SAMPLE).fill({
       base64: '',
@@ -226,14 +310,15 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
       const newResolutionPresets = getResolutionPresets(s);
       const newResolution = newResolutionPresets[0];
       const currentMode = get().generationMode;
-      const availableModes = getModeOptions(s).map((option) => option.value);
+      const availableModes = modelInfo[s]?.supportedModes || [
+        AMAZON_ADVANCED_GENERATION_MODE.TEXT_IMAGE,
+      ];
+      const isValidMode = availableModes.some((mode) => mode === currentMode);
       set(() => ({
         imageGenModelId: s,
         resolutionPresets: newResolutionPresets,
         resolution: newResolution,
-        generationMode: availableModes.includes(currentMode)
-          ? currentMode
-          : availableModes[0],
+        generationMode: isValidMode ? currentMode : availableModes[0],
       }));
     },
     setPrompt: (s) => {
@@ -278,6 +363,16 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
         imageStrength: n,
       }));
     },
+    setControlStrength: (n) => {
+      set(() => ({
+        controlStrength: n,
+      }));
+    },
+    setControlMode: (n) => {
+      set(() => ({
+        controlMode: n,
+      }));
+    },
     setGenerationMode: (s) => {
       set(() => ({
         generationMode: s,
@@ -296,6 +391,11 @@ const useGenerateImagePageState = create<StateType>((set, get) => {
     setMaskPrompt: (s) => {
       set(() => ({
         maskPrompt: s,
+      }));
+    },
+    setColors: (s) => {
+      set(() => ({
+        colors: s,
       }));
     },
     setImageSample: (n) => {
@@ -368,6 +468,12 @@ const stylePresetOptions = [
   label: s,
 }));
 
+// Titan Image Generator v2のImage Conditioning適用時のControl Mode
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-image.html
+const controlModeOptions = ['CANNY_EDGE', 'SEGMENTATION'].map((s) => ({
+  value: s as ControlMode,
+  label: s as ControlMode,
+}));
 const GenerateImagePage: React.FC = () => {
   const {
     imageGenModelId,
@@ -395,6 +501,8 @@ const GenerateImagePage: React.FC = () => {
     setMaskImage,
     maskPrompt,
     setMaskPrompt,
+    colors,
+    setColors,
     image,
     setImage,
     setImageError,
@@ -403,6 +511,10 @@ const GenerateImagePage: React.FC = () => {
     setImageSample,
     imageStrength,
     setImageStrength,
+    controlStrength,
+    setControlStrength,
+    controlMode,
+    setControlMode,
     chatContent,
     setChatContent,
     clear,
@@ -423,6 +535,9 @@ const GenerateImagePage: React.FC = () => {
   const [isOpenMask, setIsOpenMask] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const [detailExpanded, setDetailExpanded] = useState(false);
+  const [previousImageSample, setPreviousImageSample] = useState(3);
+  const [previousGenerationMode, setPreviousGenerationMode] =
+    useState<AmazonUIImageGenerationMode>('TEXT_IMAGE');
   const { modelIds, imageGenModelIds, imageGenModels } = MODELS;
   const modelId = getModelId();
   const prompter = useMemo(() => {
@@ -446,6 +561,20 @@ const GenerateImagePage: React.FC = () => {
       imageGenModelId === AMAZON_MODELS.NOVA_CANVAS
     );
   }, [imageGenModelId]);
+
+  useEffect(() => {
+    setPreviousGenerationMode(generationMode);
+  }, [generationMode]);
+
+  useEffect(() => {
+    if (generationMode === 'BACKGROUND_REMOVAL') {
+      setPreviousImageSample(imageSample);
+      setImageSample(1);
+    } else if (previousGenerationMode === 'BACKGROUND_REMOVAL') {
+      setImageSample(previousImageSample);
+    }
+    // eslint-disable-next-line  react-hooks/exhaustive-deps
+  }, [generationMode]);
 
   const modeOptions = useMemo(
     () => getModeOptions(imageGenModelId),
@@ -539,6 +668,10 @@ const GenerateImagePage: React.FC = () => {
           seed: _seed,
           step,
           stylePreset: _stylePreset ?? stylePreset,
+          taskType:
+            generationMode === 'IMAGE_CONDITIONING'
+              ? 'TEXT_IMAGE'
+              : generationMode,
         };
 
         if (generationMode === GENERATION_MODES.IMAGE_VARIATION) {
@@ -556,7 +689,31 @@ const GenerateImagePage: React.FC = () => {
             initImage: initImage.imageBase64,
             maskPrompt: maskImage.imageBase64 ? undefined : maskPrompt,
             maskImage: maskImage.imageBase64,
-            maskMode: generationMode,
+          };
+        } else if (
+          generationMode === AMAZON_ADVANCED_GENERATION_MODE.IMAGE_CONDITIONING
+        ) {
+          params = {
+            ...params,
+            initImage: initImage.imageBase64,
+            controlStrength,
+            controlMode,
+          };
+        } else if (
+          generationMode ===
+          AMAZON_ADVANCED_GENERATION_MODE.COLOR_GUIDED_GENERATION
+        ) {
+          params = {
+            ...params,
+            initImage: initImage.imageBase64,
+            colors: colors.split(',').map((color) => color.trim()),
+          };
+        } else if (
+          generationMode === AMAZON_ADVANCED_GENERATION_MODE.BACKGROUND_REMOVAL
+        ) {
+          params = {
+            ...params,
+            initImage: initImage.imageBase64,
           };
         }
 
@@ -600,6 +757,7 @@ const GenerateImagePage: React.FC = () => {
       initImage,
       maskPrompt,
       maskImage,
+      colors,
       seed,
       setImage,
       setImageError,
@@ -607,6 +765,8 @@ const GenerateImagePage: React.FC = () => {
       step,
       stylePreset,
       resolution.value,
+      controlMode,
+      controlStrength,
     ]
   );
 
@@ -785,24 +945,26 @@ const GenerateImagePage: React.FC = () => {
               <PiNotePencil></PiNotePencil>
             </Button>
           </div>
-
-          <Textarea
-            label="プロンプト"
-            help="生成したい画像の説明を記載してください。文章ではなく、単語の羅列で記載します。"
-            value={prompt}
-            onChange={setPrompt}
-            maxHeight={60}
-            rows={2}
-          />
-
-          <Textarea
-            label="ネガティブプロンプト"
-            help="生成したくない要素、排除したい要素を記載してください。文章ではなく、単語の羅列で記載します。"
-            value={negativePrompt}
-            onChange={setNegativePrompt}
-            maxHeight={60}
-            rows={2}
-          />
+          {generationMode !== 'BACKGROUND_REMOVAL' && (
+            <>
+              <Textarea
+                label="プロンプト"
+                help="生成したい画像の説明を記載してください。文章ではなく、単語の羅列で記載します。"
+                value={prompt}
+                onChange={setPrompt}
+                maxHeight={60}
+                rows={2}
+              />
+              <Textarea
+                label="ネガティブプロンプト"
+                help="生成したくない要素、排除したい要素を記載してください。文章ではなく、単語の羅列で記載します。"
+                value={negativePrompt}
+                onChange={setNegativePrompt}
+                maxHeight={60}
+                rows={2}
+              />
+            </>
+          )}
 
           <div className="grid w-full grid-cols-2 gap-2">
             <Select
@@ -813,52 +975,56 @@ const GenerateImagePage: React.FC = () => {
                 return { value: m, label: m };
               })}
             />
-            <Select
-              label="サイズ"
-              value={resolution.value}
-              onChange={(value: string) => {
-                const selectedResolution = resolutionPresets.find(
-                  (option: StateType['resolution']) => option.value === value
-                );
-                if (selectedResolution) {
-                  setResolution(selectedResolution);
-                }
-              }}
-              options={resolutionPresets}
-              fullWidth
-            />
-          </div>
-
-          <div className="grid w-full grid-cols-2 gap-2 pt-4">
-            <div className="relative col-span-2 flex flex-row items-center lg:col-span-1">
-              <RangeSlider
-                className="w-full"
-                label="Seed"
-                min={0}
-                max={4294967295}
-                value={seed[selectedImageIndex]}
-                onChange={(n) => {
-                  setSeed(n, selectedImageIndex);
+            {generationMode !== 'BACKGROUND_REMOVAL' && (
+              <Select
+                label="サイズ"
+                value={resolution.value}
+                onChange={(value: string) => {
+                  const selectedResolution = resolutionPresets.find(
+                    (option: StateType['resolution']) => option.value === value
+                  );
+                  if (selectedResolution) {
+                    setResolution(selectedResolution);
+                  }
                 }}
-                help="乱数のシード値です。同じシード値を指定すると同じ画像が生成されます。"
+                options={resolutionPresets}
+                fullWidth
               />
-              <ButtonIcon
-                className="absolute -top-0.5 right-[8.2rem]"
-                onClick={onClickRandomSeed}>
-                <PiDiceFive />
-              </ButtonIcon>
-            </div>
-
-            <RangeSlider
-              className="col-span-2 lg:col-span-1"
-              label="画像生成数"
-              min={1}
-              max={7}
-              value={imageSample}
-              onChange={setImageSample}
-              help="Seed をランダム設定しながら画像を指定の数だけ同時に生成します。"
-            />
+            )}
           </div>
+
+          {generationMode !== 'BACKGROUND_REMOVAL' && (
+            <div className="grid w-full grid-cols-2 gap-2 pt-4">
+              <div className="relative col-span-2 flex flex-row items-center lg:col-span-1">
+                <RangeSlider
+                  className="w-full"
+                  label="Seed"
+                  min={0}
+                  max={4294967295}
+                  value={seed[selectedImageIndex]}
+                  onChange={(n) => {
+                    setSeed(n, selectedImageIndex);
+                  }}
+                  help="乱数のシード値です。同じシード値を指定すると同じ画像が生成されます。"
+                />
+                <ButtonIcon
+                  className="absolute -top-0.5 right-[8.2rem]"
+                  onClick={onClickRandomSeed}>
+                  <PiDiceFive />
+                </ButtonIcon>
+              </div>
+
+              <RangeSlider
+                className="col-span-2 lg:col-span-1"
+                label="画像生成数"
+                min={1}
+                max={7}
+                value={imageSample}
+                onChange={setImageSample}
+                help="Seed をランダム設定しながら画像を指定の数だけ同時に生成します。"
+              />
+            </div>
+          )}
 
           <ExpandableField
             label="詳細なパラメータ"
@@ -870,7 +1036,9 @@ const GenerateImagePage: React.FC = () => {
                   label="GenerationMode"
                   options={modeOptions}
                   value={generationMode}
-                  onChange={(v) => setGenerationMode(v as GenerationMode)}
+                  onChange={(v) =>
+                    setGenerationMode(v as AmazonUIImageGenerationMode)
+                  }
                   fullWidth
                 />
                 <div className="mb-2 flex flex-row justify-center gap-2 lg:flex-col xl:flex-row">
@@ -936,53 +1104,88 @@ const GenerateImagePage: React.FC = () => {
                     disabled={!!maskImage.imageBase64}
                   />
                 )}
-              </div>
-
-              <div className="col-span-2 flex flex-col items-center justify-start lg:col-span-1">
-                <div className="mb-2 w-full">
+                {generationMode === 'COLOR_GUIDED_GENERATION' && (
                   <Select
-                    label="StylePreset"
-                    options={stylePresetOptions}
-                    value={stylePreset}
-                    onChange={setStylePreset}
-                    clearable
+                    label="カラーパレット"
+                    help="生成画像の色合いを指定指定します。"
+                    options={colorsOptions}
+                    value={colors}
+                    onChange={setColors}
                     fullWidth
+                    showColorChips
                   />
-                </div>
-
-                <RangeSlider
-                  className="w-full"
-                  label="CFG Scale"
-                  min={0}
-                  max={30}
-                  value={cfgScale}
-                  onChange={setCfgScale}
-                  help="この値が高いほどプロンプトに対して忠実な画像を生成します。"
-                />
-
-                <RangeSlider
-                  className="w-full"
-                  label="Step"
-                  min={10}
-                  max={50}
-                  value={step}
-                  onChange={setStep}
-                  help="画像生成の反復回数です。Step 数が多いほど画像が洗練されますが、生成に時間がかかります。"
-                />
-
-                {generationMode === GENERATION_MODES.IMAGE_VARIATION && (
-                  <RangeSlider
-                    className="w-full"
-                    label="ImageStrength"
-                    min={0}
-                    max={1}
-                    step={0.01}
-                    value={imageStrength}
-                    onChange={setImageStrength}
-                    help="1に近いほど「初期画像」に近い画像が生成され、0に近いほど「初期画像」とは異なる画像が生成されます。"
+                )}
+                {generationMode === 'IMAGE_CONDITIONING' && (
+                  <Select
+                    label="コントロールモード"
+                    help="CANNY_EDGE:参照画像のエッジを抽出します。詳細な模様などを反映したい場合に最適です。SEGMENTATION:参照画像内を領域に区切ります。複数の物体の位置関係を反映したい場合に最適です。"
+                    options={controlModeOptions}
+                    value={controlMode}
+                    onChange={(v) => setControlMode(v as ControlMode)}
+                    fullWidth
                   />
                 )}
               </div>
+
+              {generationMode !== 'BACKGROUND_REMOVAL' && (
+                <div className="col-span-2 flex flex-col items-center justify-start lg:col-span-1">
+                  <div className="mb-2 w-full">
+                    <Select
+                      label="StylePreset"
+                      options={stylePresetOptions}
+                      value={stylePreset}
+                      onChange={setStylePreset}
+                      clearable
+                      fullWidth
+                    />
+                  </div>
+
+                  <RangeSlider
+                    className="w-full"
+                    label="CFG Scale"
+                    min={0}
+                    max={30}
+                    value={cfgScale}
+                    onChange={setCfgScale}
+                    help="この値が高いほどプロンプトに対して忠実な画像を生成します。"
+                  />
+
+                  <RangeSlider
+                    className="w-full"
+                    label="Step"
+                    min={10}
+                    max={50}
+                    value={step}
+                    onChange={setStep}
+                    help="画像生成の反復回数です。Step 数が多いほど画像が洗練されますが、生成に時間がかかります。"
+                  />
+
+                  {generationMode === GENERATION_MODES.IMAGE_VARIATION && (
+                    <RangeSlider
+                      className="w-full"
+                      label="ImageStrength"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={imageStrength}
+                      onChange={setImageStrength}
+                      help="1に近いほど「初期画像」に近い画像が生成され、0に近いほど「初期画像」とは異なる画像が生成されます。"
+                    />
+                  )}
+                  {generationMode === 'IMAGE_CONDITIONING' && (
+                    <RangeSlider
+                      className="w-full"
+                      label="ControlStrength"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={controlStrength}
+                      onChange={setControlStrength}
+                      help="1に近いほど「参照画像」の構図に基づいた画像が生成され、0に近いほど「参照画像」の構図とは異なる画像が生成されます。"
+                    />
+                  )}
+                </div>
+              )}
             </div>
           </ExpandableField>
 
@@ -995,13 +1198,20 @@ const GenerateImagePage: React.FC = () => {
               }}
               loading={generating || loadingChat}
               disabled={
-                prompt.length === 0 ||
+                (generationMode !==
+                  AMAZON_ADVANCED_GENERATION_MODE.BACKGROUND_REMOVAL &&
+                  prompt.length === 0) ||
                 (generationMode !== GENERATION_MODES.TEXT_IMAGE &&
+                  generationMode !==
+                    AMAZON_ADVANCED_GENERATION_MODE.COLOR_GUIDED_GENERATION &&
                   !initImage.imageBase64) ||
                 ((generationMode === GENERATION_MODES.INPAINTING ||
                   generationMode === GENERATION_MODES.OUTPAINTING) &&
                   !maskImage.imageBase64 &&
-                  !maskPrompt)
+                  !maskPrompt) ||
+                (generationMode ===
+                  AMAZON_ADVANCED_GENERATION_MODE.COLOR_GUIDED_GENERATION &&
+                  !colors)
               }>
               生成
             </Button>

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -8,6 +8,7 @@ import Select from '../components/Select';
 import ExpandableField from '../components/ExpandableField';
 import ButtonIcon from '../components/ButtonIcon';
 import { PiFileArrowUp, PiDiceFive, PiNotePencil } from 'react-icons/pi';
+import { MdDeleteOutline } from 'react-icons/md';
 import useImage from '../hooks/useImage';
 import GenerateImageAssistant from '../components/GenerateImageAssistant';
 import SketchPad, { Canvas } from '../components/SketchPad';
@@ -28,6 +29,7 @@ import {
   AmazonUIImageGenerationMode,
   ControlMode,
 } from 'generative-ai-use-cases-jp';
+import InputText from '../components/InputText';
 
 const MAX_SAMPLE = 7;
 
@@ -546,6 +548,9 @@ const GenerateImagePage: React.FC = () => {
   const [width, height] = useMemo(() => {
     return resolution.label.split('x').map((v) => Number(v));
   }, [resolution]);
+  const [colorList, setColorList] = useState<string[]>(
+    colors.split(',').map((color) => color.trim())
+  );
 
   const maskMode = useMemo(() => {
     return (
@@ -1105,15 +1110,83 @@ const GenerateImagePage: React.FC = () => {
                   />
                 )}
                 {generationMode === 'COLOR_GUIDED_GENERATION' && (
-                  <Select
-                    label="カラーパレット"
-                    help="生成画像の色合いを指定指定します。"
-                    options={colorsOptions}
-                    value={colors}
-                    onChange={setColors}
-                    fullWidth
-                    showColorChips
-                  />
+                  <div className="space-y-4">
+                    <div>
+                      <Select
+                        label="プリセットパレット"
+                        help="プリセットのカラーパレットから選択できます"
+                        options={colorsOptions}
+                        value={
+                          colorsOptions.find(
+                            (option) => option.value === colors
+                          )?.value || ''
+                        }
+                        onChange={(value) => {
+                          const newColors = value
+                            .split(',')
+                            .map((color) => color.trim());
+                          setColorList(newColors);
+                          setColors(value);
+                        }}
+                        fullWidth
+                        showColorChips
+                      />
+                    </div>
+
+                    <div>
+                      <label className="text-sm font-bold">
+                        カスタムカラー
+                      </label>
+                      <div className="mt-2 space-y-2">
+                        {colorList.map((color, index) => (
+                          <div key={index} className="flex items-center gap-2">
+                            <input
+                              type="color"
+                              value={color}
+                              onChange={(e) => {
+                                const newColors = [...colorList];
+                                newColors[index] = e.target.value;
+                                setColorList(newColors);
+                                setColors(newColors.join(','));
+                              }}
+                              className="h-8 w-8 bg-white"
+                            />
+                            <InputText
+                              value={color}
+                              onChange={(value) => {
+                                const newColors = [...colorList];
+                                newColors[index] = value;
+                                setColorList(newColors);
+                                setColors(newColors.join(','));
+                              }}
+                              className="w-24"
+                            />
+                            <ButtonIcon
+                              onClick={() => {
+                                const newColors = colorList.filter(
+                                  (_, i) => i !== index
+                                );
+                                setColorList(newColors);
+                                setColors(newColors.join(','));
+                              }}>
+                              <MdDeleteOutline />
+                            </ButtonIcon>
+                          </div>
+                        ))}
+
+                        <Button
+                          onClick={() => {
+                            const newColors = [...colorList, '#000000'];
+                            setColorList(newColors);
+                            setColors(newColors.join(','));
+                          }}
+                          className="mt-2"
+                          disabled={colorList.length >= 5}>
+                          カラーを追加
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
                 )}
                 {generationMode === 'IMAGE_CONDITIONING' && (
                   <Select


### PR DESCRIPTION
## 変更内容の説明
画像生成 Titan v2 と Amazon Nova Canvas の新しい 3 つの機能に対応。
画像コンディショニング、カラーパレットによる画像ガイダンス、背景の削除。
https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-image.html
https://docs.aws.amazon.com/nova/latest/userguide/image-gen-access.html

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
関連する Issue を可能な限り挙げてください。
[756](https://github.com/aws-samples/generative-ai-use-cases-jp/issues/756)

複雑な conflict 対応のため、過去の [PR](https://github.com/aws-samples/generative-ai-use-cases-jp/pull/603) を使用して新規ブランチで実装しております。