### PR TITLE
[ユースケースビルダー] 対応が必要なメニューにドットを表示

### DIFF
--- a/packages/web/src/pages/useCaseBuilder/UseCaseBuilderEditPage.tsx
+++ b/packages/web/src/pages/useCaseBuilder/UseCaseBuilderEditPage.tsx
@@ -7,7 +7,14 @@ import { create } from 'zustand';
 import RowItem from '../../components/RowItem';
 import AppBuilderView from '../../components/useCaseBuilder/UseCaseBuilderView';
 import InputText from '../../components/InputText';
-import { PiPlus, PiQuestion, PiTrash, PiEye, PiX } from 'react-icons/pi';
+import {
+  PiPlus,
+  PiQuestion,
+  PiTrash,
+  PiEye,
+  PiX,
+  PiCircleFill,
+} from 'react-icons/pi';
 import useMyUseCases from '../../hooks/useCaseBuilder/useMyUseCases';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import useUseCase from '../../hooks/useCaseBuilder/useUseCase';
@@ -272,6 +279,23 @@ const UseCaseBuilderEditPage: React.FC = () => {
 
   const [currentMenu, setCurrentMenu] = useState(menu[0]);
 
+  const dottedMenu = useMemo(() => {
+    const errorMenu = [...createErrorMessages, ...updateErrorMessages]
+      .map((e) => e.menu)
+      .filter((elem, idx, self) => self.indexOf(elem) === idx);
+
+    if (errorMenu.length > 0) {
+      return errorMenu;
+    } else {
+      // エラーがない場合は「更新」「作成」にドットを表示
+      if (isUpdate) {
+        return ['更新'];
+      } else {
+        return ['作成'];
+      }
+    }
+  }, [createErrorMessages, updateErrorMessages, isUpdate]);
+
   // ページタイトルの設定
   useEffect(() => {
     setPageTitle(isUpdate ? 'ユースケース編集' : 'ユースケース新規作成');
@@ -359,6 +383,7 @@ const UseCaseBuilderEditPage: React.FC = () => {
         .then(() => {
           // DB変更直後は更新ボタンをDisabledにする
           setIsDisabledUpdate(true);
+          setCurrentMenu(menu[0]);
         })
         .finally(() => {
           setIsPosting(false);
@@ -399,6 +424,7 @@ const UseCaseBuilderEditPage: React.FC = () => {
     useCaseId,
     fixedModelId,
     fileUpload,
+    menu,
   ]);
 
   const onClickDelete = useCallback(() => {
@@ -452,22 +478,32 @@ const UseCaseBuilderEditPage: React.FC = () => {
               return (
                 <div
                   key={idx}
-                  className={`text-aws-smile border-aws-smile cursor-pointer border-b-2 px-2 py-2 text-sm font-bold lg:border-b-0 lg:border-r-2`}
+                  className={`text-aws-smile border-aws-smile flex cursor-pointer flex-row border-b-2 px-2 py-2 text-sm font-bold lg:border-b-0 lg:border-r-2`}
                   onClick={() => {
                     setCurrentMenu(m);
                   }}>
                   {m}
+                  {dottedMenu.includes(m) && (
+                    <div className="ml-0.5">
+                      <PiCircleFill className="text-aws-smile text-[6px]" />
+                    </div>
+                  )}
                 </div>
               );
             } else {
               return (
                 <div
                   key={idx}
-                  className={`hover:text-aws-smile cursor-pointer border-b-2 border-gray-200 px-2 py-2 text-sm text-gray-800 lg:border-b-0 lg:border-r-2`}
+                  className={`hover:text-aws-smile flex cursor-pointer flex-row border-b-2 border-gray-200 px-2 py-2 text-sm text-gray-800 lg:border-b-0 lg:border-r-2`}
                   onClick={() => {
                     setCurrentMenu(m);
                   }}>
                   {m}
+                  {dottedMenu.includes(m) && (
+                    <div className="ml-0.5">
+                      <PiCircleFill className="text-aws-smile text-[6px]" />
+                    </div>
+                  )}
                 </div>
               );
             }


### PR DESCRIPTION
## 変更内容の説明
- 以前の挙動では更新時に「更新」メニューにとどまるため、更新完了時に急に「更新内容がありません」と表示されて意味が分かりにくかった
- 更新完了時にアプリ定義メニューに遷移するように変更した
- ミニマムでどこの作業が必要なのかわかりにくいので、対応が必要なメニューにドットを表示するようにした
- エラーがない場合 (作成・更新が可能な場合) は作成・更新メニューにドットを表示するようにした。

## チェック項目
- [x] npm run lint を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み

## 関連する Issue
なし
