### PR TITLE
Add Nova Cross Region Model IDs in APAC

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -613,7 +613,9 @@ const envs: Record<string, Partial<StackInput>> = {
 "us.meta.llama3-2-90b-instruct-v1:0",
 "us.meta.llama3-2-11b-instruct-v1:0",
 "amazon.nova-pro-v1:0",
-"amazon.nova-lite-v1:0"
+"amazon.nova-lite-v1:0",
+"apac.amazon.nova-pro-v1:0",
+"apac.amazon.nova-lite-v1:0"
 ```
 
 これらのいずれかが `modelIds` に定義されている必要があります。

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -725,7 +725,7 @@ const envs: Record<string, Partial<StackInput>> = {
 
 `parameter.ts` もしくは `cdk.json` の `modelRegion`, `modelIds`, `imageGenerationModelIds` でモデルとモデルのリージョンを指定します。`modelIds` と `imageGenerationModelIds` は指定したリージョンで利用できるモデルの中から利用したいモデルのリストで指定してください。AWS ドキュメントに、[モデルの一覧](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html)と[リージョン別のモデルサポート一覧](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html)があります。
 
-また、[cross-region inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html)のモデルに対応しています。cross-region inference のモデルは `{us|eu}.{model-provider}.{model-name}` で表されるモデルで、設定した modelRegion で指定したリージョンの `{us|eu}` と一致している必要があります。
+また、[cross-region inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html)のモデルに対応しています。cross-region inference のモデルは `{us|eu|apac}.{model-provider}.{model-name}` で表されるモデルで、設定した modelRegion で指定したリージョンの `{us|eu|apac}` と一致している必要があります。
 
 (例) `modelRegion` が `us-east-1` の場合、`us.anthropic.claude-3-5-sonnet-20240620-v1:0` は OK だが、`eu.anthropic.claude-3-5-sonnet-20240620-v1:0` は NG です。
 
@@ -777,9 +777,11 @@ const envs: Record<string, Partial<StackInput>> = {
 "amazon.nova-micro-v1:0",
 "us.amazon.nova-pro-v1:0",
 "us.amazon.nova-lite-v1:0",
-"us.amazon.nova-micro-v1:0"
+"us.amazon.nova-micro-v1:0",
+"apac.amazon.nova-pro-v1:0",
+"apac.amazon.nova-lite-v1:0",
+"apac.amazon.nova-micro-v1:0"
 ```
-
 
 このソリューションが対応している画像生成モデルは以下です。
 

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -1067,6 +1067,30 @@ export const BEDROCK_TEXT_GEN_MODELS: {
     extractConverseOutput: extractConverseOutput,
     extractConverseStreamOutput: extractConverseStreamOutput,
   },
+  'apac.amazon.nova-pro-v1:0': {
+    defaultParams: NOVA_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutput: extractConverseOutput,
+    extractConverseStreamOutput: extractConverseStreamOutput,
+  },
+  'apac.amazon.nova-lite-v1:0': {
+    defaultParams: NOVA_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutput: extractConverseOutput,
+    extractConverseStreamOutput: extractConverseStreamOutput,
+  },
+  'apac.amazon.nova-micro-v1:0': {
+    defaultParams: NOVA_DEFAULT_PARAMS,
+    usecaseParams: USECASE_DEFAULT_PARAMS,
+    createConverseCommandInput: createConverseCommandInput,
+    createConverseStreamCommandInput: createConverseStreamCommandInput,
+    extractConverseOutput: extractConverseOutput,
+    extractConverseStreamOutput: extractConverseStreamOutput,
+  },
 };
 
 // 画像生成に関する、各のModel のパラメーターや関数の定義

--- a/packages/common/src/application/model.ts
+++ b/packages/common/src/application/model.ts
@@ -96,6 +96,15 @@ export const modelFeatureFlags: Record<string, FeatureFlags> = {
     ...MODEL_FEATURE.TEXT_ONLY,
     ...MODEL_FEATURE.LIGHT,
   },
+  'apac.amazon.nova-pro-v1:0': MODEL_FEATURE.TEXT_DOC_IMAGE, // S3 Video アップロードが us-east-1 のみ対応のため。 Video を利用したい場合は us-east-1 の amazon.nova-pro-v1:0 で利用できます。（注意: リージョン変更の際 RAG を有効化している場合削除されます）
+  'apac.amazon.nova-lite-v1:0': {
+    ...MODEL_FEATURE.TEXT_DOC_IMAGE, // 同上
+    ...MODEL_FEATURE.LIGHT,
+  },
+  'apac.amazon.nova-micro-v1:0': {
+    ...MODEL_FEATURE.TEXT_ONLY,
+    ...MODEL_FEATURE.LIGHT,
+  },
   // Meta
   'meta.llama3-8b-instruct-v1:0': MODEL_FEATURE.TEXT_DOC,
   'meta.llama3-70b-instruct-v1:0': MODEL_FEATURE.TEXT_DOC,


### PR DESCRIPTION
## 変更内容の説明
Novaのクロスリージョン推論用のモデルID (in APAC) を追加しました
"apac.amazon.nova-pro-v1:0",
"apac.amazon.nova-lite-v1:0",
"apac.amazon.nova-micro-v1:0",

## チェック項目
- [✓] `npm run lint` を実行した
- [✓] 関連するドキュメントを修正した
- [✓] 手元の環境で動作確認済み
- [✓] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
https://github.com/aws-samples/generative-ai-use-cases-jp/issues/924

