### PR TITLE
画像生成 Stable Diffusion 3.5 Large への対応

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -490,7 +490,8 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
 "stability.stable-diffusion-xl-v1",
 "stability.sd3-large-v1:0",
 "stability.stable-image-core-v1:0",
-"stability.stable-image-ultra-v1:0"
+"stability.stable-image-ultra-v1:0",
+"stability.sd3-5-large-v1:0"
 ```
 
 **指定したリージョンで指定したモデルが有効化されているかご確認ください。**
@@ -544,7 +545,8 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
     "stability.stable-diffusion-xl-v1",
     "stability.sd3-large-v1:0",
     "stability.stable-image-core-v1:0",
-    "stability.stable-image-ultra-v1:0"
+    "stability.stable-image-ultra-v1:0",
+    "stability.sd3-5-large-v1:0"
   ],
 ```
 ### cross-region inference が対応しているモデルで us(北部バージニアもしくはオレゴン) の Amazon Bedrock のモデルを利用する場合
@@ -577,7 +579,8 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
     "stability.stable-diffusion-xl-v1",
     "stability.sd3-large-v1:0",
     "stability.stable-image-core-v1:0",
-    "stability.stable-image-ultra-v1:0"
+    "stability.stable-image-ultra-v1:0",
+    "stability.sd3-5-large-v1:0"
   ],
 ```
 

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -1026,6 +1026,10 @@ export const BEDROCK_IMAGE_GEN_MODELS: {
     createBodyImage: createBodyImageStabilityAI2024Model,
     extractOutputImage: extractOutputImageStabilityAI2024Model,
   },
+  'stability.sd3-5-large-v1:0': {
+    createBodyImage: createBodyImageStabilityAI2024Model,
+    extractOutputImage: extractOutputImageStabilityAI2024Model,
+  },
   'amazon.titan-image-generator-v1': {
     createBodyImage: createBodyImageAmazonGeneralImage,
     extractOutputImage: extractOutputImageAmazonImage,

--- a/packages/common/src/model.ts
+++ b/packages/common/src/model.ts
@@ -68,6 +68,7 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
   'stability.sd3-large-v1:0': MODEL_FEATURE.IMAGE_GEN,
   'stability.stable-image-core-v1:0': MODEL_FEATURE.IMAGE_GEN,
   'stability.stable-image-ultra-v1:0': MODEL_FEATURE.IMAGE_GEN,
+  'stability.sd3-5-large-v1:0': MODEL_FEATURE.IMAGE_GEN,
   // Amazon Image Gen
   'amazon.titan-image-generator-v2:0': MODEL_FEATURE.IMAGE_GEN,
   'amazon.titan-image-generator-v1': MODEL_FEATURE.IMAGE_GEN,

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -1045,6 +1045,7 @@ const GenerateImagePage: React.FC = () => {
                     setGenerationMode(v as AmazonUIImageGenerationMode)
                   }
                   fullWidth
+                  help="TEXT_IMAGE:テキストから画像を生成します。IMAGE_VARIATION:参照画像から類似画像を生成します。INPAINTING:画像の一部を編集します。OUTPAINTING:画像を拡張します。IMAGE_CONDITIONING:構図を反映します。COLOR_GUIDED_GENERATION:配色指定で生成します。BACKGROUND_REMOVAL:背景を除去します"
                 />
                 <div className="mb-2 flex flex-row justify-center gap-2 lg:flex-col xl:flex-row">
                   {generationMode !== GENERATION_MODES.TEXT_IMAGE && (

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -43,6 +43,7 @@ const STABILITY_AI_MODELS = {
   SD3_LARGE: 'stability.sd3-large-v1:0',
   STABLE_IMAGE_CORE: 'stability.stable-image-core-v1:0',
   STABLE_IMAGE_ULTRA: 'stability.stable-image-ultra-v1:0',
+  SD3_5: 'stability.sd3-5-large-v1:0',
 };
 const GENERATION_MODES: Record<
   AmazonBaseImageGenerationMode,
@@ -104,6 +105,13 @@ const modelInfo: Record<string, ModelInfo<'base' | 'advanced'>> = {
   },
   [STABILITY_AI_MODELS.STABLE_IMAGE_ULTRA]: {
     supportedModes: [GENERATION_MODES.TEXT_IMAGE],
+    resolutionPresets: stabilityAi2024ModelPresets,
+  },
+  [STABILITY_AI_MODELS.SD3_5]: {
+    supportedModes: [
+      GENERATION_MODES.TEXT_IMAGE,
+      GENERATION_MODES.IMAGE_VARIATION,
+    ],
     resolutionPresets: stabilityAi2024ModelPresets,
   },
   [AMAZON_MODELS.TITAN_V1]: {


### PR DESCRIPTION
## 変更内容の説明
- us-west-2 のみ対応しております。以下のように cdk.json を変更して確認お願いします。
```
"modelRegion": "us-west-2",
"imageGenerationModelIds": [
  "stability.sd3-5-large-v1:0",
]
```

- 別タスクですが、GenerationMode の説明 Tooltip も追加しております。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
#793 