### PR TITLE
動きがない Issue/PR の自動削除 workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,28 @@
+# https://github.com/marketplace/actions/close-stale-issues
+# https://docs.github.com/ja/actions/use-cases-and-examples/project-management/closing-inactive-issues
+name: Close stale issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          stale-pr-message: "This PR is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          close-pr-message: "This PR was closed because it has been inactive for 14 days since being marked as stale."
+          exempt-issue-labels: "bug,dnc"
+          exempt-pr-labels: "bug,dnc"
+          exempt-draft-pr: true
+          delete-branch: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -17,6 +17,7 @@ jobs:
           days-before-stale: 30
           days-before-close: 14
           stale-issue-label: "stale"
+          stale-pr-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           stale-pr-message: "This PR is stale because it has been open for 30 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
@@ -25,4 +26,3 @@ jobs:
           exempt-pr-labels: "bug,dnc"
           exempt-draft-pr: true
           delete-branch: true
-          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 変更内容の説明
- 30日間動きがないと警告コメントとラベルが付与される
- そこから14日間動きがないと削除される

## チェック項目
- [-] `npm run lint` を実行した
- [-] 関連するドキュメントを修正した
- [-] 手元の環境で動作確認済み
- [-] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
N/A
