### PR TITLE
動画生成 Nova Reel 最初のフレーム画像を指定できるように

### DIFF
--- a/packages/cdk/lambda/repositoryVideoJob.ts
+++ b/packages/cdk/lambda/repositoryVideoJob.ts
@@ -34,6 +34,19 @@ export const createJob = async (
 ) => {
   const userId = `videoJob#${_userId}`;
   const jobId = invocationArn.split('/').slice(-1)[0];
+
+  const params = req.params.params;
+
+  // Nova Reel の 1 フレーム目画像指定が params に含まれていたら、その情報は ddb に保存しない
+  if (
+    params &&
+    params.textToVideoParams &&
+    params.textToVideoParams.images &&
+    params.textToVideoParams.images.length > 0
+  ) {
+    params.textToVideoParams.images = [];
+  }
+
   const item = {
     id: userId,
     createdDate: `${Date.now()}`,
@@ -44,7 +57,7 @@ export const createJob = async (
     modelId: req.model!.modelId,
     region: req.model!.region,
     prompt: req.params.prompt,
-    params: JSON.stringify(req.params.params),
+    params: JSON.stringify(params),
   };
 
   await dynamoDbDocument.send(

--- a/packages/cdk/lambda/repositoryVideoJob.ts
+++ b/packages/cdk/lambda/repositoryVideoJob.ts
@@ -35,16 +35,11 @@ export const createJob = async (
   const userId = `videoJob#${_userId}`;
   const jobId = invocationArn.split('/').slice(-1)[0];
 
-  const params = req.params.params;
+  const params = req.params;
 
   // Nova Reel の 1 フレーム目画像指定が params に含まれていたら、その情報は ddb に保存しない
-  if (
-    params &&
-    params.textToVideoParams &&
-    params.textToVideoParams.images &&
-    params.textToVideoParams.images.length > 0
-  ) {
-    params.textToVideoParams.images = [];
+  if (params.images && params.images.length > 0) {
+    params.images = [];
   }
 
   const item = {
@@ -56,8 +51,7 @@ export const createJob = async (
     output: `s3://${BUCKET_NAME}/${jobId}/output.mp4`,
     modelId: req.model!.modelId,
     region: req.model!.region,
-    prompt: req.params.prompt,
-    params: JSON.stringify(params),
+    ...params,
   };
 
   await dynamoDbDocument.send(

--- a/packages/cdk/lambda/utils/bedrockApi.ts
+++ b/packages/cdk/lambda/utils/bedrockApi.ts
@@ -21,7 +21,11 @@ import {
   StreamingChunk,
   UnrecordedMessage,
 } from 'generative-ai-use-cases-jp';
-import { BEDROCK_TEXT_GEN_MODELS, BEDROCK_IMAGE_GEN_MODELS } from './models';
+import {
+  BEDROCK_TEXT_GEN_MODELS,
+  BEDROCK_IMAGE_GEN_MODELS,
+  BEDROCK_VIDEO_GEN_MODELS,
+} from './models';
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { streamingChunk } from './streamingChunk';
 
@@ -148,6 +152,11 @@ const extractOutputImage = (
   return modelConfig.extractOutputImage(response);
 };
 
+const createBodyVideo = (model: Model, params: GenerateVideoParams) => {
+  const modelConfig = BEDROCK_VIDEO_GEN_MODELS[model.modelId];
+  return modelConfig.createBodyVideo(params);
+};
+
 const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
   invoke: async (model, messages, id) => {
     const region = model.region || defaultRegion;
@@ -255,7 +264,7 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
 
     const command = new StartAsyncInvokeCommand({
       modelId: model.modelId,
-      modelInput: params.params,
+      modelInput: createBodyVideo(model, params),
       outputDataConfig: {
         s3OutputDataConfig: {
           s3Uri: `s3://${tmpOutputBucket}`,

--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -1,6 +1,7 @@
 import {
   BedrockImageGenerationResponse,
   GenerateImageParams,
+  GenerateVideoParams,
   Model,
   ModelConfiguration,
   PromptTemplate,
@@ -699,6 +700,33 @@ const extractOutputImageAmazonImage = (
     throw new Error('Unexpected response type for Amazon Image');
   }
 };
+
+const createBodyVideoNovaReel = (params: GenerateVideoParams) => {
+  return {
+    taskType: 'TEXT_VIDEO',
+    textToVideoParams: {
+      text: params.prompt,
+      images: params.images,
+    },
+    videoGenerationConfig: {
+      durationSeconds: params.durationSeconds,
+      fps: params.fps,
+      dimension: params.dimension,
+      seed: params.seed,
+    },
+  };
+};
+
+const createBodyVideoLumaRayV2 = (params: GenerateVideoParams) => {
+  return {
+    prompt: params.prompt,
+    aspect_ratio: params.aspectRatio,
+    loop: params.loop,
+    duration: `${params.durationSeconds}s`,
+    resolution: params.resolution,
+  };
+};
+
 // テキスト生成に関する、各のModel のパラメーターや関数の定義
 
 export const BEDROCK_TEXT_GEN_MODELS: {
@@ -1219,6 +1247,20 @@ export const BEDROCK_IMAGE_GEN_MODELS: {
   'amazon.nova-canvas-v1:0': {
     createBodyImage: createBodyImageAmazonAdvancedImage,
     extractOutputImage: extractOutputImageAmazonImage,
+  },
+};
+
+export const BEDROCK_VIDEO_GEN_MODELS: {
+  [key: string]: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createBodyVideo: (params: GenerateVideoParams) => any;
+  };
+} = {
+  'amazon.nova-reel-v1:0': {
+    createBodyVideo: createBodyVideoNovaReel,
+  },
+  'luma.ray-v2:0': {
+    createBodyVideo: createBodyVideoLumaRayV2,
   },
 };
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.755.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.755.0",
-    "@aws-sdk/client-kendra": "^3.755.0",
-    "@smithy/types": "^4.1.0"
+    "@aws-sdk/client-kendra": "^3.755.0"
   }
 }

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -77,6 +77,7 @@ export type FileLimit = {
   maxImageFileSizeMB: number;
   maxVideoFileCount: number;
   maxVideoFileSizeMB: number;
+  strictImageDimensions?: { width: number; height: number }[];
 };
 
 export type RecordedMessage = PrimaryKey &

--- a/packages/types/src/video.d.ts
+++ b/packages/types/src/video.d.ts
@@ -1,11 +1,11 @@
 import { PrimaryKey } from './base';
-import { DocumentType } from '@smithy/types';
 
 export type GenerateVideoParams = {
   prompt: string;
   // モデルごとに固有のパラメータは以下
   // そのまま StartAsyncInvokeCommand に渡すもの
-  params: DocumentType;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: any;
 };
 
 export type VideoJob = PrimaryKey & {

--- a/packages/types/src/video.d.ts
+++ b/packages/types/src/video.d.ts
@@ -2,10 +2,19 @@ import { PrimaryKey } from './base';
 
 export type GenerateVideoParams = {
   prompt: string;
-  // モデルごとに固有のパラメータは以下
-  // そのまま StartAsyncInvokeCommand に渡すもの
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params: any;
+  durationSeconds: number;
+  dimension?: string;
+  fps?: number;
+  seed?: number;
+  resolution?: string;
+  aspectRatio?: string;
+  loop?: boolean;
+  images?: {
+    format: 'png' | 'jpeg';
+    source: {
+      bytes: string;
+    };
+  }[];
 };
 
 export type VideoJob = PrimaryKey & {

--- a/packages/web/src/components/Base64Image.tsx
+++ b/packages/web/src/components/Base64Image.tsx
@@ -21,7 +21,7 @@ const Base64Image: React.FC<Props> = (props) => {
   const src = useMemo(() => {
     return props.imageBase64?.startsWith('data')
       ? props.imageBase64
-      : `data:image/jpg;base64,${props.imageBase64}`;
+      : `data:image/png;base64,${props.imageBase64}`;
   }, [props.imageBase64]);
 
   return (

--- a/packages/web/src/hooks/useVideo.ts
+++ b/packages/web/src/hooks/useVideo.ts
@@ -21,8 +21,8 @@ const useVideo = () => {
     generate: async (params: GenerateVideoParams, model: Model | undefined) => {
       return (
         await generateVideo({
-          model,
           params,
+          model,
         })
       ).data;
     },

--- a/packages/web/src/pages/GenerateImagePage.tsx
+++ b/packages/web/src/pages/GenerateImagePage.tsx
@@ -84,6 +84,11 @@ const stabilityAi2024ModelPresets = [
   { value: '16:9', label: '1344 x 768' },
   { value: '21:9', label: '1536 x 640' },
 ];
+// Nova Reel の 1 フレーム目画像の生成に使うために以下の画像サイズを Nova Canvas に追加
+const novaCanvasPresets = [
+  ...defaultModelPresets,
+  { value: '1280 x 720', label: '1280 x 720' },
+];
 const modelInfo: Record<string, ModelInfo<'base' | 'advanced'>> = {
   [STABILITY_AI_MODELS.STABLE_DIFFUSION_XL]: {
     supportedModes: [
@@ -155,7 +160,7 @@ const modelInfo: Record<string, ModelInfo<'base' | 'advanced'>> = {
       AMAZON_ADVANCED_GENERATION_MODE.COLOR_GUIDED_GENERATION,
       AMAZON_ADVANCED_GENERATION_MODE.BACKGROUND_REMOVAL,
     ],
-    resolutionPresets: defaultModelPresets,
+    resolutionPresets: novaCanvasPresets,
   },
 };
 


### PR DESCRIPTION
## 変更内容の説明
- Nova Reel の最初のフレーム画像を指定できるようにした
- Nova Canvas で 1280x720 サイズの画像を作成できるようにした
- FileLimit に strictImageDimensions を指定できるようにした (画像の幅と高さの指定)

## チェック項目
- [x] `npm run lint` を実行した
- [x] 関連するドキュメントを修正した
- [x] 手元の環境で動作確認済み
- [x] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue

