### PR TITLE
[ユースケースビルダー] `{{select}}` の追加

### DIFF
--- a/packages/web/src/components/Select.tsx
+++ b/packages/web/src/components/Select.tsx
@@ -21,9 +21,10 @@ type Props = RowItemProps & {
 
 const Select: React.FC<Props> = (props) => {
   const selectedLabel = useMemo(() => {
-    return props.value === ''
-      ? ''
-      : props.options.filter((o) => o.value === props.value)[0].label;
+    if (!props.value || props.value === '') return '';
+    const selectedOption = props.options.find((o) => o.value === props.value);
+    if (!selectedOption) return '';
+    return selectedOption.label;
   }, [props.options, props.value]);
 
   const onClear = useCallback(() => {

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
@@ -38,7 +38,7 @@ const Placeholder: React.FC<{
 }> = (props) => {
   return (
     <span className="rounded bg-gray-200 px-1 py-0.5">
-      {`{{${props.inputType}${props.label ? ':' + props.label : ''}${props.options ? ':' + props.options : ''}}}`}
+      {`{{${props.inputType}${props.label !== undefined ? ':' + props.label : ''}${props.options !== undefined ? ':' + props.options : ''}}}`}
     </span>
   );
 };
@@ -154,7 +154,14 @@ const UseCaseBuilderHelp = () => {
                 label="ラベル"
                 options="選択肢1,選択肢2"
               />{' '}
-              のように記述します。 選択肢はカンマ区切りで定義します。
+              のように記述します。
+              選択肢はカンマ区切りで定義します。ラベルを表示したくない場合は
+              <Placeholder
+                inputType="select"
+                label=""
+                options="選択肢1,選択肢2"
+              />
+              のように空文字ラベルを使います。(空文字ラベルは無ラベルとは異なります。)
               <PromptSample
                 title="AWS サービスについての質問"
                 prompt={`あなたは AWS サービスに詳しいスペシャリストです。

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderHelp.tsx
@@ -31,12 +31,14 @@ const PromptSample: React.FC<PromptSampleProps> = (props) => {
   );
 };
 
-const Placeholder: React.FC<{ inputType: string; label?: string }> = (
-  props
-) => {
+const Placeholder: React.FC<{
+  inputType: string;
+  label?: string;
+  options?: string;
+}> = (props) => {
   return (
     <span className="rounded bg-gray-200 px-1 py-0.5">
-      {`{{${props.inputType}${props.label ? ':' + props.label : ''}}}`}
+      {`{{${props.inputType}${props.label ? ':' + props.label : ''}${props.options ? ':' + props.options : ''}}}`}
     </span>
   );
 };
@@ -130,6 +132,39 @@ const UseCaseBuilderHelp = () => {
 <情報>
 {{retrieveKendra:クイズの元になる情報を検索}}
 </情報>`}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-4">
+            <div className="flex items-center text-base font-bold">
+              <Placeholder inputType="select" />{' '}
+              <ButtonCopy text={'{{select}}'} />
+            </div>
+            <div className="text-sm leading-relaxed">
+              <Placeholder inputType="select" />{' '}
+              はセレクトボックスを定義するための placeholder です。
+              <Placeholder inputType="select" /> は
+              <span className="font-bold">
+                ラベルとオプションを省略できません。
+              </span>
+              必ず{' '}
+              <Placeholder
+                inputType="select"
+                label="ラベル"
+                options="選択肢1,選択肢2"
+              />{' '}
+              のように記述します。 選択肢はカンマ区切りで定義します。
+              <PromptSample
+                title="AWS サービスについての質問"
+                prompt={`あなたは AWS サービスに詳しいスペシャリストです。
+
+以下のサービスについての質問に答えてください。
+{{select:AWS サービス:Amazon Bedrock,Amazon S3,AWS Lambda}}
+
+質問は以下です。
+{{text:質問}}
+`}
               />
             </div>
           </div>

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -185,6 +185,10 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
     return getTextFormItemsFromItems(items);
   }, [items]);
 
+  const selectItems = useMemo(() => {
+    return textFormItems.filter((i) => i.inputType === 'select');
+  }, [textFormItems]);
+
   const textFormUniqueLabels = useMemo(() => {
     return getTextFormUniqueLabels(textFormItems);
   }, [textFormItems]);
@@ -193,6 +197,18 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
     clear(textFormUniqueLabels);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [textFormUniqueLabels]);
+
+  useEffect(() => {
+    for (const item of selectItems) {
+      if (
+        item.options &&
+        item.options.length > 0 &&
+        values[item.label] === ''
+      ) {
+        setValue(item.label, item.options.split(',')[0]);
+      }
+    }
+  }, [selectItems, values, setValue]);
 
   useEffect(() => {
     setModelId(
@@ -260,10 +276,41 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
       }
     }
 
+    for (const item of selectItems) {
+      if (item.label === NOLABEL || item.label === '') {
+        tmpErrorMessages.push(
+          `{{select}} にラベルが設定されていません。{{select}} はラベルの設定が必須です。{{select:ラベル:オプション1,オプション2}} のように設定してください。`
+        );
+      } else if (!item.options || item.options.length === 0) {
+        tmpErrorMessages.push(
+          `{{select}} にオプションが設定されていません。{{select:ラベル:オプション1,オプション2}} のように設定してください`
+        );
+      } else {
+        const options = item.options.split(',');
+        const emptyOptions = options.filter((o) => o === '');
+
+        if (emptyOptions.length > 0) {
+          tmpErrorMessages.push(
+            `{{select:${item.label}}} に空のオプションが含まれています。`
+          );
+        }
+
+        const uniqueOptions = options.filter(
+          (elem, idx, self) => self.findIndex((e) => e === elem) === idx
+        );
+
+        if (options.length !== uniqueOptions.length) {
+          tmpErrorMessages.push(
+            `{{select:${item.label}}} に重複したオプションが含まれています。`
+          );
+        }
+      }
+    }
+
     tmpErrorMessages.push(...fileErrorMessages);
 
     setErrorMessages(tmpErrorMessages);
-  }, [setErrorMessages, items, textFormItems, fileErrorMessages]);
+  }, [setErrorMessages, items, textFormItems, fileErrorMessages, selectItems]);
 
   const onClickExec = useCallback(async () => {
     if (loading) return;
@@ -282,12 +329,16 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
         let placeholder;
 
         if (item.label !== NOLABEL) {
-          placeholder = `{{${item.inputType}:${item.label}}}`;
+          if (item.options) {
+            placeholder = `{{${item.inputType}:${item.label}:${item.options}}}`;
+          } else {
+            placeholder = `{{${item.inputType}:${item.label}}}`;
+          }
         } else {
           placeholder = `{{${item.inputType}}}`;
         }
 
-        if (item.inputType === 'text') {
+        if (item.inputType === 'text' || item.inputType === 'select') {
           prompt = prompt.replace(
             new RegExp(placeholder, 'g'),
             values[item.label]
@@ -527,14 +578,30 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
           <div className="flex flex-col ">
             {textFormItems.map((item, idx) => (
               <div key={idx}>
-                <Textarea
-                  label={item.label !== NOLABEL ? item.label : undefined}
-                  rows={item.inputType === 'text' ? 2 : 1}
-                  value={values[item.label]}
-                  onChange={(v) => {
-                    setValue(item.label, v);
-                  }}
-                />
+                {(item.inputType === 'text' || item.inputType === 'form') && (
+                  <Textarea
+                    label={item.label !== NOLABEL ? item.label : undefined}
+                    rows={item.inputType === 'text' ? 2 : 1}
+                    value={values[item.label]}
+                    onChange={(v) => {
+                      setValue(item.label, v);
+                    }}
+                  />
+                )}
+                {item.inputType === 'select' && (
+                  <Select
+                    label={item.label !== NOLABEL ? item.label : undefined}
+                    value={values[item.label] ?? ''}
+                    options={
+                      item.options?.split(',')?.map((v: string) => {
+                        return { value: v, label: v };
+                      }) ?? []
+                    }
+                    onChange={(value) => {
+                      setValue(item.label, value);
+                    }}
+                  />
+                )}
               </div>
             ))}
           </div>

--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -277,11 +277,7 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
     }
 
     for (const item of selectItems) {
-      if (item.label === NOLABEL || item.label === '') {
-        tmpErrorMessages.push(
-          `{{select}} にラベルが設定されていません。{{select}} はラベルの設定が必須です。{{select:ラベル:オプション1,オプション2}} のように設定してください。`
-        );
-      } else if (!item.options || item.options.length === 0) {
+      if (!item.options || item.options.length === 0) {
         tmpErrorMessages.push(
           `{{select}} にオプションが設定されていません。{{select:ラベル:オプション1,オプション2}} のように設定してください`
         );

--- a/packages/web/src/utils/UseCaseBuilderUtils.ts
+++ b/packages/web/src/utils/UseCaseBuilderUtils.ts
@@ -5,6 +5,7 @@ export const NOLABEL = 'NOLABEL';
 export type BuilderItem = {
   inputType: string;
   label: string;
+  options?: string;
 };
 
 export const SUPPORTED_TYPES: string[] = [
@@ -12,9 +13,10 @@ export const SUPPORTED_TYPES: string[] = [
   'form',
   'retrieveKendra',
   'retrieveKnowledgeBase',
+  'select',
 ];
 
-export const TEXT_FORM_TYPES: string[] = ['text', 'form'];
+export const TEXT_FORM_TYPES: string[] = ['text', 'form', 'select'];
 
 export const extractPlaceholdersFromPromptTemplate = (
   promptTemplate: string
@@ -32,13 +34,30 @@ export const getItemsFromPlaceholders = (
           .replace(/^\{\{|\}\}$/g, '')
           .split(':');
 
-        // 現状は : を含んだラベルを許容している
-        // この仕様はオプション等の追加に伴い変更される可能性あり
-        const label = labels.join(':');
+        let label: string;
+        let options: string | undefined = undefined;
+
+        // 現状オプションが許可されているのは select のみ
+        if (inputType === 'select') {
+          if (labels.length >= 2) {
+            const [tmpLabel, ...tmpOptions] = labels;
+            label = tmpLabel;
+            options = tmpOptions.join(':');
+          } else {
+            label = labels[0] ?? NOLABEL;
+          }
+        } else {
+          if (labels.length === 0) {
+            label = NOLABEL;
+          } else {
+            label = labels.join(':');
+          }
+        }
 
         return {
           inputType,
-          label: label.length > 0 ? label : NOLABEL,
+          label,
+          options,
         };
       })
       .filter((item) => SUPPORTED_TYPES.includes(item.inputType))

--- a/packages/web/tests/use-case-builder/items.test.ts
+++ b/packages/web/tests/use-case-builder/items.test.ts
@@ -126,6 +126,14 @@ describe('オプションを正しくパースできる', () => {
       },
     ]);
 
+    expect(getItemsFromPlaceholders(['{{select::hoge}}'])).toEqual([
+      {
+        inputType: 'select',
+        label: '',
+        options: 'hoge',
+      },
+    ]);
+
     expect(getItemsFromPlaceholders(['{{select:hoge:fuga,hage}}'])).toEqual([
       {
         inputType: 'select',

--- a/packages/web/tests/use-case-builder/items.test.ts
+++ b/packages/web/tests/use-case-builder/items.test.ts
@@ -53,6 +53,15 @@ describe('単一のラベルを正しくパースできる', () => {
     ]);
   });
 
+  test('空文字ラベル', () => {
+    expect(getItemsFromPlaceholders(['{{text:}}'])).toEqual([
+      {
+        inputType: 'text',
+        label: '',
+      },
+    ]);
+  });
+
   test('{} が含まれる', () => {
     expect(getItemsFromPlaceholders(['{{text:x{x}x}}'])).toEqual([
       {
@@ -62,8 +71,7 @@ describe('単一のラベルを正しくパースできる', () => {
     ]);
   });
 
-  // これは将来的に仕様が変更される可能性あり
-  test(': が含まれる', () => {
+  test('オプションが許可されていない inputType のラベルに : が含まれる', () => {
     expect(getItemsFromPlaceholders(['{{text:x:x:x}}'])).toEqual([
       {
         inputType: 'text',
@@ -77,6 +85,52 @@ describe('単一のラベルを正しくパースできる', () => {
       {
         inputType: 'text',
         label: ' xxx ',
+      },
+    ]);
+  });
+});
+
+describe('オプションを正しくパースできる', () => {
+  test('オプション未指定', () => {
+    expect(getItemsFromPlaceholders(['{{select}}'])).toEqual([
+      {
+        inputType: 'select',
+        label: NOLABEL,
+        options: undefined,
+      },
+    ]);
+
+    expect(getItemsFromPlaceholders(['{{select:}}'])).toEqual([
+      {
+        inputType: 'select',
+        label: '',
+        options: undefined,
+      },
+    ]);
+
+    expect(getItemsFromPlaceholders(['{{select:hoge}}'])).toEqual([
+      {
+        inputType: 'select',
+        label: 'hoge',
+        options: undefined,
+      },
+    ]);
+  });
+
+  test('オプション指定', () => {
+    expect(getItemsFromPlaceholders(['{{select:hoge:}}'])).toEqual([
+      {
+        inputType: 'select',
+        label: 'hoge',
+        options: '',
+      },
+    ]);
+
+    expect(getItemsFromPlaceholders(['{{select:hoge:fuga,hage}}'])).toEqual([
+      {
+        inputType: 'select',
+        label: 'hoge',
+        options: 'fuga,hage',
       },
     ]);
   });


### PR DESCRIPTION
## 変更内容の説明
- セレクトボックスを定義する `{{select}}` を追加
- 選択肢は `{{select:ラベル:選択肢1,選択肢2}}` のように定義する。(そのためラベルは省略不可。)
- 仕様の詳細は「ヘルプ」と単体テストを確認していただけると

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
- https://github.com/aws-samples/generative-ai-use-cases-jp/issues/732
