### PR TITLE
画像生成ドキュメント修正 & Stablity AI モデル新バージョン追加

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -703,14 +703,16 @@ const envs: Record<string, Partial<StackInput>> = {
 このソリューションが対応している画像生成モデルは以下です。
 
 ```
+"amazon.nova-canvas-v1:0",
 "amazon.titan-image-generator-v2:0",
 "amazon.titan-image-generator-v1",
-"amazon.nova-canvas-v1:0",
-"stability.stable-diffusion-xl-v1",
 "stability.sd3-large-v1:0",
-"stability.stable-image-core-v1:0",
-"stability.stable-image-ultra-v1:0",
 "stability.sd3-5-large-v1:0"
+"stability.stable-image-core-v1:0",
+"stability.stable-image-core-v1:1",
+"stability.stable-image-ultra-v1:0",
+"stability.stable-image-ultra-v1:1",
+"stability.stable-diffusion-xl-v1",
 ```
 
 **指定したリージョンで指定したモデルが有効化されているかご確認ください。**
@@ -738,9 +740,9 @@ const envs: Record<string, Partial<StackInput>> = {
       "mistral.mistral-large-2402-v1:0"
     ],
     imageGenerationModelIds: [
+      "amazon.nova-canvas-v1:0",
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
-      "amazon.nova-canvas-v1:0",
       "stability.stable-diffusion-xl-v1"
     ],
   },
@@ -768,9 +770,9 @@ const envs: Record<string, Partial<StackInput>> = {
       "mistral.mistral-large-2402-v1:0"
     ],
     "imageGenerationModelIds": [
+      "amazon.nova-canvas-v1:0",
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
-      "amazon.nova-canvas-v1:0",
       "stability.stable-diffusion-xl-v1"
     ],
   }
@@ -784,7 +786,7 @@ const envs: Record<string, Partial<StackInput>> = {
 // parameter.ts
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
-    modelRegion: 'us-east-1',
+    modelRegion: 'us-east-2',
     modelIds: [
       "anthropic.claude-3-5-sonnet-20241022-v2:0",
       "anthropic.claude-3-5-haiku-20241022-v1:0",
@@ -801,11 +803,13 @@ const envs: Record<string, Partial<StackInput>> = {
     imageGenerationModelIds: [
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
-      "stability.stable-diffusion-xl-v1",
       "stability.sd3-large-v1:0",
-      "stability.stable-image-core-v1:0",
-      "stability.stable-image-ultra-v1:0",
       "stability.sd3-5-large-v1:0"
+      "stability.stable-image-core-v1:0",
+      "stability.stable-image-core-v1:1",
+      "stability.stable-image-ultra-v1:0",
+      "stability.stable-image-ultra-v1:1",
+      "stability.stable-diffusion-xl-v1",
     ],
   },
 };
@@ -833,11 +837,13 @@ const envs: Record<string, Partial<StackInput>> = {
     "imageGenerationModelIds": [
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
-      "stability.stable-diffusion-xl-v1",
       "stability.sd3-large-v1:0",
-      "stability.stable-image-core-v1:0",
-      "stability.stable-image-ultra-v1:0",
       "stability.sd3-5-large-v1:0"
+      "stability.stable-image-core-v1:0",
+      "stability.stable-image-core-v1:1",
+      "stability.stable-image-ultra-v1:0",
+      "stability.stable-image-ultra-v1:1",
+      "stability.stable-diffusion-xl-v1",
     ],
   }
 }
@@ -850,7 +856,7 @@ const envs: Record<string, Partial<StackInput>> = {
 // parameter.ts
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
-    modelRegion: 'us-east-1',
+    modelRegion: 'us-east-2',
     modelIds: [
       "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
       "us.anthropic.claude-3-5-haiku-20241022-v1:0",
@@ -875,11 +881,13 @@ const envs: Record<string, Partial<StackInput>> = {
     imageGenerationModelIds: [
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
-      "stability.stable-diffusion-xl-v1",
       "stability.sd3-large-v1:0",
-      "stability.stable-image-core-v1:0",
-      "stability.stable-image-ultra-v1:0",
       "stability.sd3-5-large-v1:0"
+      "stability.stable-image-core-v1:0",
+      "stability.stable-image-core-v1:1",
+      "stability.stable-image-ultra-v1:0",
+      "stability.stable-image-ultra-v1:1",
+      "stability.stable-diffusion-xl-v1",
     ],
   },
 };
@@ -915,11 +923,13 @@ const envs: Record<string, Partial<StackInput>> = {
     "imageGenerationModelIds": [
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
-      "stability.stable-diffusion-xl-v1",
       "stability.sd3-large-v1:0",
-      "stability.stable-image-core-v1:0",
-      "stability.stable-image-ultra-v1:0",
       "stability.sd3-5-large-v1:0"
+      "stability.stable-image-core-v1:0",
+      "stability.stable-image-core-v1:1",
+      "stability.stable-image-ultra-v1:0",
+      "stability.stable-image-ultra-v1:1",
+      "stability.stable-diffusion-xl-v1",
     ],
   }
 }

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -705,6 +705,7 @@ const envs: Record<string, Partial<StackInput>> = {
 ```
 "amazon.titan-image-generator-v2:0",
 "amazon.titan-image-generator-v1",
+"amazon.nova-canvas-v1:0",
 "stability.stable-diffusion-xl-v1",
 "stability.sd3-large-v1:0",
 "stability.stable-image-core-v1:0",

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -1030,7 +1030,15 @@ export const BEDROCK_IMAGE_GEN_MODELS: {
     createBodyImage: createBodyImageStabilityAI2024Model,
     extractOutputImage: extractOutputImageStabilityAI2024Model,
   },
+  'stability.stable-image-core-v1:1': {
+    createBodyImage: createBodyImageStabilityAI2024Model,
+    extractOutputImage: extractOutputImageStabilityAI2024Model,
+  },
   'stability.stable-image-ultra-v1:0': {
+    createBodyImage: createBodyImageStabilityAI2024Model,
+    extractOutputImage: extractOutputImageStabilityAI2024Model,
+  },
+  'stability.stable-image-ultra-v1:1': {
     createBodyImage: createBodyImageStabilityAI2024Model,
     extractOutputImage: extractOutputImageStabilityAI2024Model,
   },

--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -113,7 +113,9 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
   'stability.stable-diffusion-xl-v1': MODEL_FEATURE.IMAGE_GEN,
   'stability.sd3-large-v1:0': MODEL_FEATURE.IMAGE_GEN,
   'stability.stable-image-core-v1:0': MODEL_FEATURE.IMAGE_GEN,
+  'stability.stable-image-core-v1:1': MODEL_FEATURE.IMAGE_GEN,
   'stability.stable-image-ultra-v1:0': MODEL_FEATURE.IMAGE_GEN,
+  'stability.stable-image-ultra-v1:1': MODEL_FEATURE.IMAGE_GEN,
   'stability.sd3-5-large-v1:0': MODEL_FEATURE.IMAGE_GEN,
   // Amazon Image Gen
   'amazon.titan-image-generator-v2:0': MODEL_FEATURE.IMAGE_GEN,

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -41,8 +41,10 @@ const AMAZON_MODELS = {
 const STABILITY_AI_MODELS = {
   STABLE_DIFFUSION_XL: 'stability.stable-diffusion-xl-v1',
   SD3_LARGE: 'stability.sd3-large-v1:0',
-  STABLE_IMAGE_CORE: 'stability.stable-image-core-v1:0',
-  STABLE_IMAGE_ULTRA: 'stability.stable-image-ultra-v1:0',
+  STABLE_IMAGE_CORE1_0: 'stability.stable-image-core-v1:0',
+  STABLE_IMAGE_CORE1_1: 'stability.stable-image-core-v1:1',
+  STABLE_IMAGE_ULTRA1_0: 'stability.stable-image-ultra-v1:0',
+  STABLE_IMAGE_ULTRA1_1: 'stability.stable-image-ultra-v1:1',
   SD3_5: 'stability.sd3-5-large-v1:0',
 };
 const GENERATION_MODES: Record<
@@ -99,11 +101,19 @@ const modelInfo: Record<string, ModelInfo<'base' | 'advanced'>> = {
     ],
     resolutionPresets: stabilityAi2024ModelPresets,
   },
-  [STABILITY_AI_MODELS.STABLE_IMAGE_CORE]: {
+  [STABILITY_AI_MODELS.STABLE_IMAGE_CORE1_0]: {
     supportedModes: [GENERATION_MODES.TEXT_IMAGE],
     resolutionPresets: stabilityAi2024ModelPresets,
   },
-  [STABILITY_AI_MODELS.STABLE_IMAGE_ULTRA]: {
+  [STABILITY_AI_MODELS.STABLE_IMAGE_CORE1_1]: {
+    supportedModes: [GENERATION_MODES.TEXT_IMAGE],
+    resolutionPresets: stabilityAi2024ModelPresets,
+  },
+  [STABILITY_AI_MODELS.STABLE_IMAGE_ULTRA1_0]: {
+    supportedModes: [GENERATION_MODES.TEXT_IMAGE],
+    resolutionPresets: stabilityAi2024ModelPresets,
+  },
+  [STABILITY_AI_MODELS.STABLE_IMAGE_ULTRA1_1]: {
     supportedModes: [GENERATION_MODES.TEXT_IMAGE],
     resolutionPresets: stabilityAi2024ModelPresets,
   },


### PR DESCRIPTION
## 変更内容の説明
- 画像ソリューション対応に Canvas, SD 系モデルが漏れていたため追加
- 新バージョン (stability.stable-image-ultra-v1:1, stability.stable-image-core-v1:1) 追加
  - こちらの[リンク](https://docs.aws.amazon.com/ja_jp/bedrock/latest/userguide/models-supported.html)の順番に並べてます。PR の際にご活用ください。
## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
関連する Issue を可能な限り挙げてください。
