### PR TITLE
Reasoning support for claude 3.7 sonnet

### DIFF
--- a/docs/mkdocs/material/overrides/home.html
+++ b/docs/mkdocs/material/overrides/home.html
@@ -323,7 +323,9 @@
               alt="タキヒヨー"
               class="mb-4 h-16 object-contain" />
             <p class="text-center text-sm text-gray-600">
-              生成 AI を活用し社内業務効率化と 450 時間超の工数削減を実現。Amazon Bedrock を衣服デザイン等に適用、デジタル人材育成を推進。
+              生成 AI を活用し社内業務効率化と 450
+              時間超の工数削減を実現。Amazon Bedrock
+              を衣服デザイン等に適用、デジタル人材育成を推進。
             </p>
           </a>
         </div>

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -85,6 +85,12 @@ const RINNA_PROMPT: PromptTemplate = {
 
 // Model Params
 
+const CLAUDE_3_5_DEFAULT_PARAMS: ConverseInferenceParams = {
+  maxTokens: 8192,
+  temperature: 0.6,
+  topP: 0.8,
+};
+
 const CLAUDE_DEFAULT_PARAMS: ConverseInferenceParams = {
   maxTokens: 4096,
   temperature: 0.6,
@@ -187,7 +193,7 @@ function normalizeId(id: string): string {
 const createConverseCommandInput = (
   messages: UnrecordedMessage[],
   id: string,
-  modelId: string,
+  model: Model,
   defaultConverseInferenceParams: ConverseInferenceParams,
   usecaseConverseInferenceParams: UsecaseConverseInferenceParams
 ) => {
@@ -266,12 +272,27 @@ const createConverseCommandInput = (
   const guardrailConfig = createGuardrailConfig();
 
   const converseCommandInput: ConverseCommandInput = {
-    modelId: modelId,
+    modelId: model.modelId,
     messages: conversation,
     system: systemContext,
     inferenceConfig: inferenceConfig,
     guardrailConfig: guardrailConfig,
   };
+
+  if (
+    modelFeatureFlags[model.modelId].reasoning &&
+    model.modelParameters?.reasoning_config?.type === 'enabled'
+  ) {
+    converseCommandInput.inferenceConfig = {
+      ...inferenceConfig,
+      temperature: 1, // reasoning は temperature を 1 必須
+      topP: undefined, // reasoning は topP は不要
+      maxTokens:
+        (model.modelParameters?.reasoning_config?.budget_tokens || 0) +
+        (inferenceConfig?.maxTokens || 0),
+    };
+    converseCommandInput.additionalModelRequestFields = model.modelParameters;
+  }
 
   return converseCommandInput;
 };
@@ -283,7 +304,7 @@ const createConverseCommandInput = (
 const createConverseCommandInputWithoutSystemContext = (
   messages: UnrecordedMessage[],
   id: string,
-  modelId: string,
+  model: Model,
   defaultConverseInferenceParams: ConverseInferenceParams,
   usecaseConverseInferenceParams: UsecaseConverseInferenceParams
 ) => {
@@ -305,7 +326,7 @@ const createConverseCommandInputWithoutSystemContext = (
   const guardrailConfig = createGuardrailConfig();
 
   const converseCommandInput: ConverseCommandInput = {
-    modelId: modelId,
+    modelId: model.modelId,
     messages: conversation,
     inferenceConfig: inferenceConfig,
     guardrailConfig: guardrailConfig,
@@ -318,14 +339,14 @@ const createConverseCommandInputWithoutSystemContext = (
 const createConverseStreamCommandInput = (
   messages: UnrecordedMessage[],
   id: string,
-  modelId: string,
+  model: Model,
   defaultParams: ConverseInferenceParams,
   usecaseParams: UsecaseConverseInferenceParams
 ): ConverseStreamCommandInput => {
   const converseCommandInput = createConverseCommandInput(
     messages,
     id,
-    modelId,
+    model,
     defaultParams,
     usecaseParams
   );
@@ -343,14 +364,14 @@ const createConverseStreamCommandInput = (
 const createConverseStreamCommandInputWithoutSystemContext = (
   messages: UnrecordedMessage[],
   id: string,
-  modelId: string,
+  model: Model,
   defaultParams: ConverseInferenceParams,
   usecaseParams: UsecaseConverseInferenceParams
 ): ConverseStreamCommandInput => {
   const converseCommandInput = createConverseCommandInputWithoutSystemContext(
     messages,
     id,
-    modelId,
+    model,
     defaultParams,
     usecaseParams
   );
@@ -626,14 +647,14 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     createConverseCommandInput: (
       messages: UnrecordedMessage[],
       id: string,
-      modelId: string,
+      model: Model,
       defaultParams: ConverseInferenceParams,
       usecaseParams: UsecaseConverseInferenceParams
     ) => ConverseCommandInput;
     createConverseStreamCommandInput: (
       messages: UnrecordedMessage[],
       id: string,
-      modelId: string,
+      model: Model,
       defaultParams: ConverseInferenceParams,
       usecaseParams: UsecaseConverseInferenceParams
     ) => ConverseStreamCommandInput;
@@ -642,7 +663,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
   };
 } = {
   'anthropic.claude-3-5-sonnet-20241022-v2:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -650,7 +671,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'us.anthropic.claude-3-5-sonnet-20241022-v2:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -658,7 +679,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'anthropic.claude-3-5-haiku-20241022-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -666,7 +687,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'us.anthropic.claude-3-7-sonnet-20250219-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -674,7 +695,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -682,7 +703,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'anthropic.claude-3-5-sonnet-20240620-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -690,7 +711,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'us.anthropic.claude-3-5-sonnet-20240620-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -698,7 +719,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'eu.anthropic.claude-3-5-sonnet-20240620-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,
@@ -706,7 +727,7 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseStreamOutputText: extractConverseStreamOutputText,
   },
   'apac.anthropic.claude-3-5-sonnet-20240620-v1:0': {
-    defaultParams: CLAUDE_DEFAULT_PARAMS,
+    defaultParams: CLAUDE_3_5_DEFAULT_PARAMS,
     usecaseParams: USECASE_DEFAULT_PARAMS,
     createConverseCommandInput: createConverseCommandInput,
     createConverseStreamCommandInput: createConverseStreamCommandInput,

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -281,17 +281,23 @@ const createConverseCommandInput = (
 
   if (
     modelFeatureFlags[model.modelId].reasoning &&
-    model.modelParameters?.reasoning_config?.type === 'enabled'
+    model.modelParameters?.reasoningConfig?.type === 'enabled'
   ) {
     converseCommandInput.inferenceConfig = {
       ...inferenceConfig,
       temperature: 1, // reasoning は temperature を 1 必須
       topP: undefined, // reasoning は topP は不要
       maxTokens:
-        (model.modelParameters?.reasoning_config?.budget_tokens || 0) +
+        (model.modelParameters?.reasoningConfig?.budgetTokens || 0) +
         (inferenceConfig?.maxTokens || 0),
     };
-    converseCommandInput.additionalModelRequestFields = model.modelParameters;
+    converseCommandInput.additionalModelRequestFields = {
+      reasoning_config: {
+        type: model.modelParameters?.reasoningConfig?.type,
+        budget_tokens:
+          model.modelParameters?.reasoningConfig?.budgetTokens || 0,
+      },
+    };
   }
 
   return converseCommandInput;

--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -7,6 +7,13 @@ const MODEL_FEATURE: Record<string, FeatureFlags> = {
   TEXT_ONLY: { text: true, doc: false, image: false, video: false },
   TEXT_DOC: { text: true, doc: true, image: false, video: false },
   TEXT_DOC_IMAGE: { text: true, doc: true, image: true, video: false },
+  TEXT_DOC_IMAGE_REASONING: {
+    text: true,
+    doc: true,
+    image: true,
+    video: false,
+    reasoning: true,
+  },
   TEXT_DOC_IMAGE_VIDEO: { text: true, doc: true, image: true, video: true },
   IMAGE_GEN: { image_gen: true },
   VIDEO_GEN: { video_gen: true },
@@ -31,7 +38,8 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
     ...MODEL_FEATURE.TEXT_DOC_IMAGE,
     ...MODEL_FEATURE.LIGHT,
   },
-  'us.anthropic.claude-3-7-sonnet-20250219-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
+  'us.anthropic.claude-3-7-sonnet-20250219-v1:0':
+    MODEL_FEATURE.TEXT_DOC_IMAGE_REASONING,
   'us.anthropic.claude-3-5-sonnet-20241022-v2:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,
   'us.anthropic.claude-3-5-sonnet-20240620-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE,

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -1,10 +1,12 @@
 import { PrimaryKey } from './base';
+import { AdditionalModelRequestFields } from './text';
 
 export type Role = 'system' | 'user' | 'assistant';
 
 export type Model = {
   type: 'bedrock' | 'bedrockAgent' | 'bedrockKb' | 'sagemaker';
   modelId: string;
+  modelParameters?: AdditionalModelRequestFields;
   sessionId?: string;
 };
 

--- a/packages/types/src/model.d.ts
+++ b/packages/types/src/model.d.ts
@@ -5,8 +5,11 @@ export type FeatureFlags = {
   doc?: boolean;
   image?: boolean;
   video?: boolean;
+  reasoning?: boolean;
+
   image_gen?: boolean;
   video_gen?: boolean;
+
   embedding?: boolean;
   reranking?: boolean;
   // Additional Flags

--- a/packages/types/src/text.d.ts
+++ b/packages/types/src/text.d.ts
@@ -11,6 +11,13 @@ export type UsecaseConverseInferenceParams = {
   [key: string]: ConverseInferenceParams;
 };
 
+export type AdditionalModelRequestFields = {
+  reasoning_config?: {
+    type: 'enabled' | 'disabled';
+    budget_tokens?: number;
+  };
+};
+
 export type BaseGuardrailConfigParams = {
   guardrailIdentifier: string;
   guardrailVersion: string;

--- a/packages/types/src/text.d.ts
+++ b/packages/types/src/text.d.ts
@@ -12,9 +12,9 @@ export type UsecaseConverseInferenceParams = {
 };
 
 export type AdditionalModelRequestFields = {
-  reasoning_config?: {
+  reasoningConfig?: {
     type: 'enabled' | 'disabled';
-    budget_tokens?: number;
+    budgetTokens?: number;
   };
 };
 

--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -40,16 +40,10 @@ type Props = {
   | {
       hideReset: true;
     }
-) &
-  (
-    | {
-        setting: true;
-        onSetting: () => void;
-      }
-    | {
-        setting?: false;
-      }
-  );
+) & {
+    setting?: boolean;
+    onSetting?: () => void;
+  };
 
 const InputChatContent: React.FC<Props> = (props) => {
   const { pathname } = useLocation();
@@ -127,7 +121,7 @@ const InputChatContent: React.FC<Props> = (props) => {
         className={`relative flex items-end rounded-xl border border-black/10 bg-gray-100 shadow-[0_0_30px_1px] shadow-gray-400/40 ${
           props.disableMarginBottom ? '' : 'mb-7'
         }`}>
-        <div className="flex w-full flex-col">
+        <div className="flex grow flex-col">
           {props.fileUpload && uploadedFiles.length > 0 && (
             <div className="m-2 flex flex-wrap gap-2">
               {uploadedFiles.map((uploadedFile, idx) => {
@@ -187,7 +181,7 @@ const InputChatContent: React.FC<Props> = (props) => {
             </div>
           )}
           <Textarea
-            className={`scrollbar-thumb-gray-200 scrollbar-thin m-2 -mr-14 bg-transparent ${props.fileUpload || props.setting ? 'pr-24' : 'pr-14'}`}
+            className={`scrollbar-thumb-gray-200 scrollbar-thin m-2 -mr-14 bg-transparent`}
             placeholder={props.placeholder ?? '入力してください'}
             noBorder
             notItem
@@ -197,43 +191,45 @@ const InputChatContent: React.FC<Props> = (props) => {
             onEnter={disabledSend ? undefined : props.onSend}
           />
         </div>
-        {props.fileUpload && (
-          <div className="absolute bottom-2 right-12">
-            <label>
-              <input
-                hidden
-                onChange={onChangeFiles}
-                type="file"
-                accept={props.accept?.join(',')}
-                multiple
-                value={[]}
-              />
-              <div
-                className={`${uploading ? 'bg-gray-300' : 'bg-aws-smile cursor-pointer '} flex items-center justify-center rounded-xl p-2 align-bottom text-xl text-white`}>
-                {uploading ? (
-                  <PiSpinnerGap className="animate-spin" />
-                ) : (
-                  <PiPaperclip />
-                )}
-              </div>
-            </label>
-          </div>
-        )}
-        {props.setting && (
+        <div className="m-2 flex gap-1">
+          {props.fileUpload && (
+            <div className="">
+              <label>
+                <input
+                  hidden
+                  onChange={onChangeFiles}
+                  type="file"
+                  accept={props.accept?.join(',')}
+                  multiple
+                  value={[]}
+                />
+                <div
+                  className={`${uploading ? 'bg-gray-300' : 'bg-aws-smile cursor-pointer '} flex items-center justify-center rounded-xl p-2 align-bottom text-xl text-white`}>
+                  {uploading ? (
+                    <PiSpinnerGap className="animate-spin" />
+                  ) : (
+                    <PiPaperclip />
+                  )}
+                </div>
+              </label>
+            </div>
+          )}
+          {props.setting && (
+            <ButtonSend
+              className=""
+              disabled={loading}
+              onClick={props.onSetting ?? (() => {})}
+              icon={<PiSlidersHorizontal />}
+            />
+          )}
           <ButtonSend
-            className="absolute bottom-2 right-12"
-            disabled={loading}
-            onClick={props.onSetting}
-            icon={<PiSlidersHorizontal />}
+            className=""
+            disabled={disabledSend}
+            loading={loading || uploading}
+            onClick={props.onSend}
+            icon={props.sendIcon}
           />
-        )}
-        <ButtonSend
-          className="absolute bottom-2  right-2"
-          disabled={disabledSend}
-          loading={loading || uploading}
-          onClick={props.onSend}
-          icon={props.sendIcon}
-        />
+        </div>
 
         {!isEmpty && !props.resetDisabled && !props.hideReset && (
           <Button

--- a/packages/web/src/components/ModelParameters.tsx
+++ b/packages/web/src/components/ModelParameters.tsx
@@ -1,0 +1,92 @@
+import {
+  AdditionalModelRequestFields,
+  FeatureFlags,
+} from 'generative-ai-use-cases-jp';
+import Switch from './Switch';
+import RangeSlider from './RangeSlider';
+
+const DEFAULT_REASONING_BUDGET = 4096; // Claude 3.7 Sonnet 推奨最小値
+const MIN_REASONING_BUDGET = 1024; // Claude 3.7 Sonnet 最小値
+const MAX_REASONING_BUDGET = 32768; // 仮置き
+const REASONING_BUDGET_STEP = 1024;
+
+export const ModelParameters: React.FC<{
+  modelFeatureFlags: FeatureFlags;
+  overrideModelParameters: AdditionalModelRequestFields | undefined;
+  setOverrideModelParameters: (
+    overrideModelParameters: AdditionalModelRequestFields | undefined
+  ) => void;
+}> = ({
+  modelFeatureFlags,
+  overrideModelParameters,
+  setOverrideModelParameters,
+}) => {
+  const handleReasoningSwitch = (newValue: boolean) => {
+    setOverrideModelParameters({
+      ...overrideModelParameters,
+      reasoning_config: newValue
+        ? {
+            type: 'enabled',
+            budget_tokens:
+              overrideModelParameters?.reasoning_config?.budget_tokens ||
+              DEFAULT_REASONING_BUDGET,
+          }
+        : { type: 'disabled' },
+    });
+  };
+
+  const handleReasoningBudgetChange = (value: number) => {
+    setOverrideModelParameters({
+      ...overrideModelParameters,
+      reasoning_config: {
+        type: 'enabled',
+        budget_tokens: value,
+      },
+    });
+  };
+
+  const isReasoningEnabled =
+    overrideModelParameters?.reasoning_config?.type === 'enabled';
+
+  if (!modelFeatureFlags.reasoning) {
+    return null;
+  }
+
+  return (
+    <div>
+      {modelFeatureFlags.reasoning && (
+        <div>
+          <div>
+            <div>Reasoning</div>
+            <div>
+              <Switch
+                label=""
+                checked={isReasoningEnabled}
+                onSwitch={handleReasoningSwitch}
+              />
+            </div>
+          </div>
+          {overrideModelParameters?.reasoning_config?.type === 'enabled' && (
+            <div>
+              <div>Reasoning Budget</div>
+              <div>
+                <RangeSlider
+                  min={MIN_REASONING_BUDGET}
+                  max={MAX_REASONING_BUDGET}
+                  step={REASONING_BUDGET_STEP}
+                  value={
+                    overrideModelParameters?.reasoning_config?.budget_tokens ||
+                    DEFAULT_REASONING_BUDGET
+                  }
+                  onChange={handleReasoningBudgetChange}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ModelParameters;

--- a/packages/web/src/components/ModelParameters.tsx
+++ b/packages/web/src/components/ModelParameters.tsx
@@ -24,11 +24,11 @@ export const ModelParameters: React.FC<{
   const handleReasoningSwitch = (newValue: boolean) => {
     setOverrideModelParameters({
       ...overrideModelParameters,
-      reasoning_config: newValue
+      reasoningConfig: newValue
         ? {
             type: 'enabled',
-            budget_tokens:
-              overrideModelParameters?.reasoning_config?.budget_tokens ||
+            budgetTokens:
+              overrideModelParameters?.reasoningConfig?.budgetTokens ||
               DEFAULT_REASONING_BUDGET,
           }
         : { type: 'disabled' },
@@ -38,15 +38,15 @@ export const ModelParameters: React.FC<{
   const handleReasoningBudgetChange = (value: number) => {
     setOverrideModelParameters({
       ...overrideModelParameters,
-      reasoning_config: {
+      reasoningConfig: {
         type: 'enabled',
-        budget_tokens: value,
+        budgetTokens: value || DEFAULT_REASONING_BUDGET,
       },
     });
   };
 
   const isReasoningEnabled =
-    overrideModelParameters?.reasoning_config?.type === 'enabled';
+    overrideModelParameters?.reasoningConfig?.type === 'enabled';
 
   if (!modelFeatureFlags.reasoning) {
     return null;
@@ -66,7 +66,7 @@ export const ModelParameters: React.FC<{
               />
             </div>
           </div>
-          {overrideModelParameters?.reasoning_config?.type === 'enabled' && (
+          {overrideModelParameters?.reasoningConfig?.type === 'enabled' && (
             <div>
               <div>Reasoning Budget</div>
               <div>
@@ -75,7 +75,7 @@ export const ModelParameters: React.FC<{
                   max={MAX_REASONING_BUDGET}
                   step={REASONING_BUDGET_STEP}
                   value={
-                    overrideModelParameters?.reasoning_config?.budget_tokens ||
+                    overrideModelParameters?.reasoningConfig?.budgetTokens ||
                     DEFAULT_REASONING_BUDGET
                   }
                   onChange={handleReasoningBudgetChange}

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -13,6 +13,7 @@ import {
   Model,
   UpdateFeedbackRequest,
   ListChatsResponse,
+  AdditionalModelRequestFields,
 } from 'generative-ai-use-cases-jp';
 import { useEffect, useMemo } from 'react';
 import { v4 as uuid } from 'uuid';
@@ -62,7 +63,8 @@ const useChatState = create<{
     extraData: ExtraData[] | undefined,
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
-    base64Cache: Record<string, string> | undefined
+    base64Cache: Record<string, string> | undefined,
+    overrideModelParameters: AdditionalModelRequestFields | undefined
   ) => void;
   continueGeneration: (
     generationMode: GenerationMode,
@@ -76,7 +78,8 @@ const useChatState = create<{
     extraData: ExtraData[] | undefined,
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
-    base64Cache: Record<string, string> | undefined
+    base64Cache: Record<string, string> | undefined,
+    overrideModelParameters: AdditionalModelRequestFields | undefined
   ) => void;
   retryGeneration: (
     generationMode: GenerationMode,
@@ -90,7 +93,8 @@ const useChatState = create<{
     extraData: ExtraData[] | undefined,
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
-    base64Cache: Record<string, string> | undefined
+    base64Cache: Record<string, string> | undefined,
+    overrideModelParameters: AdditionalModelRequestFields | undefined
   ) => void;
   sendFeedback: (
     id: string,
@@ -391,7 +395,10 @@ const useChatState = create<{
     extraData: ExtraData[] | undefined = undefined,
     overrideModelType: Model['type'] | undefined = undefined,
     setSessionId: (sessionId: string) => void = () => {},
-    base64Cache: Record<string, string> | undefined = undefined
+    base64Cache: Record<string, string> | undefined = undefined,
+    overrideModelParameters:
+      | AdditionalModelRequestFields
+      | undefined = undefined
   ) => {
     const modelId = get().modelIds[id];
 
@@ -409,6 +416,10 @@ const useChatState = create<{
 
     if (overrideModelType) {
       model.type = overrideModelType;
+    }
+
+    if (overrideModelParameters) {
+      model.modelParameters = overrideModelParameters;
     }
 
     // Agent 用の対応
@@ -677,7 +688,10 @@ const useChatState = create<{
       extraData: ExtraData[] | undefined = undefined,
       overrideModelType: Model['type'] | undefined = undefined,
       setSessionId: (sessionId: string) => void = () => {},
-      base64Cache: Record<string, string> | undefined = undefined
+      base64Cache: Record<string, string> | undefined = undefined,
+      overrideModelParameters:
+        | AdditionalModelRequestFields
+        | undefined = undefined
     ) => {
       const unrecordedUserMessage: UnrecordedMessage = {
         role: 'user',
@@ -729,7 +743,8 @@ const useChatState = create<{
         extraData,
         overrideModelType,
         setSessionId,
-        base64Cache
+        base64Cache,
+        overrideModelParameters
       );
     },
 
@@ -847,7 +862,10 @@ const useChat = (id: string, chatId?: string) => {
       extraData: ExtraData[] | undefined = undefined,
       overrideModelType: Model['type'] | undefined = undefined,
       setSessionId: (sessionId: string) => void = () => {},
-      base64Cache: Record<string, string> | undefined = undefined
+      base64Cache: Record<string, string> | undefined = undefined,
+      overrideModelParameters:
+        | AdditionalModelRequestFields
+        | undefined = undefined
     ) => {
       post(
         id,
@@ -861,7 +879,8 @@ const useChat = (id: string, chatId?: string) => {
         extraData,
         overrideModelType,
         setSessionId,
-        base64Cache
+        base64Cache,
+        overrideModelParameters
       );
     },
     continueGeneration: (
@@ -875,7 +894,10 @@ const useChat = (id: string, chatId?: string) => {
       extraData: ExtraData[] | undefined = undefined,
       overrideModelType: Model['type'] | undefined = undefined,
       setSessionId: (sessionId: string) => void = () => {},
-      base64Cache: Record<string, string> | undefined = undefined
+      base64Cache: Record<string, string> | undefined = undefined,
+      overrideModelParameters:
+        | AdditionalModelRequestFields
+        | undefined = undefined
     ) => {
       continueGeneration(
         'continue',
@@ -889,7 +911,8 @@ const useChat = (id: string, chatId?: string) => {
         extraData,
         overrideModelType,
         setSessionId,
-        base64Cache
+        base64Cache,
+        overrideModelParameters
       );
     },
     retryGeneration: (
@@ -903,7 +926,10 @@ const useChat = (id: string, chatId?: string) => {
       extraData: ExtraData[] | undefined = undefined,
       overrideModelType: Model['type'] | undefined = undefined,
       setSessionId: (sessionId: string) => void = () => {},
-      base64Cache: Record<string, string> | undefined = undefined
+      base64Cache: Record<string, string> | undefined = undefined,
+      overrideModelParameters:
+        | AdditionalModelRequestFields
+        | undefined = undefined
     ) => {
       retryGeneration(
         'retry',
@@ -917,7 +943,8 @@ const useChat = (id: string, chatId?: string) => {
         extraData,
         overrideModelType,
         setSessionId,
-        base64Cache
+        base64Cache,
+        overrideModelParameters
       );
     },
     sendFeedback: async (feedbackData: UpdateFeedbackRequest) => {


### PR DESCRIPTION
## 変更内容の説明

- Claude 3.7 Sonnet の Reasoning に対応
- chore: Claude 3.5 以降の max token を 8192 に増加

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
関連する Issue を可能な限り挙げてください。
