### PR TITLE
Claude 3.7 の追加

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -731,6 +731,7 @@ const envs: Record<string, Partial<StackInput>> = {
 "anthropic.claude-3-opus-20240229-v1:0",
 "anthropic.claude-3-sonnet-20240229-v1:0",
 "anthropic.claude-3-haiku-20240307-v1:0",
+"us.anthropic.claude-3-7-sonnet-20250219-v1:0",
 "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
 "us.anthropic.claude-3-5-haiku-20241022-v1:0",
 "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
@@ -931,6 +932,7 @@ const envs: Record<string, Partial<StackInput>> = {
   dev: {
     modelRegion: 'us-east-2',
     modelIds: [
+      "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
       "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
       "us.anthropic.claude-3-5-haiku-20241022-v1:0",
       "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
@@ -971,6 +973,7 @@ const envs: Record<string, Partial<StackInput>> = {
   "context": {
     "modelRegion": "us-west-2",
     "modelIds": [
+      "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
       "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
       "us.anthropic.claude-3-5-haiku-20241022-v1:0",
       "us.anthropic.claude-3-5-sonnet-20240620-v1:0",

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -665,6 +665,14 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseOutputText: extractConverseOutputText,
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
+  'us.anthropic.claude-3-7-sonnet-20250219-v1:0': {
+    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutputText: extractConverseOutputText,
+    extractConverseStreamOutputText: extractConverseStreamOutputText,
+  },
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': {
     defaultParams: CLAUDE_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,

--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -31,6 +31,7 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
     ...MODEL_FEATURE.TEXT_DOC_IMAGE,
     ...MODEL_FEATURE.LIGHT,
   },
+  'us.anthropic.claude-3-7-sonnet-20250219-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-sonnet-20241022-v2:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-sonnet-20240620-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,


### PR DESCRIPTION
## 変更内容の説明

- Claude 3.7 の追加 (現状 Inference Profile `us.anthropic.claude-3-7-sonnet-20250219-v1:0` のみ)
https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
関連する Issue を可能な限り挙げてください。
