### PR TITLE
【ダイアグラム生成】Readmeの修正とその他の細かな修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Generative AI（生成 AI）は、ビジネスの変革に革新的な可能性�
   ダイアグラム生成は、あらゆるトピックに関する文章や内容を最適な図を用いて視覚化します。
   テキストベースで簡単に図を生成でき、プログラマーやデザイナーでなくても効率的にフローチャートなどの図を作成できます。
 
-  <img src="/imgs/usecase_generate_diagram.gif"/>
+  <img src="./docs/assets/images/usecase_generate_diagram.gif"/>
 </details>
 
 ## ユースケースビルダー

--- a/packages/web/src/hooks/useDiagram.ts
+++ b/packages/web/src/hooks/useDiagram.ts
@@ -35,21 +35,11 @@ const useDiagram = (id: string) => {
     getModelId,
     setModelId,
     setLoading,
-    loadingMessages,
-    init,
     clear,
     updateSystemContext,
-    updateSystemContextByModel,
-    getCurrentSystemContext,
-    pushMessage,
-    popMessage,
-    rawMessages,
     messages,
     isEmpty,
     postChat,
-    continueGeneration,
-    sendFeedback,
-    getStopReason,
   } = useChat(id);
 
   const modelId = useMemo(() => getModelId(), [getModelId]);
@@ -104,7 +94,7 @@ const useDiagram = (id: string) => {
           messages: [
             {
               role: 'system',
-              content: prompter.diagramPrompt({ determinType: true }),
+              content: prompter.diagramPrompt({ determineType: true }),
             },
             {
               role: 'user',
@@ -143,7 +133,7 @@ const useDiagram = (id: string) => {
 
         // 3. 決定したダイアグラムタイプのシステムプロンプトを設定
         const systemPrompt = prompter.diagramPrompt({
-          determinType: false,
+          determineType: false,
           diagramType: chosenType,
         });
         updateSystemContext(systemPrompt);
@@ -163,21 +153,9 @@ const useDiagram = (id: string) => {
     getModelId,
     setModelId,
     setLoading,
-    loadingMessages,
-    init,
     clear,
-    updateSystemContext,
-    updateSystemContextByModel,
-    getCurrentSystemContext,
-    pushMessage,
-    popMessage,
-    rawMessages,
     messages,
     isEmpty,
-    postChat,
-    continueGeneration,
-    sendFeedback,
-    getStopReason,
     postDiagram,
     diagramType,
   };

--- a/packages/web/src/prompts/claude.ts
+++ b/packages/web/src/prompts/claude.ts
@@ -747,7 +747,7 @@ XXX
     ];
   },
   diagramPrompt(params: DiagramParams): string {
-    if (params.determinType)
+    if (params.determineType)
       return `<instruction>
 あなたは図の種類を決定する専門家です。以下の手順に従って、与えられた<content></content>タグ内の情報を分析し、最適な図の種類を選択してください。
 重要: ユーザーが特定の図を作成したいようであればそれを選択してください。これは絶対です。日本語で特定の図を指定されるので、その場合はその特定の図の日本語を英語にして考えてください。

--- a/packages/web/src/prompts/index.ts
+++ b/packages/web/src/prompts/index.ts
@@ -60,7 +60,7 @@ export type SetTitleParams = {
 };
 
 export type DiagramParams = {
-  determinType: boolean;
+  determineType: boolean;
   diagramType?: string;
 };
 


### PR DESCRIPTION
## 変更内容の説明
- Readmeでダイアグラム生成動画のパスを修正し忘れていて動画が映っていなかったのでパスの修正。
- typoの修正
- useDiagram.tsの不必要なimportの削除

修正し忘れていたところがあったので変更です。再度レビューお願いします!

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
関連する Issue を可能な限り挙げてください。
