### PR TITLE
ユーザーの入力もインデント等が正常に描写されるように修正

### DIFF
--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -208,11 +208,7 @@ const ChatMessage: React.FC<Props> = (props) => {
               </div>
             )}
             {chatContent?.role === 'user' && (
-              <div className="break-all">
-                {typingTextOutput.split('\n').map((c, idx) => (
-                  <div key={idx}>{c}</div>
-                ))}
-              </div>
+              <div className="whitespace-pre-wrap">{typingTextOutput}</div>
             )}
             {chatContent?.role === 'assistant' && (
               <Markdown prefix={`${props.idx}`}>

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -221,11 +221,7 @@ const ChatMessage: React.FC<Props> = (props) => {
               </Markdown>
             )}
             {chatContent?.role === 'system' && (
-              <div className="break-all">
-                {typingTextOutput.split('\n').map((c, idx) => (
-                  <div key={idx}>{c}</div>
-                ))}
-              </div>
+              <div className="whitespace-pre-wrap">{typingTextOutput}</div>
             )}
             {props.loading && (chatContent?.content ?? '') === '' && (
               <div className="animate-pulse">▍</div>


### PR DESCRIPTION
## 変更内容の説明
今までの 改行 + break-all 方式から whitespace-pre-wrap に変更。

正常にコードがインデントされている様子
![スクリーンショット 2025-01-30 11 21 54](https://github.com/user-attachments/assets/3d465f10-997c-4390-bbe2-707d8966853f)

長い文章では折り返される
![スクリーンショット 2025-01-30 11 33 11](https://github.com/user-attachments/assets/8359fd45-7e26-4817-8d29-9232732fbd5f)

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
なし
