### PR TITLE
[ユースケースビルダー] フォーム・オプションの定義に含まれる空白のチェックを追加

### DIFF
--- a/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
+++ b/packages/web/src/components/useCaseBuilder/UseCaseBuilderView.tsx
@@ -276,6 +276,14 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
       }
     }
 
+    for (const item of items) {
+      if (item.label != item.label.trim()) {
+        tmpErrorMessages.push(
+          `"${item.label}"の前後にある空白を削除してください。`
+        );
+      }
+    }
+
     for (const item of selectItems) {
       if (!item.options || item.options.length === 0) {
         tmpErrorMessages.push(
@@ -288,6 +296,14 @@ const UseCaseBuilderView: React.FC<Props> = (props) => {
         if (emptyOptions.length > 0) {
           tmpErrorMessages.push(
             `{{select:${item.label}}} に空のオプションが含まれています。`
+          );
+        }
+
+        // Check for options with leading/trailing spaces
+        const spacedOptions = options.filter((o) => o !== o.trim());
+        if (spacedOptions.length > 0) {
+          tmpErrorMessages.push(
+            `{{select:${item.label}}}のオプションを設定する際は、カンマの前後に空白を含まないでください: ${spacedOptions.map(o => `"${o}"`).join(', ')}`
           );
         }
 


### PR DESCRIPTION
## 変更内容の説明

ユースケースビルダーで入力項目を定義する際、ラベルやオプションに空白が含まれていた場合バリデーションエラーを出すように修正しました。

* 例えば `{{text: 入力}}` という定義の場合、"入力"の前に空白があるためエラーが出力されます
* `{{select:選択項目:1, 2, 3, 4}}` という場合、オプションの各数字の前に空白があるためエラーが出力されます

画面イメージ
![image](https://github.com/user-attachments/assets/ff5cf740-470a-4e2e-8f11-ae2116a17bf3)

**背景**
特にselectの入力例を設定する際、意図せず空白が含まれていると入力例と空白が含まれたoptionがマッチせず、値が設定されない事態が起こる (#958)。ユースケースの作成者からすると非常に気づきにくいので、ユースケースを定義する段階でバリデーションエラーを表示することで速やかに修正できるようにする

## チェック項目
- [X] `npm run lint` を実行した
- [X] 関連するドキュメントを修正した
- [X] 手元の環境で動作確認済み
- [X] `npm run cdk:test` を実行しスナップショット差分がある場合は `npm run cdk:test:update-snapshot` を実行してスナップショットを更新した

## 関連する Issue
#958