### PR TITLE
複数リージョンのモデルを同時に指定する

### DIFF
--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -813,7 +813,15 @@ const envs: Record<string, Partial<StackInput>> = {
 
 ### 複数のリージョンのモデルを同時に利用する
 
-一部のモデルは、特定のリージョンのみで利用可能です。`modelIds`に`{modelId: '<モデル名>', region: '<リージョンコード>'}`を指定することで、`modelRegion`のリージョンにかかわらず、特定のモデルのみ指定したリージョンのモデルを利用することができます。
+GenU では、特に指定がない限り`modelRegion`のモデルを使用します。一部リージョンのみで利用可能な最新モデル等を使いたい場合、`modelIds`または`imageGenerationModelIds`に`{modelId: '<モデル名>', region: '<リージョンコード>'}`を指定することで、そのモデルのみ指定したリージョンから呼び出すことができます。
+
+> [!NOTE]
+> [モニタリング用ダッシュボード](#モニタリング用のダッシュボードの有効化)と複数リージョンのモデル利用を併用する場合、デフォルトのダッシュボード設定では主リージョン（`modelRegion`で指定したリージョン）以外のモデルのプロンプトログが表示されません。
+> 
+> 全リージョンのプロンプトログを一つのダッシュボード上で一覧したい場合は、以下の追加設定が必要です：
+> 
+> 1. 各リージョンのAmazon Bedrock設定画面で「Model invocation logging」を手動で有効化する
+> 2. CloudWatchダッシュボードに各リージョンのログを集計するウィジェットを追加する
 
 #### 東京リージョンを優先しつつ、バージニア北部リージョン・オレゴンリージョンの最新のモデルも使いたい場合
 **[parameter.ts](/packages/cdk/parameter.ts) を編集**
@@ -843,6 +851,58 @@ const envs: Record<string, Partial<StackInput>> = {
   },
 };
 ```
+
+**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
+```json
+{
+  "context": {
+    "modelRegion": "ap-northeast-1",
+    "modelIds": [
+      {
+        "modelId": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "region": "us-east-1"
+      },
+      "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      {
+        "modelId": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+        "region": "us-east-1"
+      },
+      "apac.amazon.nova-pro-v1:0",
+      "apac.amazon.nova-lite-v1:0",
+      "apac.amazon.nova-micro-v1:0",
+      {
+        "modelId": "us.deepseek.r1-v1:0",
+        "region": "us-east-1"
+      },
+      {
+        "modelId": "us.meta.llama3-3-70b-instruct-v1:0",
+        "region": "us-east-1"
+      },
+      {
+        "modelId": "us.meta.llama3-2-90b-instruct-v1:0",
+        "region": "us-east-1"
+      }
+    ],
+    "imageGenerationModelIds": [
+      "amazon.nova-canvas-v1:0",
+      {
+        "modelId": "stability.sd3-5-large-v1:0",
+        "region": "us-west-2"
+      },
+      {
+        "modelId": "stability.stable-image-core-v1:1",
+        "region": "us-west-2"
+      },
+      {
+        "modelId": "stability.stable-image-ultra-v1:1",
+        "region": "us-west-2"
+      }
+    ]
+  }
+}
+```
+
 
 ### us-east-1 (バージニア) の Amazon Bedrock のモデルを利用する例
 
@@ -931,7 +991,7 @@ const envs: Record<string, Partial<StackInput>> = {
       "amazon.titan-image-generator-v2:0",
       "amazon.titan-image-generator-v1",
       "stability.sd3-large-v1:0",
-      "stability.sd3-5-large-v1:0"
+      "stability.sd3-5-large-v1:0",
       "stability.stable-image-core-v1:0",
       "stability.stable-image-core-v1:1",
       "stability.stable-image-ultra-v1:0",

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -592,7 +592,7 @@ const envs: Record<string, Partial<StackInput>> = {
 映像分析ユースケースでは、映像の画像フレームとテキストを入力して画像の内容を LLM に分析させます。
 映像分析ユースケースを直接有効化するオプションはありませんが、パラメータでマルチモーダルのモデルが有効化されている必要があります。
 
-2024/06 現在、マルチモーダルのモデルは以下です。
+2025/03 現在、マルチモーダルのモデルは以下です。
 
 ```
 "anthropic.claude-3-5-sonnet-20241022-v2:0",
