### PR TITLE
特定のユースケースを非表示にすることを可能にするオプション

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ npm run cdk:deploy:quick
   - [Flow チャットユースケースの有効化](./docs/DEPLOY_OPTION.md#flow-チャットユースケースの有効化)
   - [映像分析ユースケースの有効化](./docs/DEPLOY_OPTION.md#映像分析ユースケースの有効化)
   - [プロンプト最適化ツールの有効化](./docs/DEPLOY_OPTION.md#プロンプト最適化ツールの有効化)
+  - [特定のユースケースを非表示にする](./docs/DEPLOY_OPTION.md#特定のユースケースを非表示にする)
 - [ユースケースビルダーの設定](./docs/DEPLOY_OPTION.md#ユースケースビルダーの設定)
 - [Amazon Bedrock のモデルを変更する](./docs/DEPLOY_OPTION.md#amazon-bedrock-のモデルを変更する)
   - [us-east-1 (バージニア) の Amazon Bedrock のモデルを利用する例](./docs/DEPLOY_OPTION.md#us-east-1-バージニア-の-amazon-bedrock-のモデルを利用する例)

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -618,6 +618,49 @@ const envs: Record<string, Partial<StackInput>> = {
 
 Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-management-optimize.html) をご参照ください。
 
+### 特定のユースケースを非表示にする
+
+以下のオプションで指定できるユースケースは非表示にできます。
+特に指定がない場合や false を指定した場合は表示されます。
+
+**[parameter.ts](/packages/cdk/parameter.ts) を編集**
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    hiddenUseCases: {
+      generate: true, // 文章生成を非表示
+      summarize: true, // 要約を非表示
+      editorial: true, // 校正を非表示
+      translate: true, // 翻訳を非表示
+      webContent: true, // Web コンテンツ抽出を非表示
+      image: true, // 画像生成を非表示
+      video: true, // 映像分析を非表示
+      diagram: true, // ダイアグラム生成を非表示
+    }
+  },
+};
+```
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+```json
+// cdk.json
+{
+  "context": {
+    "hiddenUseCases": {
+      "generate": true,
+      "summarize": true,
+      "editorial": true,
+      "translate": true,
+      "webContent": true,
+      "image": true,
+      "video": true,
+      "diagram": true
+    }
+  }
+}
+```
+
 ## ユースケースビルダーの設定
 
 ユースケースビルダーはデフォルトで有効化されており、デプロイ後画面上に表示される「ビルダーモード」という項目から利用できます。ユースケースビルダーを無効化する場合は、パラメータの `useCaseBuilderEnabled` に `false` を指定します。(デフォルトは `true`)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,6 +53,7 @@ export VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME=<SAML Cognito Prov
 export VITE_APP_AGENT_NAMES=<Bedrock Agent Names の JSON Array>
 export VITE_APP_USE_CASE_BUILDER_ENABLED=<UseCase Builder Flag>
 export VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN=<Function ARN>
+export VITE_APP_HIDDEN_USE_CASES=<非表示メニューの設定 JSON>
 ```
 
 具体例は以下です。
@@ -77,6 +78,7 @@ export VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME=EntraID
 export VITE_APP_AGENT_NAMES=["SearchEngine"]
 export VITE_APP_USE_CASE_BUILDER_ENABLED=true
 export VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN=arn:aws:lambda:ap-northeast-1:000000000000:function:FunctionName
+export VITE_APP_HIDDEN_USE_CASES={}
 ```
 
 #### `.env` ファイルを利用する方法

--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -36,6 +36,7 @@
     "samlAuthEnabled": false,
     "samlCognitoDomainName": "",
     "samlCognitoFederatedIdentityProviderName": "",
+    "hiddenUseCases": {},
     "modelRegion": "us-east-1",
     "modelIds": [
       "us.anthropic.claude-3-5-sonnet-20241022-v2:0",

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -10,7 +10,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
-import { Flow } from 'generative-ai-use-cases-jp';
+import { Flow, HiddenUseCases } from 'generative-ai-use-cases-jp';
 
 export interface WebProps {
   apiEndpointUrl: string;
@@ -39,6 +39,7 @@ export interface WebProps {
   domainName?: string | null;
   hostedZoneId?: string | null;
   useCaseBuilderEnabled: boolean;
+  hiddenUseCases: HiddenUseCases;
 }
 
 export class Web extends Construct {
@@ -186,6 +187,7 @@ export class Web extends Construct {
         VITE_APP_AGENT_NAMES: JSON.stringify(props.agentNames),
         VITE_APP_USE_CASE_BUILDER_ENABLED:
           props.useCaseBuilderEnabled.toString(),
+        VITE_APP_HIDDEN_USE_CASES: JSON.stringify(props.hiddenUseCases),
       },
     });
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -129,6 +129,8 @@ export class GenerativeAiUseCasesStack extends Stack {
       endpointNames: api.endpointNames,
       agentNames: api.agentNames,
       useCaseBuilderEnabled: params.useCaseBuilderEnabled,
+      // Frontend
+      hiddenUseCases: params.hiddenUseCases,
       // Custom Domain
       cert: props.cert,
       hostName: params.hostName,
@@ -279,6 +281,10 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     new CfnOutput(this, 'UseCaseBuilderEnabled', {
       value: params.useCaseBuilderEnabled.toString(),
+    });
+
+    new CfnOutput(this, 'HiddenUseCases', {
+      value: JSON.stringify(params.hiddenUseCases),
     });
 
     this.userPool = auth.userPool;

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -13,6 +13,19 @@ export const stackInputSchema = z.object({
   samlAuthEnabled: z.boolean().default(false),
   samlCognitoDomainName: z.string().nullish(),
   samlCognitoFederatedIdentityProviderName: z.string().nullish(),
+  // Frontend
+  hiddenUseCases: z
+    .object({
+      generate: z.boolean().optional(),
+      summarize: z.boolean().optional(),
+      editorial: z.boolean().optional(),
+      translate: z.boolean().optional(),
+      webContent: z.boolean().optional(),
+      image: z.boolean().optional(),
+      video: z.boolean().optional(),
+      diagram: z.boolean().optional(),
+    })
+    .default({}),
   // API
   modelRegion: z.string().default('us-east-1'),
   modelIds: z

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -1958,6 +1958,9 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
     "Flows": {
       "Value": "W10=",
     },
+    "HiddenUseCases": {
+      "Value": "{}",
+    },
     "IdPoolId": {
       "Value": {
         "Ref": "AuthIdentityPool659E7F64",
@@ -11874,6 +11877,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "Arn",
             ],
           },
+          "VITE_APP_HIDDEN_USE_CASES": "{}",
           "VITE_APP_IDENTITY_POOL_ID": {
             "Ref": "AuthIdentityPool659E7F64",
           },

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -12,3 +12,4 @@ export * from './useCaseBuilder';
 export * from './protocolUseCaseBuilder';
 export * from './model';
 export * from './rag-knowledge-base';
+export * from './useCases';

--- a/packages/types/src/useCases.d.ts
+++ b/packages/types/src/useCases.d.ts
@@ -1,0 +1,12 @@
+export type HiddenUseCases = {
+  generate?: boolean;
+  summarize?: boolean;
+  editorial?: boolean;
+  translate?: boolean;
+  webContent?: boolean;
+  image?: boolean;
+  video?: boolean;
+  diagram?: boolean;
+};
+
+export type HiddenUseCasesKeys = keyof HiddenUseCases;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -31,6 +31,7 @@ import useInterUseCases from './hooks/useInterUseCases';
 import { MODELS } from './hooks/useModel';
 import useScreen from './hooks/useScreen';
 import { optimizePromptEnabled } from './hooks/useOptimizePrompt';
+import useUseCases from './hooks/useUseCases';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const ragKnowledgeBaseEnabled: boolean =
@@ -46,125 +47,6 @@ const getFlows = () => {
 };
 const flows = getFlows();
 const flowChatEnabled: boolean = flows.length > 0;
-
-const items: ItemProps[] = [
-  {
-    label: 'ホーム',
-    to: '/',
-    icon: <PiHouse />,
-    display: 'usecase' as const,
-  },
-  {
-    label: '設定情報',
-    to: '/setting',
-    icon: <PiGear />,
-    display: 'none' as const,
-  },
-  {
-    label: 'チャット',
-    to: '/chat',
-    icon: <PiChatsCircle />,
-    display: 'usecase' as const,
-  },
-  ragEnabled
-    ? {
-        label: 'RAG チャット',
-        to: '/rag',
-        icon: <PiChatCircleText />,
-        display: 'usecase' as const,
-        sub: 'Amazon Kendra',
-      }
-    : null,
-  ragKnowledgeBaseEnabled
-    ? {
-        label: 'RAG チャット',
-        to: '/rag-knowledge-base',
-        icon: <PiChatCircleText />,
-        display: 'usecase' as const,
-        sub: 'Knowledge Base',
-      }
-    : null,
-  agentEnabled
-    ? {
-        label: 'Agent チャット',
-        to: '/agent',
-        icon: <PiRobot />,
-        display: 'usecase' as const,
-      }
-    : null,
-  flowChatEnabled
-    ? {
-        label: 'Flow チャット',
-        to: '/flow-chat',
-        icon: <PiFlowArrow />,
-        display: 'usecase' as const,
-      }
-    : null,
-  {
-    label: '文章生成',
-    to: '/generate',
-    icon: <PiPencil />,
-    display: 'usecase' as const,
-  },
-  {
-    label: '要約',
-    to: '/summarize',
-    icon: <PiNote />,
-    display: 'usecase' as const,
-  },
-  {
-    label: '校正',
-    to: '/editorial',
-    icon: <PiPenNib />,
-    display: 'usecase' as const,
-  },
-  {
-    label: '翻訳',
-    to: '/translate',
-    icon: <PiTranslate />,
-    display: 'usecase' as const,
-  },
-  {
-    label: 'Web コンテンツ抽出',
-    to: '/web-content',
-    icon: <PiGlobe />,
-    display: 'usecase' as const,
-  },
-  {
-    label: '画像生成',
-    to: '/image',
-    icon: <PiImages />,
-    display: 'usecase' as const,
-  },
-  visionEnabled
-    ? {
-        label: '映像分析',
-        to: '/video',
-        icon: <PiVideoCamera />,
-        display: 'usecase' as const,
-      }
-    : null,
-  {
-    label: 'ダイアグラム生成',
-    to: '/diagram',
-    icon: <PiTreeStructure />,
-    display: 'usecase' as const,
-  },
-  {
-    label: '音声認識',
-    to: '/transcribe',
-    icon: <PiSpeakerHighBold />,
-    display: 'tool' as const,
-  },
-  optimizePromptEnabled
-    ? {
-        label: 'プロンプト最適化',
-        to: '/optimize',
-        icon: <PiMagicWand />,
-        display: 'tool' as const,
-      }
-    : null,
-].flatMap((i) => (i !== null ? [i] : []));
 
 // /chat/:chatId の形式から :chatId を返す
 // path が別の形式の場合は null を返す
@@ -182,6 +64,140 @@ const App: React.FC = () => {
   const { isShow } = useInterUseCases();
   const { screen, notifyScreen, scrollTopAnchorRef, scrollBottomAnchorRef } =
     useScreen();
+  const { enabled } = useUseCases();
+
+  const items: ItemProps[] = [
+    {
+      label: 'ホーム',
+      to: '/',
+      icon: <PiHouse />,
+      display: 'usecase' as const,
+    },
+    {
+      label: '設定情報',
+      to: '/setting',
+      icon: <PiGear />,
+      display: 'none' as const,
+    },
+    {
+      label: 'チャット',
+      to: '/chat',
+      icon: <PiChatsCircle />,
+      display: 'usecase' as const,
+    },
+    ragEnabled
+      ? {
+          label: 'RAG チャット',
+          to: '/rag',
+          icon: <PiChatCircleText />,
+          display: 'usecase' as const,
+          sub: 'Amazon Kendra',
+        }
+      : null,
+    ragKnowledgeBaseEnabled
+      ? {
+          label: 'RAG チャット',
+          to: '/rag-knowledge-base',
+          icon: <PiChatCircleText />,
+          display: 'usecase' as const,
+          sub: 'Knowledge Base',
+        }
+      : null,
+    agentEnabled
+      ? {
+          label: 'Agent チャット',
+          to: '/agent',
+          icon: <PiRobot />,
+          display: 'usecase' as const,
+        }
+      : null,
+    flowChatEnabled
+      ? {
+          label: 'Flow チャット',
+          to: '/flow-chat',
+          icon: <PiFlowArrow />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('generate')
+      ? {
+          label: '文章生成',
+          to: '/generate',
+          icon: <PiPencil />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('summarize')
+      ? {
+          label: '要約',
+          to: '/summarize',
+          icon: <PiNote />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('editorial')
+      ? {
+          label: '校正',
+          to: '/editorial',
+          icon: <PiPenNib />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('translate')
+      ? {
+          label: '翻訳',
+          to: '/translate',
+          icon: <PiTranslate />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('webContent')
+      ? {
+          label: 'Web コンテンツ抽出',
+          to: '/web-content',
+          icon: <PiGlobe />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('image')
+      ? {
+          label: '画像生成',
+          to: '/image',
+          icon: <PiImages />,
+          display: 'usecase' as const,
+        }
+      : null,
+    visionEnabled && enabled('video')
+      ? {
+          label: '映像分析',
+          to: '/video',
+          icon: <PiVideoCamera />,
+          display: 'usecase' as const,
+        }
+      : null,
+    enabled('diagram')
+      ? {
+          label: 'ダイアグラム生成',
+          to: '/diagram',
+          icon: <PiTreeStructure />,
+          display: 'usecase' as const,
+        }
+      : null,
+    {
+      label: '音声認識',
+      to: '/transcribe',
+      icon: <PiSpeakerHighBold />,
+      display: 'tool' as const,
+    },
+    optimizePromptEnabled
+      ? {
+          label: 'プロンプト最適化',
+          to: '/optimize',
+          icon: <PiMagicWand />,
+          display: 'tool' as const,
+        }
+      : null,
+  ].flatMap((i) => (i !== null ? [i] : []));
 
   const label = useMemo(() => {
     const chatId = extractChatId(pathname);
@@ -191,7 +207,7 @@ const App: React.FC = () => {
     } else {
       return items.find((i) => i.to === pathname)?.label || '';
     }
-  }, [pathname, getChatTitle]);
+  }, [items, pathname, getChatTitle]);
 
   // 画面間遷移時にスクロールイベントが発火しない場合 (ページ最上部からページ最上部への移動など)
   // 最上部/最下部の判定がされないので、pathname の変化に応じて再判定する

--- a/packages/web/src/hooks/useUseCases.ts
+++ b/packages/web/src/hooks/useUseCases.ts
@@ -1,0 +1,21 @@
+import { HiddenUseCases, HiddenUseCasesKeys } from 'generative-ai-use-cases-jp';
+
+const hiddenUseCases: HiddenUseCases = JSON.parse(
+  import.meta.env.VITE_APP_HIDDEN_USE_CASES
+);
+
+const useUseCases = () => {
+  const enabledSingle = (useCase: HiddenUseCasesKeys): boolean => {
+    return !hiddenUseCases[useCase];
+  };
+
+  const enabled = (...useCases: HiddenUseCasesKeys[]): boolean => {
+    return useCases.every(enabledSingle);
+  };
+
+  return {
+    enabled,
+  };
+};
+
+export default useUseCases;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -36,6 +36,7 @@ import UseCaseBuilderSamplesPage from './pages/useCaseBuilder/UseCaseBuilderSamp
 import UseCaseBuilderMyUseCasePage from './pages/useCaseBuilder/UseCaseBuilderMyUseCasePage.tsx';
 import { optimizePromptEnabled } from './hooks/useOptimizePrompt';
 import GenerateDiagramPage from './pages/GenerateDiagramPage.tsx';
+import useUseCases from './hooks/useUseCases';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const ragKnowledgeBaseEnabled: boolean =
@@ -46,6 +47,8 @@ const agentEnabled: boolean = import.meta.env.VITE_APP_AGENT_ENABLED === 'true';
 const { visionEnabled } = MODELS;
 const useCaseBuilderEnabled: boolean =
   import.meta.env.VITE_APP_USE_CASE_BUILDER_ENABLED === 'true';
+// eslint-disable-next-line  react-hooks/rules-of-hooks
+const { enabled } = useUseCases();
 
 const routes: RouteObject[] = [
   {
@@ -68,34 +71,48 @@ const routes: RouteObject[] = [
     path: '/share/:shareId',
     element: <SharedChatPage />,
   },
-  {
-    path: '/generate',
-    element: <GenerateTextPage />,
-  },
-  {
-    path: '/summarize',
-    element: <SummarizePage />,
-  },
-  {
-    path: '/editorial',
-    element: <EditorialPage />,
-  },
-  {
-    path: '/translate',
-    element: <TranslatePage />,
-  },
-  {
-    path: '/web-content',
-    element: <WebContent />,
-  },
-  {
-    path: '/image',
-    element: <GenerateImagePage />,
-  },
-  {
-    path: '/diagram',
-    element: <GenerateDiagramPage />,
-  },
+  enabled('generate')
+    ? {
+        path: '/generate',
+        element: <GenerateTextPage />,
+      }
+    : null,
+  enabled('summarize')
+    ? {
+        path: '/summarize',
+        element: <SummarizePage />,
+      }
+    : null,
+  enabled('editorial')
+    ? {
+        path: '/editorial',
+        element: <EditorialPage />,
+      }
+    : null,
+  enabled('translate')
+    ? {
+        path: '/translate',
+        element: <TranslatePage />,
+      }
+    : null,
+  enabled('webContent')
+    ? {
+        path: '/web-content',
+        element: <WebContent />,
+      }
+    : null,
+  enabled('image')
+    ? {
+        path: '/image',
+        element: <GenerateImagePage />,
+      }
+    : null,
+  enabled('diagram')
+    ? {
+        path: '/diagram',
+        element: <GenerateDiagramPage />,
+      }
+    : null,
   optimizePromptEnabled
     ? {
         path: '/optimize',
@@ -110,7 +127,7 @@ const routes: RouteObject[] = [
     path: '/flow-chat',
     element: <FlowChatPage />,
   },
-  visionEnabled
+  visionEnabled && enabled('video')
     ? {
         path: '/video',
         element: <VideoAnalyzerPage />,

--- a/packages/web/src/pages/LandingPage.tsx
+++ b/packages/web/src/pages/LandingPage.tsx
@@ -36,6 +36,7 @@ import {
 } from '../@types/navigate';
 import queryString from 'query-string';
 import { MODELS } from '../hooks/useModel';
+import useUseCases from '../hooks/useUseCases';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
 const ragKnowledgeBaseEnabled: boolean =
@@ -54,6 +55,7 @@ const flowChatEnabled: boolean = flows.length > 0;
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
+  const { enabled } = useUseCases();
   const { setIsShow, init } = useInterUseCases();
 
   const demoChat = () => {
@@ -332,43 +334,55 @@ const LandingPage: React.FC = () => {
             description="Flow を使用して、複数のステップを持つ対話型チャットフローを作成します。ユーザーの入力に基づいて、動的に次のステップを決定し、より複雑な対話シナリオを実現します。"
           />
         )}
-        <CardDemo
-          label="文章生成"
-          onClickDemo={demoGenerate}
-          icon={<PiPencil />}
-          description="あらゆるコンテキストで文章を生成することは LLM が最も得意とするタスクの 1 つです。記事・レポート・メールなど、あらゆるコンテキストに対応します。"
-        />
-        <CardDemo
-          label="要約"
-          onClickDemo={demoSummarize}
-          icon={<PiNote />}
-          description="LLM は、大量の文章を要約するタスクを得意としています。要約する際に「1行で」や「子供でもわかる言葉で」などコンテキストを与えることができます。"
-        />
-        <CardDemo
-          label="校正"
-          onClickDemo={demoEditorial}
-          icon={<PiPenNib />}
-          description="LLM は、誤字脱字のチェックだけでなく、文章の流れや内容を考慮したより客観的な視点から改善点を提案できます。人に見せる前に LLM に自分では気づかなかった点を客観的にチェックしてもらいクオリティを上げる効果が期待できます。"
-        />
-        <CardDemo
-          label="翻訳"
-          onClickDemo={demoTranslate}
-          icon={<PiTranslate />}
-          description="多言語で学習した LLM は、翻訳を行うことも可能です。また、ただ翻訳するだけではなく、カジュアルさ・対象層など様々な指定されたコンテキスト情報を翻訳に反映させることが可能です。"
-        />
-        <CardDemo
-          label="Web コンテンツ抽出"
-          onClickDemo={demoWebContent}
-          icon={<PiGlobe />}
-          description="ブログやドキュメントなどの Web コンテンツを抽出します。LLM によって不要な情報はそぎ落とし、成立した文章として整形します。抽出したコンテンツは要約、翻訳などの別のユースケースで利用できます。"
-        />
-        <CardDemo
-          label="画像生成"
-          onClickDemo={demoGenerateImage}
-          icon={<PiImages />}
-          description="画像生成 AI は、テキストや画像を元に新しい画像を生成できます。アイデアを即座に可視化することができ、デザイン作業などの効率化を期待できます。こちらの機能では、プロンプトの作成を LLM に支援してもらうことができます。"
-        />
-        {visionEnabled && (
+        {enabled('generate') && (
+          <CardDemo
+            label="文章生成"
+            onClickDemo={demoGenerate}
+            icon={<PiPencil />}
+            description="あらゆるコンテキストで文章を生成することは LLM が最も得意とするタスクの 1 つです。記事・レポート・メールなど、あらゆるコンテキストに対応します。"
+          />
+        )}
+        {enabled('summarize') && (
+          <CardDemo
+            label="要約"
+            onClickDemo={demoSummarize}
+            icon={<PiNote />}
+            description="LLM は、大量の文章を要約するタスクを得意としています。要約する際に「1行で」や「子供でもわかる言葉で」などコンテキストを与えることができます。"
+          />
+        )}
+        {enabled('editorial') && (
+          <CardDemo
+            label="校正"
+            onClickDemo={demoEditorial}
+            icon={<PiPenNib />}
+            description="LLM は、誤字脱字のチェックだけでなく、文章の流れや内容を考慮したより客観的な視点から改善点を提案できます。人に見せる前に LLM に自分では気づかなかった点を客観的にチェックしてもらいクオリティを上げる効果が期待できます。"
+          />
+        )}
+        {enabled('translate') && (
+          <CardDemo
+            label="翻訳"
+            onClickDemo={demoTranslate}
+            icon={<PiTranslate />}
+            description="多言語で学習した LLM は、翻訳を行うことも可能です。また、ただ翻訳するだけではなく、カジュアルさ・対象層など様々な指定されたコンテキスト情報を翻訳に反映させることが可能です。"
+          />
+        )}
+        {enabled('webContent') && (
+          <CardDemo
+            label="Web コンテンツ抽出"
+            onClickDemo={demoWebContent}
+            icon={<PiGlobe />}
+            description="ブログやドキュメントなどの Web コンテンツを抽出します。LLM によって不要な情報はそぎ落とし、成立した文章として整形します。抽出したコンテンツは要約、翻訳などの別のユースケースで利用できます。"
+          />
+        )}
+        {enabled('image') && (
+          <CardDemo
+            label="画像生成"
+            onClickDemo={demoGenerateImage}
+            icon={<PiImages />}
+            description="画像生成 AI は、テキストや画像を元に新しい画像を生成できます。アイデアを即座に可視化することができ、デザイン作業などの効率化を期待できます。こちらの機能では、プロンプトの作成を LLM に支援してもらうことができます。"
+          />
+        )}
+        {visionEnabled && enabled('video') && (
           <CardDemo
             label="映像分析"
             onClickDemo={demoVideoAnalyzer}
@@ -376,32 +390,49 @@ const LandingPage: React.FC = () => {
             description="マルチモーダルモデルによってテキストのみではなく、画像を入力することが可能になりました。こちらの機能では、映像の画像フレームとテキストを入力として LLM に分析を依頼します。"
           />
         )}
-        <CardDemo
-          label="ダイアグラム生成"
-          onClickDemo={demoGenerateDiagram}
-          icon={<PiTreeStructure />}
-          description="自然言語による説明、文書やコードから、フローチャート、シーケンス図、マインドマップなどの様々な図を自動的に作成できます。システム設計、ビジネスフロー、プロジェクト計画などの複雑な関係性を、視覚的に表現し理解を効率化します。"
-        />
+        {enabled('diagram') && (
+          <CardDemo
+            label="ダイアグラム生成"
+            onClickDemo={demoGenerateDiagram}
+            icon={<PiTreeStructure />}
+            description="自然言語による説明、文書やコードから、フローチャート、シーケンス図、マインドマップなどの様々な図を自動的に作成できます。システム設計、ビジネスフロー、プロジェクト計画などの複雑な関係性を、視覚的に表現し理解を効率化します。"
+          />
+        )}
       </div>
 
-      <h1 className="mb-6 mt-12 flex justify-center text-2xl font-bold">
-        ユースケース連携
-      </h1>
+      {
+        // いずれかのユースケース連携が有効であれば表示する
+        // ブログ記事作成
+        (enabled('webContent', 'generate', 'summarize', 'image') ||
+          // 議事録作成
+          enabled('generate')) && (
+          <>
+            <h1 className="mb-6 mt-12 flex justify-center text-2xl font-bold">
+              ユースケース連携
+            </h1>
 
-      <div className="mx-20 grid gap-x-20 gap-y-5 md:grid-cols-1 xl:grid-cols-2">
-        <CardDemo
-          label="ブログ記事作成"
-          onClickDemo={demoBlog}
-          icon={<PiPen />}
-          description="複数のユースケースを組み合わせて、ブログ記事を生成します。記事の概要とサムネイル画像も自動生成することで、OGP の設定も容易になります。例として、AWS 公式サイトの情報を元に生成 AI を紹介するブログ記事を生成します。"
-        />
-        <CardDemo
-          label="議事録作成"
-          onClickDemo={demoMeetingReport}
-          icon={<PiNotebook />}
-          description="複数のユースケースを組み合わせて、会議の録音データから議事録を自動作成します。録音データの文字起こし、文字起こし結果の整形、議事録作成を人的コストをかけずに行うことが可能です。"
-        />
-      </div>
+            <div className="mx-20 grid gap-x-20 gap-y-5 md:grid-cols-1 xl:grid-cols-2">
+              {enabled('webContent', 'generate', 'summarize', 'image') && (
+                <CardDemo
+                  label="ブログ記事作成"
+                  onClickDemo={demoBlog}
+                  icon={<PiPen />}
+                  description="複数のユースケースを組み合わせて、ブログ記事を生成します。記事の概要とサムネイル画像も自動生成することで、OGP の設定も容易になります。例として、AWS 公式サイトの情報を元に生成 AI を紹介するブログ記事を生成します。"
+                />
+              )}
+
+              {enabled('generate') && (
+                <CardDemo
+                  label="議事録作成"
+                  onClickDemo={demoMeetingReport}
+                  icon={<PiNotebook />}
+                  description="複数のユースケースを組み合わせて、会議の録音データから議事録を自動作成します。録音データの文字起こし、文字起こし結果の整形、議事録作成を人的コストをかけずに行うことが可能です。"
+                />
+              )}
+            </div>
+          </>
+        )
+      }
     </div>
   );
 };

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -24,6 +24,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_AGENT_NAMES: string;
   readonly VITE_APP_USE_CASE_BUILDER_ENABLED: string;
   readonly VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN: string;
+  readonly VITE_APP_HIDDEN_USE_CASES: string;
 }
 
 interface ImportMeta {

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -44,3 +44,4 @@ export VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME=$(extract_value "$
 export VITE_APP_AGENT_NAMES=$(extract_value "$stack_output" AgentNames)
 export VITE_APP_USE_CASE_BUILDER_ENABLED=$(extract_value "$stack_output" UseCaseBuilderEnabled)
 export VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN=$(extract_value "$stack_output" OptimizePromptFunctionArn)
+export VITE_APP_HIDDEN_USE_CASES=$(extract_value "$stack_output" HiddenUseCases)


### PR DESCRIPTION
## 変更内容の説明
`hiddenUseCases` を指定することで基本ユースケースの表示/非表示が切り替えられるようにしました。現状、デフォルトでは全てのユースケースが表示されます。

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/679
