### PR TITLE
incrase GitHub Action operations per run

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -25,4 +25,5 @@ jobs:
           exempt-issue-labels: 'bug,dnc'
           exempt-pr-labels: 'bug,dnc'
           exempt-draft-pr: true
+          operations-per-run: 100
           delete-branch: true


### PR DESCRIPTION
## 変更内容の説明

- Stale Issue の operations-per-run を 100 に変更。

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
関連する Issue を可能な限り挙げてください。