@@ -810,6 +810,39 @@ const envs: Record<string, Partial<StackInput>> = {
 ```
 
 **指定したリージョンで指定したモデルが有効化されているかご確認ください。**
+
+### 複数のリージョンのモデルを同時に利用する
+
+一部のモデルは、特定のリージョンのみで利用可能です。`modelIds`に`{modelId: '<モデル名>', region: '<リージョンコード>'}`を指定することで、`modelRegion`のリージョンにかかわらず、特定のモデルのみ指定したリージョンのモデルを利用することができます。
+
+#### 東京リージョンを優先しつつ、バージニア北部リージョン・オレゴンリージョンの最新のモデルも使いたい場合
+**[parameter.ts](/packages/cdk/parameter.ts) を編集**
+```typescript
+// parameter.ts
+const envs: Record<string, Partial<StackInput>> = {
+  dev: {
+    modelRegion: 'ap-northeast-1',
+    modelIds: [
+      {modelId: "us.anthropic.claude-3-7-sonnet-20250219-v1:0", region: "us-east-1"},
+      "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      {modelId: "us.anthropic.claude-3-5-haiku-20241022-v1:0", region: "us-east-1"},
+      "apac.mazon.nova-pro-v1:0",
+      "apac.amazon.nova-lite-v1:0",
+      "apac.amazon.nova-micro-v1:0",
+      {modelId: "us.deepseek.r1-v1:0", region: "us-east-1"},
+      {modelId: "us.meta.llama3-3-70b-instruct-v1:0", region: "us-east-1"},
+      {modelId: "us.meta.llama3-2-90b-instruct-v1:0", region: "us-east-1"}
+    ],
+    imageGenerationModelIds: [
+      "amazon.nova-canvas-v1:0",
+      {modelId: "stability.sd3-5-large-v1:0", region: "us-west-2"}
+      {modelId: "stability.stable-image-core-v1:1", region: "us-west-2"}
+      {modelId: "stability.stable-image-ultra-v1:1", region: "us-west-2"}
+    ],
+  },
+};
+```
 
 ### us-east-1 (バージニア) の Amazon Bedrock のモデルを利用する例
 

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -827,18 +827,18 @@ const envs: Record<string, Partial<StackInput>> = {
       "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
       "anthropic.claude-3-5-sonnet-20240620-v1:0",
       {modelId: "us.anthropic.claude-3-5-haiku-20241022-v1:0", region: "us-east-1"},
-      "apac.mazon.nova-pro-v1:0",
+      "apac.amazon.nova-pro-v1:0",
       "apac.amazon.nova-lite-v1:0",
       "apac.amazon.nova-micro-v1:0",
       {modelId: "us.deepseek.r1-v1:0", region: "us-east-1"},
       {modelId: "us.meta.llama3-3-70b-instruct-v1:0", region: "us-east-1"},
-      {modelId: "us.meta.llama3-2-90b-instruct-v1:0", region: "us-east-1"}
+      {modelId: "us.meta.llama3-2-90b-instruct-v1:0", region: "us-east-1"},
     ],
     imageGenerationModelIds: [
       "amazon.nova-canvas-v1:0",
-      {modelId: "stability.sd3-5-large-v1:0", region: "us-west-2"}
-      {modelId: "stability.stable-image-core-v1:1", region: "us-west-2"}
-      {modelId: "stability.stable-image-ultra-v1:1", region: "us-west-2"}
+      {modelId: "stability.sd3-5-large-v1:0", region: "us-west-2"},
+      {modelId: "stability.stable-image-core-v1:1", region: "us-west-2"},
+      {modelId: "stability.stable-image-ultra-v1:1", region: "us-west-2"},
     ],
   },
 };

--- a/docs/DEPLOY_OPTION.md
+++ b/docs/DEPLOY_OPTION.md
@@ -210,6 +210,7 @@ const envs: Record<string, Partial<StackInput>> = {
 
 変更後に `npm run cdk:deploy` で再度デプロイして反映させます。この際、`modelRegion` で指定されているリージョンに Knowledge Base がデプロイされます。以下に注意してください。
 
+- `modelRegion` リージョンのモデルが 1 つ以上 `modelIds` に定義されている必要があります。
 - `modelRegion` リージョンの Bedrock で `embeddingModelId` のモデルが有効化されている必要があります。
 - `modelRegion` リージョンの Bedrock で `rerankingModelId` のモデルが有効化されている必要があります。
 - `modelRegion` リージョンで `npm run cdk:deploy` の前に AWS CDK の Bootstrap が完了している必要があります。

--- a/packages/cdk/lambda/utils/bedrockApi.ts
+++ b/packages/cdk/lambda/utils/bedrockApi.ts
@@ -53,7 +53,10 @@ const assumeRole = async (crossAccountBedrockRoleArn: string) => {
 // そのような場合、CROSS_ACCOUNT_BEDROCK_ROLE_ARN 環境変数が設定されているかをチェックします。(cdk.json で crossAccountBedrockRoleArn が設定されている場合に環境変数として設定される)
 // 設定されている場合、指定されたロールを AssumeRole 操作によって引き受け、取得した一時的な認証情報を用いて BedrockRuntimeClient を初期化します。
 // これにより、別の AWS アカウントの Bedrock リソースへのアクセスが可能になります。
-const initBedrockClient = async () => {
+const initBedrockClient = async (region?: string) => {
+  // 引数にregionが指定されている場合はそちらを優先する。
+  region = region || process.env.MODEL_REGION;
+
   // CROSS_ACCOUNT_BEDROCK_ROLE_ARN が設定されているかチェック
   if (process.env.CROSS_ACCOUNT_BEDROCK_ROLE_ARN) {
     // STS から一時的な認証情報を取得してクライアントを初期化
@@ -70,7 +73,7 @@ const initBedrockClient = async () => {
     }
 
     return new BedrockRuntimeClient({
-      region: process.env.MODEL_REGION,
+      region,
       credentials: {
         accessKeyId: tempCredentials.accessKeyId,
         secretAccessKey: tempCredentials.secretAccessKey,
@@ -80,7 +83,7 @@ const initBedrockClient = async () => {
   } else {
     // STSを使用しない場合のクライアント初期化
     return new BedrockRuntimeClient({
-      region: process.env.MODEL_REGION,
+      region,
     });
   }
 };
@@ -145,8 +148,8 @@ const extractOutputImage = (
 };
 
 const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
-  invoke: async (model, messages, id) => {
-    const client = await initBedrockClient();
+  invoke: async (model, messages, id, region?) => {
+    const client = await initBedrockClient(region);
 
     const converseCommandInput = createConverseCommandInput(
       model,
@@ -158,9 +161,9 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
 
     return extractConverseOutput(model, output).text;
   },
-  invokeStream: async function* (model, messages, id) {
-    const client = await initBedrockClient();
-
+  invokeStream: async function* (model, messages, id, idToken?, region?) {
+    const client = await initBedrockClient(region);
+    region = region || process.env.MODEL_REGION;
     try {
       const converseStreamCommandInput = createConverseStreamCommandInput(
         model,
@@ -205,7 +208,7 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
           stopReason: 'error',
         });
       } else if (e instanceof AccessDeniedException) {
-        const modelAccessURL = `https://${process.env.MODEL_REGION}.console.aws.amazon.com/bedrock/home?region=${process.env.MODEL_REGION}#/modelaccess`;
+        const modelAccessURL = `https://${region}.console.aws.amazon.com/bedrock/home?region=${region}#/modelaccess`;
         yield streamingChunk({
           text: `選択したモデルが有効化されていないようです。[Bedrock コンソールの Model Access 画面](${modelAccessURL})にて、利用したいモデルを有効化してください。`,
           stopReason: 'error',
@@ -221,8 +224,8 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
       }
     }
   },
