### PR TITLE
Search agentでユーザー入力を有効化するアクショングループの定義を修正

### DIFF
--- a/packages/cdk/lib/construct/agent.ts
+++ b/packages/cdk/lib/construct/agent.ts
@@ -110,7 +110,7 @@ export class Agent extends Construct {
             description: 'Search',
           },
           {
-            actionGroupName: 'UserInput',
+            actionGroupName: 'UserInputAction',
             parentActionGroupSignature: 'AMAZON.UserInput',
           },
         ],

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -1480,7 +1480,7 @@ exports[`GenerativeAiUseCases matches the snapshot 3`] = `
             "Description": "Search",
           },
           {
-            "ActionGroupName": "UserInput",
+            "ActionGroupName": "UserInputAction",
             "ParentActionGroupSignature": "AMAZON.UserInput",
           },
         ],


### PR DESCRIPTION
## 変更内容の説明
Search agentでユーザー入力を有効化するアクショングループの定義を修正しました。

内容：`actionGroupName`を`UserInput`から`UserInputAction`に変更
理由：`actionGroupName`が`UserInputAction`でないとAgentのユーザ入力が有効化されないため (Case sensitive)

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
なし