### PR TITLE
Kendra の sync エラー解消

### DIFF
--- a/packages/cdk/lib/construct/rag.ts
+++ b/packages/cdk/lib/construct/rag.ts
@@ -179,7 +179,7 @@ export class Rag extends Construct {
         sources: [s3Deploy.Source.asset('./rag-docs')],
         destinationBucket: dataSourceBucket,
         // 以前の設定で同 Bucket にアクセスログが残っている可能性があるため、この設定は残す
-        exclude: ['AccessLogs/*', 'logs*'],
+        exclude: ['AccessLogs/*', 'logs*', 'docs/bedrock-ug.pdf.metadata.json'],
       });
 
       let index: kendra.CfnIndex;

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -14275,6 +14275,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         "Exclude": [
           "AccessLogs/*",
           "logs*",
+          "docs/bedrock-ug.pdf.metadata.json",
         ],
         "OutputObjectKeys": true,
         "Prune": true,


### PR DESCRIPTION
## 変更内容の説明

* Kendra の sync を実行すると発生するエラーを解消しました
  * https://github.com/aws-samples/generative-ai-use-cases-jp/pull/802 でコミットされた `packages/cdk/rag-docs/docs/bedrock-ug.pdf.metadata.json` が Kendra ではで sync エラーの原因になっている
  * エラーメッセージは `Found invalid Metadata file s3:....`
  * Kendra 用の S3 バケットには、当該ファイルをアップロードしないための変更を実施しています

## チェック項目
- [*] `npm run lint` を実行した
- [*] ~~関連するドキュメントを修正した~~ 修正箇所無し
- [*] 手元の環境で動作確認済み
- [*] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
なし