### PR TITLE
DEPLOY_OPTION typo fix

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -750,7 +750,7 @@ const envs: Record<string, Partial<StackInput>> = {
 "amazon.titan-image-generator-v2:0",
 "amazon.titan-image-generator-v1",
 "stability.sd3-large-v1:0",
-"stability.sd3-5-large-v1:0"
+"stability.sd3-5-large-v1:0",
 "stability.stable-image-core-v1:0",
 "stability.stable-image-core-v1:1",
 "stability.stable-image-ultra-v1:0",


### PR DESCRIPTION
json のフォーマットに誤りがあったため修正（カンマ追加）
```
"stability.sd3-large-v1:0",
"stability.sd3-5-large-v1:0"
"stability.stable-image-core-v1:0",
```
↓
```
"stability.sd3-large-v1:0",
"stability.sd3-5-large-v1:0",
"stability.stable-image-core-v1:0",
```