### PR TITLE
ファイルアップロード中にアップロード済みのファイルの削除した際のバグの解消

### DIFF
--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -51,6 +51,7 @@ export type ExtraData = {
 };
 
 export type UploadedFileType = {
+  id: string;
   file: File;
   name: string;
   type: 'image' | 'video' | 'file';

--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -79,9 +79,9 @@ const InputChatContent: React.FC<Props> = (props) => {
   };
 
   const deleteFile = useCallback(
-    (fileUrl: string) => {
+    (fileId: string) => {
       if (props.fileLimit && props.accept) {
-        deleteUploadedFile(fileUrl, props.fileLimit, props.accept);
+        deleteUploadedFile(fileId, props.fileLimit, props.accept);
       }
     },
     [deleteUploadedFile, props.fileLimit, props.accept]
@@ -141,7 +141,7 @@ const InputChatContent: React.FC<Props> = (props) => {
                       size="s"
                       error={uploadedFile.errorMessages.length > 0}
                       onDelete={() => {
-                        deleteFile(uploadedFile.s3Url ?? '');
+                        deleteFile(uploadedFile.id ?? '');
                       }}
                     />
                   );
@@ -155,7 +155,7 @@ const InputChatContent: React.FC<Props> = (props) => {
                       size="s"
                       error={uploadedFile.errorMessages.length > 0}
                       onDelete={() => {
-                        deleteFile(uploadedFile.s3Url ?? '');
+                        deleteFile(uploadedFile.id ?? '');
                       }}
                     />
                   );
@@ -169,7 +169,7 @@ const InputChatContent: React.FC<Props> = (props) => {
                       size="s"
                       error={uploadedFile.errorMessages.length > 0}
                       onDelete={() => {
-                        deleteFile(uploadedFile.s3Url ?? '');
+                        deleteFile(uploadedFile.id ?? '');
                       }}
                     />
                   );

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -396,9 +396,9 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
   };
 
   const deleteFile = useCallback(
-    (fileUrl: string) => {
+    (fileId: string) => {
       if (fileLimit && accept) {
-        deleteUploadedFile(fileUrl, fileLimit, accept);
+        deleteUploadedFile(fileId, fileLimit, accept);
       }
     },
     [deleteUploadedFile, accept]
@@ -573,7 +573,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
                           size="s"
                           error={uploadedFile.errorMessages.length > 0}
                           onDelete={() => {
-                            deleteFile(uploadedFile.s3Url ?? '');
+                            deleteFile(uploadedFile.id ?? '');
                           }}
                         />
                       );
@@ -587,7 +587,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
                           size="s"
                           error={uploadedFile.errorMessages.length > 0}
                           onDelete={() => {
-                            deleteFile(uploadedFile.s3Url ?? '');
+                            deleteFile(uploadedFile.id ?? '');
                           }}
                         />
                       );
@@ -601,7 +601,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
                           size="s"
                           error={uploadedFile.errorMessages.length > 0}
                           onDelete={() => {
-                            deleteFile(uploadedFile.s3Url ?? '');
+                            deleteFile(uploadedFile.id ?? '');
                           }}
                         />
                       );

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -247,7 +247,6 @@ const useFilesState = create<{
       };
 
       const mediaFormat = uploadedFile.file.name.split('.').pop() as string;
-      const fileId = uploadedFile.id;
 
       // 署名付き URL の取得（並列実行させるために、await せずに実行）
       api
@@ -260,7 +259,7 @@ const useFilesState = create<{
           const fileUrl = extractBaseURL(signedUrl); // 署名付き url からクエリパラメータを除外
           // ファイルのアップロード
           api.uploadFile(signedUrl, { file: uploadedFile.file }).then(() => {
-            const current_idx = get().uploadedFilesDict[id].findIndex((file) => file.id === fileId); //アップロード中に前のファイルが削除された場合idxが変化する
+            const current_idx = get().uploadedFilesDict[id].findIndex((file) => file.id === uploadedFile.id); //アップロード中に前のファイルが削除された場合idxが変化する
             set(
               produce((state) => {
                 state.uploadedFilesDict[id][current_idx].uploading = false;

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -259,11 +259,11 @@ const useFilesState = create<{
           const fileUrl = extractBaseURL(signedUrl); // 署名付き url からクエリパラメータを除外
           // ファイルのアップロード
           api.uploadFile(signedUrl, { file: uploadedFile.file }).then(() => {
-            const current_idx = get().uploadedFilesDict[id].findIndex((file) => file.id === uploadedFile.id); //アップロード中に前のファイルが削除された場合idxが変化する
+            const currentIdx = get().uploadedFilesDict[id].findIndex((file) => file.id === uploadedFile.id); //アップロード中に前のファイルが削除された場合idxが変化する
             set(
               produce((state) => {
-                state.uploadedFilesDict[id][current_idx].uploading = false;
-                state.uploadedFilesDict[id][current_idx].s3Url = fileUrl;
+                state.uploadedFilesDict[id][currentIdx].uploading = false;
+                state.uploadedFilesDict[id][currentIdx].s3Url = fileUrl;
                 state.base64Cache = {
                   ...state.base64Cache,
                   [fileUrl]: reader.result?.toString() ?? '',

--- a/packages/web/src/pages/VideoAnalyzerPage.tsx
+++ b/packages/web/src/pages/VideoAnalyzerPage.tsx
@@ -21,6 +21,7 @@ import InputChatContent from '../components/InputChatContent';
 import Card from '../components/Card';
 import Select from '../components/Select';
 import queryString from 'query-string';
+import { v4 as uuidv4 } from 'uuid';
 
 type StateType = {
   content: string;
@@ -170,8 +171,10 @@ const VideoAnalyzerPage: React.FC = () => {
       const signedUrl = (await getSignedUrl({ mediaFormat: 'png' })).data;
       await uploadFile(signedUrl, { file });
       const baseUrl = extractBaseURL(signedUrl);
+      const fileId = uuidv4();
       const uploadedFiles: UploadedFileType[] = [
         {
+          id: fileId,
           file,
           name: file.name,
           type: 'image',

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+
 # Get env from command lineargument (optional)
 if [ -n "${1:-}" ]; then
     env=$1

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -2,7 +2,6 @@
 
 set -eu
 
-
 # Get env from command lineargument (optional)
 if [ -n "${1:-}" ]; then
     env=$1


### PR DESCRIPTION
## 変更内容の説明
すでにファイルがアップロードされている状態で別のファイルをアップロードし、ロード中にアップロード済みのファイルを削除するとロード中のファイルが認識されなくなるバグを修正しました。
s3アップロード前後でファイルオブジェクト配列のインデックスが変化することに起因するため、UploadedFileTypeに別途idを用意しインデックスの再検索を行うよう変更しました。

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