-  generateImage: async (model, params) => {
-    const client = await initBedrockClient();
+  generateImage: async (model, params, region?) => {
+    const client = await initBedrockClient(region);
 
     // Stable Diffusion や Titan Image Generator を利用した画像生成は Converse API に対応していないため、InvokeModelCommand を利用する
     const command = new InvokeModelCommand({

--- a/packages/cdk/lambda/utils/bedrockApi.ts
+++ b/packages/cdk/lambda/utils/bedrockApi.ts
@@ -148,8 +148,8 @@ const extractOutputImage = (
 };
 
 const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
-  invoke: async (model, messages, id, region?) => {
-    const client = await initBedrockClient(region);
+  invoke: async (model, messages, id) => {
+    const client = await initBedrockClient(model.region);
 
     const converseCommandInput = createConverseCommandInput(
       model,
@@ -161,9 +161,9 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
 
     return extractConverseOutput(model, output).text;
   },
-  invokeStream: async function* (model, messages, id, idToken?, region?) {
+  invokeStream: async function* (model, messages, id) {
+    const region = model.region || process.env.MODEL_REGION;
     const client = await initBedrockClient(region);
-    region = region || process.env.MODEL_REGION;
     try {
       const converseStreamCommandInput = createConverseStreamCommandInput(
         model,
@@ -224,8 +224,8 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
       }
     }
   },
-  generateImage: async (model, params, region?) => {
-    const client = await initBedrockClient(region);
+  generateImage: async (model, params) => {
+    const client = await initBedrockClient(model.region);
 
     // Stable Diffusion や Titan Image Generator を利用した画像生成は Converse API に対応していないため、InvokeModelCommand を利用する
     const command = new InvokeModelCommand({

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -2,6 +2,7 @@ import {
   BedrockImageGenerationResponse,
   GenerateImageParams,
   Model,
+  ModelConfiguration,
   PromptTemplate,
   StableDiffusionParams,
   UnrecordedMessage,
@@ -27,29 +28,41 @@ import { modelFeatureFlags } from '@generative-ai-use-cases-jp/common';
 
 // Default Models
 
-const modelIds: string[] = (
-  JSON.parse(process.env.MODEL_IDS || '[]') as string[]
+const modelIds: ModelConfiguration[] = (
+  JSON.parse(process.env.MODEL_IDS || '[]') as ModelConfiguration[]
 )
-  .map((modelId: string) => modelId.trim())
-  .filter((modelId: string) => modelId);
+  .map((model) => ({
+    modelId: model.modelId.trim(),
+    region: model.region.trim(),
+  }))
+  .filter((model) => model.modelId);
 // 利用できるモデルの中で軽量モデルがあれば軽量モデルを優先する。
 const lightWeightModelIds = modelIds.filter(
-  (modelId: string) => modelFeatureFlags[modelId].light
+  (model: ModelConfiguration) => modelFeatureFlags[model.modelId].light
 );
-const defaultModelId = lightWeightModelIds[0] || modelIds[0];
+const defaultModelConfiguration = lightWeightModelIds[0] || modelIds[0];
 export const defaultModel: Model = {
   type: 'bedrock',
-  modelId: defaultModelId,
+  modelId: defaultModelConfiguration.modelId,
+  region: defaultModelConfiguration.region,
 };
 
-const imageGenerationModelIds: string[] = (
-  JSON.parse(process.env.IMAGE_GENERATION_MODEL_IDS || '[]') as string[]
+const imageGenerationModels: ModelConfiguration[] = (
+  JSON.parse(
+    process.env.IMAGE_GENERATION_MODEL_IDS || '[]'
+  ) as ModelConfiguration[]
 )
-  .map((name: string) => name.trim())
-  .filter((name: string) => name);
+  .map(
+    (model: ModelConfiguration): ModelConfiguration => ({
+      modelId: model.modelId.trim(),
+      region: model.region.trim(),
+    })
+  )
+  .filter((model) => model.modelId);
 export const defaultImageGenerationModel: Model = {
   type: 'bedrock',
-  modelId: imageGenerationModelIds[0],
+  modelId: imageGenerationModels[0].modelId,
+  region: imageGenerationModels[0].region,
 };
 
 // Prompt Templates

--- a/packages/cdk/lib/agent-stack.ts
+++ b/packages/cdk/lib/agent-stack.ts
@@ -2,10 +2,10 @@ import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { Agent } from './construct';
 import { Agent as AgentType } from 'generative-ai-use-cases-jp';
-import { StackInput } from './stack-input';
+import { ProcessedStackInput } from './stack-input';
 
 export interface AgentStackProps extends StackProps {
-  params: StackInput;
+  params: ProcessedStackInput;
 }
 
 export class AgentStack extends Stack {

--- a/packages/cdk/lib/cloud-front-waf-stack.ts
+++ b/packages/cdk/lib/cloud-front-waf-stack.ts
@@ -7,10 +7,10 @@ import {
 import { HostedZone } from 'aws-cdk-lib/aws-route53';
 import { Construct } from 'constructs';
 import { CommonWebAcl } from './construct/common-web-acl';
-import { StackInput } from './stack-input';
+import { ProcessedStackInput } from './stack-input';
 
 interface CloudFrontWafStackProps extends StackProps {
-  params: StackInput;
+  params: ProcessedStackInput;
 }
 
 export class CloudFrontWafStack extends Stack {

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -20,7 +20,11 @@ import {
   BucketEncryption,
   HttpMethods,
 } from 'aws-cdk-lib/aws-s3';
-import { Agent, AgentMap } from 'generative-ai-use-cases-jp';
+import {
+  Agent,
+  AgentMap,
+  ModelConfiguration,
+} from 'generative-ai-use-cases-jp';
 import {
   BEDROCK_IMAGE_GEN_MODELS,
   BEDROCK_RERANKING_MODELS,
@@ -30,8 +34,8 @@ import {
 export interface BackendApiProps {
   // Context Params
   modelRegion: string;
-  modelIds: string[];
-  imageGenerationModelIds: string[];
+  modelIds: ModelConfiguration[];
+  imageGenerationModelIds: ModelConfiguration[];
   endpointNames: string[];
   queryDecompositionEnabled: boolean;
   rerankingModelId?: string | null;
@@ -55,8 +59,8 @@ export class Api extends Construct {
   readonly invokeFlowFunction: NodejsFunction;
   readonly optimizePromptFunction: NodejsFunction;
   readonly modelRegion: string;
-  readonly modelIds: string[];
-  readonly imageGenerationModelIds: string[];
+  readonly modelIds: ModelConfiguration[];
+  readonly imageGenerationModelIds: ModelConfiguration[];
   readonly endpointNames: string[];
   readonly agentNames: string[];
   readonly fileBucket: Bucket;
@@ -82,14 +86,14 @@ export class Api extends Construct {
     const agents: Agent[] = [...(props.agents ?? []), ...props.customAgents];
 
     // Validate Model Names
-    for (const modelId of modelIds) {
-      if (!BEDROCK_TEXT_MODELS.includes(modelId)) {
-        throw new Error(`Unsupported Model Name: ${modelId}`);
+    for (const model of modelIds) {
+      if (!BEDROCK_TEXT_MODELS.includes(model.modelId)) {
+        throw new Error(`Unsupported Model Name: ${model.modelId}`);
       }
     }
-    for (const modelId of imageGenerationModelIds) {
-      if (!BEDROCK_IMAGE_GEN_MODELS.includes(modelId)) {
-        throw new Error(`Unsupported Model Name: ${modelId}`);
+    for (const model of imageGenerationModelIds) {
+      if (!BEDROCK_IMAGE_GEN_MODELS.includes(model.modelId)) {
+        throw new Error(`Unsupported Model Name: ${model.modelId}`);
       }
     }
     if (

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -10,7 +10,11 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
-import { Flow, HiddenUseCases } from 'generative-ai-use-cases-jp';
+import {
+  Flow,
+  HiddenUseCases,
+  ModelConfiguration,
+} from 'generative-ai-use-cases-jp';
 import { ComputeType } from 'aws-cdk-lib/aws-codebuild';
 
 export interface WebProps {
@@ -28,8 +32,8 @@ export interface WebProps {
   selfSignUpEnabled: boolean;
   webAclId?: string;
   modelRegion: string;
-  modelIds: string[];
-  imageGenerationModelIds: string[];
+  modelIds: ModelConfiguration[];
+  imageGenerationModelIds: ModelConfiguration[];
   endpointNames: string[];
   samlAuthEnabled: boolean;
   samlCognitoDomainName?: string | null;

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -6,7 +6,7 @@ import { DashboardStack } from './dashboard-stack';
 import { AgentStack } from './agent-stack';
 import { RagKnowledgeBaseStack } from './rag-knowledge-base-stack';
 import { GuardrailStack } from './guardrail-stack';
-import { StackInput } from './stack-input';
+import { ProcessedStackInput } from './stack-input';
 
 class DeletionPolicySetter implements cdk.IAspect {
   constructor(private readonly policy: cdk.RemovalPolicy) {}
@@ -18,7 +18,7 @@ class DeletionPolicySetter implements cdk.IAspect {
   }
 }
 
-export const createStacks = (app: cdk.App, params: StackInput) => {
+export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
   // CloudFront WAF
   // IP アドレス範囲(v4もしくはv6のいずれか)か地理的制限が定義されている場合のみ、CloudFrontWafStack をデプロイする
   // WAF v2 は us-east-1 でのみデプロイ可能なため、Stack を分けている

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -15,10 +15,10 @@ import * as cognito from 'aws-cdk-lib/aws-cognito';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { Agent } from 'generative-ai-use-cases-jp';
 import { UseCaseBuilder } from './construct/use-case-builder';
-import { StackInput } from './stack-input';
+import { ProcessedStackInput } from './stack-input';
 
 export interface GenerativeAiUseCasesStackProps extends StackProps {
-  params: StackInput;
+  params: ProcessedStackInput;
   // RAG Knowledge Base
   knowledgeBaseId?: string;
   knowledgeBaseDataSourceBucketName?: string;

--- a/packages/cdk/lib/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/rag-knowledge-base-stack.ts
@@ -7,7 +7,7 @@ import * as oss from 'aws-cdk-lib/aws-opensearchserverless';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3Deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { StackInput } from './stack-input';
+import { ProcessedStackInput } from './stack-input';
 
 const UUID = '339C5FED-A1B5-43B6-B40A-5E8E59E5734D';
 
@@ -120,7 +120,7 @@ class OpenSearchServerlessIndex extends Construct {
 }
 
 export interface RagKnowledgeBaseStackProps extends StackProps {
-  params: StackInput;
+  params: ProcessedStackInput;
   collectionName?: string;
   vectorIndexName?: string;
   vectorField?: string;

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -29,7 +29,15 @@ export const stackInputSchema = z.object({
   // API
   modelRegion: z.string().default('us-east-1'),
   modelIds: z
-    .array(z.string())
+    .array(
+      z.union([
+        z.string(),
+        z.object({
+          modelId: z.string(),
+          region: z.string(),
+        }),
+      ])
+    )
     .default([
       'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       'us.anthropic.claude-3-5-haiku-20241022-v1:0',
@@ -38,7 +46,15 @@ export const stackInputSchema = z.object({
       'us.amazon.nova-micro-v1:0',
     ]),
   imageGenerationModelIds: z
-    .array(z.string())
+    .array(
+      z.union([
+        z.string(),
+        z.object({
+          modelId: z.string(),
+          region: z.string(),
+        }),
+      ])
+    )
     .default(['amazon.nova-canvas-v1:0']),
   endpointNames: z.array(z.string()).default([]),
   crossAccountBedrockRoleArn: z.string().nullish(),
@@ -115,4 +131,21 @@ export const stackInputSchema = z.object({
   dashboard: z.boolean().default(false),
 });
 
+// 変換後用のschema
+export const processedStackInputSchema = stackInputSchema.extend({
+  modelIds: z.array(
+    z.object({
+      modelId: z.string(),
+      region: z.string(),
+    })
+  ),
+  imageGenerationModelIds: z.array(
+    z.object({
+      modelId: z.string(),
+      region: z.string(),
+    })
+  ),
+});
+
 export type StackInput = z.infer<typeof stackInputSchema>;
+export type ProcessedStackInput = z.infer<typeof processedStackInputSchema>;

--- a/packages/cdk/parameter.ts
+++ b/packages/cdk/parameter.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { StackInput, stackInputSchema } from './lib/stack-input';
+import { ModelConfiguration } from 'generative-ai-use-cases-jp';
 
 // CDK Context からパラメータを取得する場合
 const getContext = (app: cdk.App): StackInput => {
@@ -28,7 +29,7 @@ const envs: Record<string, Partial<StackInput>> = {
 };
 
 // 後方互換性のため、CDK Context > parameter.ts の順でパラメータを取得する
-export const getParams = (app: cdk.App): StackInput => {
+export const getParams = (app: cdk.App): ProcessedStackInput => {
   // デフォルトでは CDK Context からパラメータを取得する
   let params = getContext(app);
 
@@ -39,6 +40,24 @@ export const getParams = (app: cdk.App): StackInput => {
       env: params.env,
     });
   }
+  //modelIds, imageGenerationModelIdsのフォーマットを揃える
+  const convertToModelConfiguration = (
+    models: (string | ModelConfiguration)[],
+    defaultRegion: string
+  ): ModelConfiguration[] => {
+    return models.map((model) =>
+      typeof model === 'string'
+        ? { modelId: model, region: defaultRegion }
+        : model
+    );
+  };
 
-  return params;
+  return {
+    ...params,
+    modelIds: convertToModelConfiguration(params.modelIds, params.modelRegion),
+    imageGenerationModelIds: convertToModelConfiguration(
+      params.imageGenerationModelIds,
+      params.modelRegion
+    ),
+  };
 };

--- a/packages/cdk/parameter.ts
+++ b/packages/cdk/parameter.ts
@@ -1,5 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
-import { StackInput, stackInputSchema } from './lib/stack-input';
+import {
+  StackInput,
+  stackInputSchema,
+  ProcessedStackInput,
+} from './lib/stack-input';
 import { ModelConfiguration } from 'generative-ai-use-cases-jp';
 
 // CDK Context からパラメータを取得する場合

--- a/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
+++ b/packages/cdk/test/__snapshots__/generative-ai-use-cases.test.ts.snap
@@ -1967,7 +1967,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
       },
     },
     "ImageGenerateModelIds": {
-      "Value": "["stability.stable-diffusion-xl-v1"]",
+      "Value": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
     },
     "InlineAgents": {
       "Value": "false",
@@ -1981,7 +1981,7 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
       },
     },
     "ModelIds": {
-      "Value": "["anthropic.claude-3-sonnet-20240229-v1:0"]",
+      "Value": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
     },
     "ModelRegion": {
       "Value": "us-east-1",
@@ -10015,8 +10015,8 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
         "Environment": {
           "Variables": {
             "CROSS_ACCOUNT_BEDROCK_ROLE_ARN": "",
-            "IMAGE_GENERATION_MODEL_IDS": "["stability.stable-diffusion-xl-v1"]",
-            "MODEL_IDS": "["anthropic.claude-3-sonnet-20240229-v1:0"]",
+            "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
+            "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
           },
         },
@@ -11097,8 +11097,8 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "Fn::ImportValue": "GuardrailStack:ExportsOutputFnGetAttGuardrailguardrail03A76CF4GuardrailIdDBA991AF",
             },
             "GUARDRAIL_VERSION": "DRAFT",
-            "IMAGE_GENERATION_MODEL_IDS": "["stability.stable-diffusion-xl-v1"]",
-            "MODEL_IDS": "["anthropic.claude-3-sonnet-20240229-v1:0"]",
+            "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
+            "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
           },
         },
@@ -11219,11 +11219,11 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "Fn::ImportValue": "GuardrailStack:ExportsOutputFnGetAttGuardrailguardrail03A76CF4GuardrailIdDBA991AF",
             },
             "GUARDRAIL_VERSION": "DRAFT",
-            "IMAGE_GENERATION_MODEL_IDS": "["stability.stable-diffusion-xl-v1"]",
+            "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
             "KNOWLEDGE_BASE_ID": {
               "Fn::ImportValue": "RagKnowledgeBaseStack:ExportsOutputRefKnowledgeBaseD054384B",
             },
-            "MODEL_IDS": "["anthropic.claude-3-sonnet-20240229-v1:0"]",
+            "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
             "QUERY_DECOMPOSITION_ENABLED": "false",
             "RERANKING_MODEL_ID": "",
@@ -11363,8 +11363,8 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
               "Fn::ImportValue": "GuardrailStack:ExportsOutputFnGetAttGuardrailguardrail03A76CF4GuardrailIdDBA991AF",
             },
             "GUARDRAIL_VERSION": "DRAFT",
-            "IMAGE_GENERATION_MODEL_IDS": "["stability.stable-diffusion-xl-v1"]",
-            "MODEL_IDS": "["anthropic.claude-3-sonnet-20240229-v1:0"]",
+            "IMAGE_GENERATION_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
+            "MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
             "MODEL_REGION": "us-east-1",
             "TABLE_NAME": {
               "Ref": "DatabaseTableF104A135",
@@ -11884,9 +11884,9 @@ exports[`GenerativeAiUseCases matches the snapshot 5`] = `
           "VITE_APP_IDENTITY_POOL_ID": {
             "Ref": "AuthIdentityPool659E7F64",
           },
-          "VITE_APP_IMAGE_MODEL_IDS": "["stability.stable-diffusion-xl-v1"]",
+          "VITE_APP_IMAGE_MODEL_IDS": "[{"modelId":"stability.stable-diffusion-xl-v1","region":"us-east-1"}]",
           "VITE_APP_INLINE_AGENTS": "false",
-          "VITE_APP_MODEL_IDS": "["anthropic.claude-3-sonnet-20240229-v1:0"]",
+          "VITE_APP_MODEL_IDS": "[{"modelId":"anthropic.claude-3-sonnet-20240229-v1:0","region":"us-east-1"}]",
           "VITE_APP_MODEL_REGION": "us-east-1",
           "VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN": {
             "Fn::GetAtt": [
@@ -16837,15 +16837,15 @@ exports[`GenerativeAiUseCases matches the snapshot 6`] = `
               {
                 "Ref": "AWS::Region",
               },
-              "","metrics":[["AWS/Bedrock","InputTokenCount","ModelId","anthropic.claude-3-sonnet-20240229-v1:0",{"period":86400,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":6,"height":6,"x":6,"y":1,"properties":{"view":"timeSeries","title":"OutputTokenCount (Daily)","region":"",
+              "","metrics":[["AWS/Bedrock","InputTokenCount","ModelId","anthropic.claude-3-sonnet-20240229-v1:0",{"region":"us-east-1","period":86400,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":6,"height":6,"x":6,"y":1,"properties":{"view":"timeSeries","title":"OutputTokenCount (Daily)","region":"",
               {
                 "Ref": "AWS::Region",
               },
-              "","metrics":[["AWS/Bedrock","OutputTokenCount","ModelId","anthropic.claude-3-sonnet-20240229-v1:0",{"period":86400,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":6,"height":6,"x":12,"y":1,"properties":{"view":"timeSeries","title":"Invocations (Daily)","region":"",
+              "","metrics":[["AWS/Bedrock","OutputTokenCount","ModelId","anthropic.claude-3-sonnet-20240229-v1:0",{"region":"us-east-1","period":86400,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":6,"height":6,"x":12,"y":1,"properties":{"view":"timeSeries","title":"Invocations (Daily)","region":"",
               {
                 "Ref": "AWS::Region",
               },
-              "","metrics":[["AWS/Bedrock","Invocations","ModelId","anthropic.claude-3-sonnet-20240229-v1:0",{"period":86400,"stat":"Sum"}],["AWS/Bedrock","Invocations","ModelId","stability.stable-diffusion-xl-v1",{"period":86400,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":6,"height":6,"x":18,"y":1,"properties":{"view":"timeSeries","title":"UserPool","region":"",
+              "","metrics":[["AWS/Bedrock","Invocations","ModelId","anthropic.claude-3-sonnet-20240229-v1:0",{"region":"us-east-1","period":86400,"stat":"Sum"}],["AWS/Bedrock","Invocations","ModelId","stability.stable-diffusion-xl-v1",{"region":"us-east-1","period":86400,"stat":"Sum"}]],"yAxis":{}}},{"type":"metric","width":6,"height":6,"x":18,"y":1,"properties":{"view":"timeSeries","title":"UserPool","region":"",
               {
                 "Ref": "AWS::Region",
               },

--- a/packages/cdk/test/generative-ai-use-cases.test.ts
+++ b/packages/cdk/test/generative-ai-use-cases.test.ts
@@ -1,13 +1,13 @@
 import { Template } from 'aws-cdk-lib/assertions';
 import * as cdk from 'aws-cdk-lib';
-import { stackInputSchema } from '../lib/stack-input';
+import { processedStackInputSchema } from '../lib/stack-input';
 import { createStacks } from '../lib/create-stacks';
 
 describe('GenerativeAiUseCases', () => {
   test('matches the snapshot', () => {
     const app = new cdk.App();
 
-    const params = stackInputSchema.parse({
+    const params = processedStackInputSchema.parse({
       account: '123456890123',
       region: 'us-east-1',
       env: '',
@@ -29,8 +29,15 @@ describe('GenerativeAiUseCases', () => {
       samlCognitoDomainName: '',
       samlCognitoFederatedIdentityProviderName: '',
       modelRegion: 'us-east-1',
-      modelIds: ['anthropic.claude-3-sonnet-20240229-v1:0'],
-      imageGenerationModelIds: ['stability.stable-diffusion-xl-v1'],
+      modelIds: [
+        {
+          modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
+          region: 'us-east-1',
+        },
+      ],
+      imageGenerationModelIds: [
+        { modelId: 'stability.stable-diffusion-xl-v1', region: 'us-east-1' },
+      ],
       endpointNames: [],
       agentEnabled: true,
       searchAgentEnabled: true,

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -8,6 +8,7 @@ export type Model = {
   modelId: string;
   modelParameters?: AdditionalModelRequestFields;
   sessionId?: string;
+  region?: string;
 };
 
 export type Agent = {

--- a/packages/types/src/model.d.ts
+++ b/packages/types/src/model.d.ts
@@ -15,3 +15,8 @@ export type FeatureFlags = {
   // Additional Flags
   light?: boolean;
 };
+
+export type ModelConfiguration = {
+  modelId: string;
+  region: string;
+};

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -7,20 +7,23 @@ import {
 export type InvokeInterface = (
   model: Model,
   messages: UnrecordedMessage[],
-  id: string
+  id: string,
+  region?: string
 ) => Promise<string>;
 
 export type InvokeStreamInterface = (
   model: Model,
   messages: UnrecordedMessage[],
   id: string,
-  idToken?: string
+  idToken?: string,
+  region?: string
 ) => AsyncIterable<string>;
 
 // Base64 にエンコードした画像を Return する
 export type GenerateImageInterface = (
   model: Model,
-  params: GenerateImageParams
+  params: GenerateImageParams,
+  region?: string
 ) => Promise<string>;
 
 export type ApiInterface = {

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -7,23 +7,20 @@ import {
 export type InvokeInterface = (
   model: Model,
   messages: UnrecordedMessage[],
-  id: string,
-  region?: string
+  id: string
 ) => Promise<string>;
 
 export type InvokeStreamInterface = (
   model: Model,
   messages: UnrecordedMessage[],
   id: string,
-  idToken?: string,
-  region?: string
+  idToken?: string
 ) => AsyncIterable<string>;
 
 // Base64 にエンコードした画像を Return する
 export type GenerateImageInterface = (
   model: Model,
-  params: GenerateImageParams,
-  region?: string
+  params: GenerateImageParams
 ) => Promise<string>;
 
 export type ApiInterface = {

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -15,6 +15,9 @@ const bedrockModelConfigs = (
 const bedrockModelIds: string[] = bedrockModelConfigs.map(
   (model) => model.modelId
 );
+const modelIdsInModelRegion: string[] = bedrockModelConfigs
+  .filter((model) => model.region === modelRegion)
+  .map((model) => model.modelId);
 
 const visionModelIds: string[] = bedrockModelIds.filter(
   (modelId) => modelFeatureFlags[modelId].image
@@ -103,6 +106,7 @@ const searchAgent = agentNames.find((name) => name.includes('Search'));
 export const MODELS = {
   modelRegion: modelRegion,
   modelIds: [...bedrockModelIds, ...endpointNames],
+  modelIdsInModelRegion,
   modelFeatureFlags: modelFeatureFlags,
   visionModelIds: visionModelIds,
   visionEnabled: visionEnabled,

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -1,12 +1,21 @@
-import { Model } from 'generative-ai-use-cases-jp';
+import { Model, ModelConfiguration } from 'generative-ai-use-cases-jp';
 import { modelFeatureFlags } from '@generative-ai-use-cases-jp/common';
 
 const modelRegion = import.meta.env.VITE_APP_MODEL_REGION;
 
 // 環境変数からモデル名などを取得
-const bedrockModelIds: string[] = JSON.parse(import.meta.env.VITE_APP_MODEL_IDS)
-  .map((name: string) => name.trim())
-  .filter((name: string) => name);
+const bedrockModelConfigs = (
+  JSON.parse(import.meta.env.VITE_APP_MODEL_IDS) as ModelConfiguration[]
+)
+  .map((model) => ({
+    modelId: model.modelId.trim(),
+    region: model.region.trim(),
+  }))
+  .filter((model) => model.modelId);
+const bedrockModelIds: string[] = bedrockModelConfigs.map(
+  (model) => model.modelId
+);
+
 const visionModelIds: string[] = bedrockModelIds.filter(
   (modelId) => modelFeatureFlags[modelId].image
 );
@@ -18,11 +27,19 @@ const endpointNames: string[] = JSON.parse(
   .map((name: string) => name.trim())
   .filter((name: string) => name);
 
-const imageGenModelIds: string[] = JSON.parse(
-  import.meta.env.VITE_APP_IMAGE_MODEL_IDS
+const imageModelConfigs = (
+  JSON.parse(import.meta.env.VITE_APP_IMAGE_MODEL_IDS) as ModelConfiguration[]
 )
-  .map((name: string) => name.trim())
-  .filter((name: string) => name);
+  .map(
+    (model: ModelConfiguration): ModelConfiguration => ({
+      modelId: model.modelId.trim(),
+      region: model.region.trim(),
+    })
+  )
+  .filter((model) => model.modelId);
+const imageGenModelIds: string[] = imageModelConfigs.map(
+  (model) => model.modelId
+);
 
 const agentNames: string[] = JSON.parse(import.meta.env.VITE_APP_AGENT_NAMES)
   .map((name: string) => name.trim())
@@ -40,16 +57,26 @@ const flows = getFlows();
 
 // モデルオブジェクトの定義
 const textModels = [
-  ...bedrockModelIds.map(
-    (name) => ({ modelId: name, type: 'bedrock' }) as Model
+  ...bedrockModelConfigs.map(
+    (model) =>
+      ({
+        modelId: model.modelId,
+        type: 'bedrock',
+        region: model.region,
+      }) as Model
   ),
   ...endpointNames.map(
     (name) => ({ modelId: name, type: 'sagemaker' }) as Model
   ),
 ];
 const imageGenModels = [
-  ...imageGenModelIds.map(
-    (name) => ({ modelId: name, type: 'bedrock' }) as Model
+  ...imageModelConfigs.map(
+    (model) =>
+      ({
+        modelId: model.modelId,
+        type: 'bedrock',
+        region: model.region,
+      }) as Model
   ),
 ];
 const agentModels = [

--- a/packages/web/src/pages/RagKnowledgeBasePage.tsx
+++ b/packages/web/src/pages/RagKnowledgeBasePage.tsx
@@ -73,7 +73,7 @@ const RagKnowledgeBasePage: React.FC = () => {
     retryGeneration,
   } = useChat(pathname);
   const { scrollableContainer, setFollowing } = useFollow();
-  const { modelIds: availableModels } = MODELS;
+  const { modelIdsInModelRegion: availableModels } = MODELS;
   const modelId = getModelId();
   const prompter = useMemo(() => {
     return getPrompter(modelId);


### PR DESCRIPTION
## 変更内容の説明
テキスト生成と画像生成について、複数リージョンを同時に利用できるようにした。

現状できないこと：modelRegion以外のAgent/Knowledge Base/Flowsを指定する

残作業
- [X] ダッシュボード確認
  - メトリクスはマルチリージョン対応確認。しかし、Prompt LogsはmodelRegionに指定したリージョンでの推論しか表示できない
- [X] ドキュメンテーション

現状の制限事項
- 異なるリージョンで同じ名前のモデルを指定すると意図した動作とならない

## チェック項目
- [X] `npm run lint` を実行した
- [X] 関連するドキュメントを修正した
- [X] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
関連する Issue を可能な限り挙げてください。
#932 
