### PR TITLE
agentEnabled が false でも agents に Agent が定義されていたら Agent チャットユースケースを有効にできるように変更

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -342,7 +342,7 @@ Agent チャットユースケースでは、以下のご利用が可能です�
 - Agents for Amazon Bedrock を利用したアクションを実行
 - Knowledge Bases for Amazon Bedrock のベクトルデータベースを参照
 
-Agent は `modelRegion` で指定したリージョンに生成されます。
+Agent は `modelRegion` で指定したリージョンに生成されます。後述する `agentEnabled: true` は Code Interpreter エージェントと検索エージェントを作成するためのオプションで、手動で作成した Agent を追加する際には `agentEnabled: true` である必要はありません。
 
 #### Code Interpreter エージェントのデプロイ
 
@@ -416,15 +416,17 @@ const envs: Record<string, Partial<StackInput>> = {
 
 デフォルトの Agent 以外に手動で作成した Agent を登録したい場合、以下のように追加の Agent を `agents` に追加してください。Agent は `modelRegion` で作成する点に留意してください。
 
+> [!NOTE]
+> `agentEnabled: true` は Code Interpreter エージェントと検索エージェントを作成するためのオプションですので、手動で作成した Agent を追加する際には `agentEnabled: true` である必要はありません。
+
 **[parameter.ts](/packages/cdk/parameter.ts) を編集**
 ```typescript
 // parameter.ts
 const envs: Record<string, Partial<StackInput>> = {
   dev: {
-    agentEnabled: true,
     agents: [
       {
-        displayName: 'SearchEngine',
+        displayName: 'MyCustomAgent',
         agentId: 'XXXXXXXXX',
         aliasId: 'YYYYYYYY',
       },
@@ -438,10 +440,9 @@ const envs: Record<string, Partial<StackInput>> = {
 // cdk.json
 {
   "context": {
-    "agentEnabled": true,
     "agents": [
       {
-        "displayName": "SearchEngine",
+        "displayName": "MyCustomAgent",
         "agentId": "XXXXXXXXX",
         "aliasId": "YYYYYYYY"
       }
@@ -450,7 +451,7 @@ const envs: Record<string, Partial<StackInput>> = {
 }
 ```
 
-また、`packages/cdk/lib/construct/agent.ts` を改修し新たな Agent を定義することも可能です。
+また、`packages/cdk/lib/construct/agent.ts` を改修し新たな Agent を定義することも可能です。CDK に定義した Agent を利用する場合は `agentEnabled: true` にしてください。
 
 #### Knowledge Bases for Amazon Bedrock エージェントのデプロイ
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -118,7 +118,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       predictStreamFunctionArn: api.predictStreamFunction.functionArn,
       ragEnabled: params.ragEnabled,
       ragKnowledgeBaseEnabled: params.ragKnowledgeBaseEnabled,
-      agentEnabled: params.agentEnabled,
+      agentEnabled: params.agentEnabled || params.agents.length > 0,
       flows: params.flows,
       flowStreamFunctionArn: api.invokeFlowFunction.functionArn,
       optimizePromptFunctionArn: api.optimizePromptFunction.functionArn,
@@ -241,7 +241,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     });
 
     new CfnOutput(this, 'AgentEnabled', {
-      value: params.agentEnabled.toString(),
+      value: (params.agentEnabled || params.agents.length > 0).toString(),
     });
 
     new CfnOutput(this, 'SelfSignUpEnabled', {

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -259,7 +259,9 @@ const useFilesState = create<{
           const fileUrl = extractBaseURL(signedUrl); // 署名付き url からクエリパラメータを除外
           // ファイルのアップロード
           api.uploadFile(signedUrl, { file: uploadedFile.file }).then(() => {
-            const currentIdx = get().uploadedFilesDict[id].findIndex((file) => file.id === uploadedFile.id); //アップロード中に前のファイルが削除された場合idxが変化する
+            const currentIdx = get().uploadedFilesDict[id].findIndex(
+              (file) => file.id === uploadedFile.id
+            ); //アップロード中に前のファイルが削除された場合idxが変化する
             set(
               produce((state) => {
                 state.uploadedFilesDict[id][currentIdx].uploading = false;


### PR DESCRIPTION
## 変更内容の説明
- これまでは agentEnabled が true でないと Agent チャットユースケースが利用できなかった
- 手動追加した Agent のみを利用したい場合、これだと不便
- agentEnabled は Agent スタックを作成するかのフラグに仕様変更し、手動追加された Agent がある場合は agentEnabled が false でも Agent チャットユースケースが利用できるようにした。

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
- https://github.com/aws-samples/generative-ai-use-cases-jp/issues/887
