### PR TITLE
[ユースケースビルダー] 続きを出力ボタンの設置

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -143,7 +143,9 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
     setLoading,
     messages,
     postChat,
+    continueGeneration,
     clear: clearChat,
+    getStopReason,
   } = useChat(pathname);
   const modelId = useMemo(() => {
     if (props.fixedModelId !== '') {
@@ -166,6 +168,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
     errorMessages: fileErrorMessages,
     clear: clearFiles,
   } = useFiles();
+  const stopReason = getStopReason();
   const [isOver, setIsOver] = useState(false);
 
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
@@ -633,6 +636,10 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
           )}
         </div>
         <div className="flex shrink-0 gap-3 ">
+          {stopReason === 'max_tokens' && (
+            <Button onClick={continueGeneration}>続きを出力</Button>
+          )}
+
           <Button
             outlined
             onClick={onClickClear}


### PR DESCRIPTION
## 変更内容の説明
ユースケースビルダーの出力が途中で止まった際、続きを出力できるようにした。
動作確認は https://github.com/aws-samples/generative-ai-use-cases-jp/blob/main/packages/cdk/lambda/utils/models.ts#L89 を 100 などに絞って行ってください。

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/807
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/785
